### PR TITLE
Fix unit tests — return defaults for unmocked Android methods

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,10 @@ android {
     buildFeatures {
         compose = true
     }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
Archon's scaffold passed tests on its dev machine but **3 TriggerPipelineTest cases fail in CI** because `TriggerPipeline` calls `android.util.Log.{w,d,e}` directly, and in JVM unit tests those methods throw `RuntimeException("Method not mocked")` by default.

Fix: set `testOptions.unitTests.isReturnDefaultValues = true` in `app/build.gradle.kts` — the standard Android config for JVM unit tests. Unmocked framework methods now return sensible defaults (0/null/false) instead of throwing.

This is the root-cause fix. The alternative (wrapping logging behind an interface) is a bigger change and not necessary for MVP.

## Test plan
- [ ] CI green on this PR — all 34 tests pass.
- [ ] After merge, add `Build & test` as a required status check so auto-merge can't go through on broken tests again.