### PR TITLE
Add AI autofill and notification preview to habit editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,29 @@ Expected output example for *gratefulness*:
 - "Name one thing that went better than expected today."
 
 ### Fallback
-If Gemma 4 inference fails or takes >5s, fall back to a static template: *"{name}: {low_floor_description}"*.
+If Gemma 4 inference fails or takes >5s, fall back to a static template: *"{name}: {low_floor_description}"*. Note: the AI autofill and notification preview features throw on failure (no silent fallback) so the UI can surface a clear error message.
+
+### Habit-field autofill prompt (on-device Gemma 4)
+
+Used to generate `full_description` and `low_floor_description` when the user taps "Autofill with AI" in the Habit editor. Takes only the habit title as input.
+
+```
+System: You are generating habit description fields for a productivity app.
+Given only a habit title, produce exactly two lines:
+Full: <one sentence, specific full description, max 100 chars>
+Low-floor: <minimum viable version, max 60 chars>
+Plain text only.
+
+Habit title: {name}
+```
+
+Expected output format (two lines, no extras):
+```
+Full: 20-minute guided body-scan meditation
+Low-floor: 3 deep breaths
+```
+
+Parsed via `lines().firstOrNull { it.startsWith("Full:") }` / `"Low-floor:"`. Throws `IllegalStateException` if either line is missing.
 
 ---
 
@@ -137,6 +159,7 @@ If Gemma 4 inference fails or takes >5s, fall back to a static template: *"{name
 
 1. **Home screen** — list of habits. FAB → add habit. Tap habit → edit.
 2. **Habit editor** — name, full description, low-floor description, location tag, active toggle.
+   AI-assist row: **Autofill with AI** (fills description fields from the habit name via on-device LLM; enabled when name ≥ 2 chars) · **Preview notification** (generates a sample notification text in a dialog; enabled when all description fields are filled).
 3. **Windows screen** — list of windows. FAB → add window. Tap → edit.
 4. **Window editor** — start/end time pickers, days-of-week chips, frequency slider (1–3), active toggle.
 5. **Locations screen** — "Set my Home" / "Set my Work". Uses current GPS at capture time; stores lat/lng + radius (default 100m). Re-settable.

--- a/app/src/main/java/com/alexsiri7/unreminder/domain/model/AiHabitFields.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/domain/model/AiHabitFields.kt
@@ -1,0 +1,6 @@
+package com.alexsiri7.unreminder.domain.model
+
+data class AiHabitFields(
+    val fullDescription: String,
+    val lowFloorDescription: String
+)

--- a/app/src/main/java/com/alexsiri7/unreminder/service/llm/PromptGenerator.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/llm/PromptGenerator.kt
@@ -8,6 +8,7 @@ import com.alexsiri7.unreminder.domain.model.LocationTag
 import com.google.mlkit.genai.prompt.Generation
 import com.google.mlkit.genai.prompt.GenerativeModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -41,7 +42,7 @@ class PromptGenerator @Inject constructor(
                 val response = m.generateContent(prompt)
                 response.candidates.firstOrNull()?.text?.take(80) ?: fallback(habit)
             }
-        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+        } catch (e: CancellationException) {
             throw e  // must propagate: cancellation is not an error
         } catch (e: Exception) {
             Log.w(TAG, "LLM generation failed, using fallback", e)
@@ -75,7 +76,7 @@ class PromptGenerator @Inject constructor(
                     ?: throw IllegalStateException("Could not parse Low-floor: line")
                 AiHabitFields(full, low)
             }
-        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+        } catch (e: CancellationException) {
             throw e  // must propagate: cancellation is not an error
         } catch (e: Exception) {
             Log.w(TAG, "LLM habit field generation failed", e)

--- a/app/src/main/java/com/alexsiri7/unreminder/service/llm/PromptGenerator.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/llm/PromptGenerator.kt
@@ -3,6 +3,7 @@ package com.alexsiri7.unreminder.service.llm
 import android.content.Context
 import android.util.Log
 import com.alexsiri7.unreminder.data.db.HabitEntity
+import com.alexsiri7.unreminder.domain.model.AiHabitFields
 import com.alexsiri7.unreminder.domain.model.LocationTag
 import com.google.mlkit.genai.prompt.Generation
 import com.google.mlkit.genai.prompt.GenerativeModel
@@ -56,6 +57,45 @@ class PromptGenerator @Inject constructor(
         |Low-floor version: ${habit.lowFloorDescription}
         |Current location: ${location.name}
         |Time of day: $timeOfDay""".trimMargin()
+
+    suspend fun generateHabitFields(title: String): AiHabitFields {
+        val m = model ?: throw IllegalStateException("LLM unavailable")
+        return try {
+            withTimeout(5_000) {
+                val prompt = buildHabitFieldsPrompt(title)
+                val response = m.generateContent(prompt)
+                val text = response.candidates.firstOrNull()?.text
+                    ?: throw IllegalStateException("Empty LLM response")
+                val lines = text.lines()
+                val full = lines.firstOrNull { it.startsWith("Full:") }
+                    ?.removePrefix("Full:")?.trim()
+                    ?: throw IllegalStateException("Could not parse Full: line")
+                val low = lines.firstOrNull { it.startsWith("Low-floor:") }
+                    ?.removePrefix("Low-floor:")?.trim()
+                    ?: throw IllegalStateException("Could not parse Low-floor: line")
+                AiHabitFields(full, low)
+            }
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "LLM habit field generation failed", e)
+            throw e
+        }
+    }
+
+    suspend fun previewHabitNotification(habit: HabitEntity, locationTag: LocationTag = LocationTag.ANYWHERE): String {
+        if (model == null) throw IllegalStateException("LLM unavailable")
+        return generate(habit, locationTag, "now")
+    }
+
+    private fun buildHabitFieldsPrompt(title: String): String =
+        """System: You are generating habit description fields for a productivity app.
+        |Given only a habit title, produce exactly two lines:
+        |Full: <one sentence, specific full description, max 100 chars>
+        |Low-floor: <minimum viable version, max 60 chars>
+        |Plain text only.
+        |
+        |Habit title: $title""".trimMargin()
 
     private fun fallback(habit: HabitEntity): String =
         "${habit.name}: ${habit.lowFloorDescription}"

--- a/app/src/main/java/com/alexsiri7/unreminder/service/llm/PromptGenerator.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/llm/PromptGenerator.kt
@@ -28,7 +28,7 @@ class PromptGenerator @Inject constructor(
             m.warmup()
             model = m
         } catch (e: Exception) {
-            Log.w(TAG, "LLM initialization failed, falling back to templates", e)
+            Log.w(TAG, "LLM initialization failed; notification generation will use templates, AI autofill will throw", e)
             model = null
         }
     }
@@ -42,7 +42,7 @@ class PromptGenerator @Inject constructor(
                 response.candidates.firstOrNull()?.text?.take(80) ?: fallback(habit)
             }
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-            throw e
+            throw e  // must propagate: cancellation is not an error
         } catch (e: Exception) {
             Log.w(TAG, "LLM generation failed, using fallback", e)
             fallback(habit)
@@ -76,7 +76,7 @@ class PromptGenerator @Inject constructor(
                 AiHabitFields(full, low)
             }
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-            throw e
+            throw e  // must propagate: cancellation is not an error
         } catch (e: Exception) {
             Log.w(TAG, "LLM habit field generation failed", e)
             throw e
@@ -84,8 +84,14 @@ class PromptGenerator @Inject constructor(
     }
 
     suspend fun previewHabitNotification(habit: HabitEntity, locationTag: LocationTag = LocationTag.ANYWHERE): String {
-        if (model == null) throw IllegalStateException("LLM unavailable")
-        return generate(habit, locationTag, "now")
+        val m = model ?: throw IllegalStateException("LLM unavailable")
+        return withTimeout(5_000) {
+            // "now" tells the LLM to generate a notification appropriate for the current moment
+            val prompt = buildPrompt(habit, locationTag, "now")
+            val response = m.generateContent(prompt)
+            response.candidates.firstOrNull()?.text?.take(80)
+                ?: throw IllegalStateException("Empty LLM response")
+        }
     }
 
     private fun buildHabitFieldsPrompt(title: String): String =

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditScreen.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditScreen.kt
@@ -12,18 +12,26 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -48,7 +56,27 @@ fun HabitEditScreen(
         if (uiState.isSaved) onNavigateBack()
     }
 
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.errorMessage) {
+        val msg = uiState.errorMessage ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(msg)
+        viewModel.clearError()
+    }
+
+    if (uiState.showPreviewDialog && uiState.previewNotification != null) {
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissPreviewDialog() },
+            title = { Text("Notification preview") },
+            text = { Text(uiState.previewNotification!!) },
+            confirmButton = {
+                TextButton(onClick = { viewModel.dismissPreviewDialog() }) { Text("Close") }
+            }
+        )
+    }
+
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = { Text(if (habitId != null) "Edit Habit" else "New Habit") },
@@ -92,6 +120,36 @@ fun HabitEditScreen(
                 modifier = Modifier.fillMaxWidth(),
                 minLines = 2
             )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                OutlinedButton(
+                    onClick = { viewModel.autofillWithAi() },
+                    enabled = uiState.name.length >= 2 && !uiState.isGeneratingFields,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    if (uiState.isGeneratingFields) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Text("Autofill with AI")
+                    }
+                }
+                OutlinedButton(
+                    onClick = { viewModel.previewNotification() },
+                    enabled = uiState.name.isNotBlank() &&
+                              uiState.fullDescription.isNotBlank() &&
+                              uiState.lowFloorDescription.isNotBlank() &&
+                              !uiState.isGeneratingFields,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Preview notification")
+                }
+            }
 
             Text("Location")
             FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditScreen.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditScreen.kt
@@ -8,11 +8,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -64,11 +64,12 @@ fun HabitEditScreen(
         viewModel.clearError()
     }
 
-    if (uiState.showPreviewDialog && uiState.previewNotification != null) {
+    val previewText = uiState.previewNotification
+    if (uiState.showPreviewDialog && previewText != null) {
         AlertDialog(
             onDismissRequest = { viewModel.dismissPreviewDialog() },
             title = { Text("Notification preview") },
-            text = { Text(uiState.previewNotification!!) },
+            text = { Text(previewText) },
             confirmButton = {
                 TextButton(onClick = { viewModel.dismissPreviewDialog() }) { Text("Close") }
             }

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.alexsiri7.unreminder.data.db.HabitEntity
 import com.alexsiri7.unreminder.data.repository.HabitRepository
 import com.alexsiri7.unreminder.domain.model.LocationTag
+import com.alexsiri7.unreminder.service.llm.PromptGenerator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,12 +21,17 @@ data class HabitEditUiState(
     val locationTag: LocationTag = LocationTag.ANYWHERE,
     val active: Boolean = true,
     val isLoading: Boolean = false,
-    val isSaved: Boolean = false
+    val isSaved: Boolean = false,
+    val isGeneratingFields: Boolean = false,
+    val previewNotification: String? = null,
+    val showPreviewDialog: Boolean = false,
+    val errorMessage: String? = null
 )
 
 @HiltViewModel
 class HabitEditViewModel @Inject constructor(
-    private val habitRepository: HabitRepository
+    private val habitRepository: HabitRepository,
+    private val promptGenerator: PromptGenerator
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HabitEditUiState())
@@ -86,4 +92,51 @@ class HabitEditViewModel @Inject constructor(
             _uiState.value = _uiState.value.copy(isSaved = true)
         }
     }
+
+    fun autofillWithAi() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isGeneratingFields = true, errorMessage = null)
+            try {
+                val fields = promptGenerator.generateHabitFields(_uiState.value.name)
+                _uiState.value = _uiState.value.copy(
+                    fullDescription = fields.fullDescription,
+                    lowFloorDescription = fields.lowFloorDescription,
+                    isGeneratingFields = false
+                )
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isGeneratingFields = false,
+                    errorMessage = "AI unavailable — fill in manually."
+                )
+            }
+        }
+    }
+
+    fun previewNotification() {
+        viewModelScope.launch {
+            val state = _uiState.value
+            val tempHabit = HabitEntity(
+                name = state.name,
+                fullDescription = state.fullDescription,
+                lowFloorDescription = state.lowFloorDescription,
+                locationTag = state.locationTag
+            )
+            try {
+                val text = promptGenerator.previewHabitNotification(tempHabit, state.locationTag)
+                _uiState.value = _uiState.value.copy(
+                    previewNotification = text,
+                    showPreviewDialog = true
+                )
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    errorMessage = "AI unavailable — preview not available."
+                )
+            }
+        }
+    }
+
+    fun dismissPreviewDialog() {
+        _uiState.value = _uiState.value.copy(showPreviewDialog = false, previewNotification = null)
+    }
+    fun clearError() { _uiState.value = _uiState.value.copy(errorMessage = null) }
 }

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModel.kt
@@ -104,6 +104,7 @@ class HabitEditViewModel @Inject constructor(
                     isGeneratingFields = false
                 )
             } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
                 _uiState.value = _uiState.value.copy(
                     isGeneratingFields = false,
                     errorMessage = "AI unavailable — fill in manually."
@@ -114,21 +115,25 @@ class HabitEditViewModel @Inject constructor(
 
     fun previewNotification() {
         viewModelScope.launch {
-            val state = _uiState.value
-            val tempHabit = HabitEntity(
-                name = state.name,
-                fullDescription = state.fullDescription,
-                lowFloorDescription = state.lowFloorDescription,
-                locationTag = state.locationTag
-            )
+            _uiState.value = _uiState.value.copy(isGeneratingFields = true, errorMessage = null)
             try {
+                val state = _uiState.value
+                val tempHabit = HabitEntity(
+                    name = state.name,
+                    fullDescription = state.fullDescription,
+                    lowFloorDescription = state.lowFloorDescription,
+                    locationTag = state.locationTag
+                )
                 val text = promptGenerator.previewHabitNotification(tempHabit, state.locationTag)
                 _uiState.value = _uiState.value.copy(
+                    isGeneratingFields = false,
                     previewNotification = text,
                     showPreviewDialog = true
                 )
             } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
                 _uiState.value = _uiState.value.copy(
+                    isGeneratingFields = false,
                     errorMessage = "AI unavailable — preview not available."
                 )
             }

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModel.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -104,7 +105,7 @@ class HabitEditViewModel @Inject constructor(
                     isGeneratingFields = false
                 )
             } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
+                if (e is CancellationException) throw e
                 _uiState.value = _uiState.value.copy(
                     isGeneratingFields = false,
                     errorMessage = "AI unavailable — fill in manually."
@@ -131,7 +132,7 @@ class HabitEditViewModel @Inject constructor(
                     showPreviewDialog = true
                 )
             } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
+                if (e is CancellationException) throw e
                 _uiState.value = _uiState.value.copy(
                     isGeneratingFields = false,
                     errorMessage = "AI unavailable — preview not available."

--- a/app/src/test/java/com/alexsiri7/unreminder/service/llm/PromptGeneratorTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/service/llm/PromptGeneratorTest.kt
@@ -6,6 +6,7 @@ import com.alexsiri7.unreminder.domain.model.LocationTag
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.Instant
 
@@ -50,5 +51,21 @@ class PromptGeneratorTest {
         )
         val result = generator.generate(customHabit, LocationTag.ANYWHERE, "evening")
         assertEquals("reading: read one page", result)
+    }
+
+    @Test
+    fun `generateHabitFields throws when model is null`() = runTest {
+        val exception = runCatching {
+            generator.generateHabitFields("meditation")
+        }
+        assertTrue(exception.isFailure)
+    }
+
+    @Test
+    fun `previewHabitNotification throws when model is null`() = runTest {
+        val exception = runCatching {
+            generator.previewHabitNotification(habit, LocationTag.ANYWHERE)
+        }
+        assertTrue(exception.isFailure)
     }
 }

--- a/app/src/test/java/com/alexsiri7/unreminder/service/llm/PromptGeneratorTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/service/llm/PromptGeneratorTest.kt
@@ -55,17 +55,21 @@ class PromptGeneratorTest {
 
     @Test
     fun `generateHabitFields throws when model is null`() = runTest {
-        val exception = runCatching {
+        val result = runCatching {
             generator.generateHabitFields("meditation")
         }
-        assertTrue(exception.isFailure)
+        assertTrue(result.isFailure)
+        assertTrue("Expected IllegalStateException, got ${result.exceptionOrNull()?.javaClass}", result.exceptionOrNull() is IllegalStateException)
+        assertEquals("LLM unavailable", result.exceptionOrNull()?.message)
     }
 
     @Test
     fun `previewHabitNotification throws when model is null`() = runTest {
-        val exception = runCatching {
+        val result = runCatching {
             generator.previewHabitNotification(habit, LocationTag.ANYWHERE)
         }
-        assertTrue(exception.isFailure)
+        assertTrue(result.isFailure)
+        assertTrue("Expected IllegalStateException, got ${result.exceptionOrNull()?.javaClass}", result.exceptionOrNull() is IllegalStateException)
+        assertEquals("LLM unavailable", result.exceptionOrNull()?.message)
     }
 }

--- a/app/src/test/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModelTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModelTest.kt
@@ -1,0 +1,151 @@
+package com.alexsiri7.unreminder.ui.habit
+
+import com.alexsiri7.unreminder.data.db.HabitEntity
+import com.alexsiri7.unreminder.data.repository.HabitRepository
+import com.alexsiri7.unreminder.domain.model.AiHabitFields
+import com.alexsiri7.unreminder.domain.model.LocationTag
+import com.alexsiri7.unreminder.service.llm.PromptGenerator
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.time.Instant
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HabitEditViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val mockPromptGenerator: PromptGenerator = mockk()
+    private val mockHabitRepository: HabitRepository = mockk(relaxed = true)
+    private lateinit var viewModel: HabitEditViewModel
+
+    private val testHabit = HabitEntity(
+        id = 1L,
+        name = "meditation",
+        fullDescription = "20-minute guided meditation",
+        lowFloorDescription = "3 deep breaths",
+        locationTag = LocationTag.ANYWHERE,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now()
+    )
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = HabitEditViewModel(mockHabitRepository, mockPromptGenerator)
+        viewModel.updateName("meditation")
+        viewModel.updateFullDescription("20-minute guided meditation")
+        viewModel.updateLowFloorDescription("3 deep breaths")
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // --- autofillWithAi ---
+
+    @Test
+    fun `autofillWithAi updates fields and clears isGeneratingFields on success`() = runTest {
+        coEvery { mockPromptGenerator.generateHabitFields("meditation") } returns
+            AiHabitFields("20-min guided session", "3 deep breaths")
+
+        viewModel.autofillWithAi()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isGeneratingFields)
+        assertEquals("20-min guided session", state.fullDescription)
+        assertEquals("3 deep breaths", state.lowFloorDescription)
+        assertNull(state.errorMessage)
+    }
+
+    @Test
+    fun `autofillWithAi sets errorMessage and resets isGeneratingFields on failure`() = runTest {
+        coEvery { mockPromptGenerator.generateHabitFields(any()) } throws
+            IllegalStateException("LLM unavailable")
+
+        viewModel.autofillWithAi()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isGeneratingFields)
+        assertEquals("AI unavailable — fill in manually.", state.errorMessage)
+    }
+
+    // --- previewNotification ---
+
+    @Test
+    fun `previewNotification shows dialog with text and clears flag on success`() = runTest {
+        coEvery {
+            mockPromptGenerator.previewHabitNotification(any(), any())
+        } returns "Time to meditate — even 3 breaths counts"
+
+        viewModel.previewNotification()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.showPreviewDialog)
+        assertEquals("Time to meditate — even 3 breaths counts", state.previewNotification)
+        assertFalse(state.isGeneratingFields)
+        assertNull(state.errorMessage)
+    }
+
+    @Test
+    fun `previewNotification sets errorMessage and resets flag on failure`() = runTest {
+        coEvery {
+            mockPromptGenerator.previewHabitNotification(any(), any())
+        } throws IllegalStateException("LLM unavailable")
+
+        viewModel.previewNotification()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.showPreviewDialog)
+        assertFalse(state.isGeneratingFields)
+        assertEquals("AI unavailable — preview not available.", state.errorMessage)
+    }
+
+    // --- dismissPreviewDialog ---
+
+    @Test
+    fun `dismissPreviewDialog clears showPreviewDialog and previewNotification`() = runTest {
+        coEvery { mockPromptGenerator.previewHabitNotification(any(), any()) } returns "preview"
+        viewModel.previewNotification()
+        advanceUntilIdle()
+        assertTrue(viewModel.uiState.value.showPreviewDialog)
+
+        viewModel.dismissPreviewDialog()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.showPreviewDialog)
+        assertNull(state.previewNotification)
+    }
+
+    // --- clearError ---
+
+    @Test
+    fun `clearError nullifies errorMessage`() = runTest {
+        coEvery { mockPromptGenerator.generateHabitFields(any()) } throws RuntimeException("boom")
+        viewModel.autofillWithAi()
+        advanceUntilIdle()
+        assertNotNull(viewModel.uiState.value.errorMessage)
+
+        viewModel.clearError()
+
+        assertNull(viewModel.uiState.value.errorMessage)
+    }
+}


### PR DESCRIPTION
## Summary

- Add **Autofill with AI** button to the habit editor: generates `fullFloorDescription` and `lowFloorDescription` from the habit title using the on-device LLM
- Add **Preview notification** button: renders a sample notification message for the habit so users can see what they'll receive before saving
- New `AiHabitFields` data class holds the two AI-generated field values
- `PromptGenerator` extended with `generateHabitFields()` and `previewHabitNotification()` (with 5 s timeout and structured parsing)
- `HabitEditViewModel` extended with AI loading state, error state, and preview dialog state
- `HabitEditScreen` wired up with loading indicators, an `AlertDialog` for the notification preview, and a `SnackbarHost` for error messages
- Unit tests added for both new `PromptGenerator` methods

## Changes

| File | Action |
|------|--------|
| `app/src/main/java/com/alexsiri7/unreminder/domain/model/AiHabitFields.kt` | Created — data class with two String fields |
| `app/src/main/java/com/alexsiri7/unreminder/service/llm/PromptGenerator.kt` | Extended — `generateHabitFields`, `previewHabitNotification`, `buildHabitFieldsPrompt` |
| `app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModel.kt` | Extended — AI state flags, `autofillWithAi()`, `previewNotification()`, dismiss/clear actions |
| `app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditScreen.kt` | Extended — AI buttons row, `CircularProgressIndicator`, `AlertDialog`, `SnackbarHost` |
| `app/src/test/java/com/alexsiri7/unreminder/service/llm/PromptGeneratorTest.kt` | Extended — 2 new unit tests for null-model error paths |

## Validation

Local Gradle/build tasks are blocked by a pre-existing environment incompatibility (Java 25 + Kotlin 1.9.23 in the worktree — not caused by this PR). All changed files passed manual code review:

- `AiHabitFields.kt`: correct package, minimal, no imports needed ✅
- `PromptGenerator.kt`: timeout, structured parsing, `CancellationException` re-thrown correctly ✅
- `HabitEditViewModel.kt`: loading/error/dialog state handled correctly ✅
- `HabitEditScreen.kt`: button enable conditions, progress indicator, dialog, snackbar all correct ✅
- `PromptGeneratorTest.kt`: tests assert failure on null model ✅

CI will run the full lint/test/build suite on a supported JDK.

Fixes #8