### PR TITLE
Add map-based location picker with osmdroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Solo user (the author). Single-device, single-user. Personal productivity / well
 | Local storage | **Room** (SQLite) | Local-first. |
 | Scheduling | **WorkManager** + **AlarmManager** (exact alarms) | Stochastic trigger firing inside windows. |
 | Geofencing | **Android `GeofencingClient`** (Google Play Services Location API) | Background location; requires `ACCESS_BACKGROUND_LOCATION`. |
+| Map UI | **osmdroid** | OpenStreetMap-based map picker for location selection; tiles cached automatically on-device. |
 | Notifications | **NotificationManager** (Android 13+ runtime permission) | Native. |
 | LLM | **Gemma 4 E2B on-device** via **ML Kit GenAI Prompt API** / **AICore** (Pixel 8 Pro is AICore-supported). | Zero-cost, offline, private, low-latency. |
 | DI | Hilt | |
@@ -139,7 +140,10 @@ If Gemma 4 inference fails or takes >5s, fall back to a static template: *"{name
 2. **Habit editor** — name, full description, low-floor description, location tag, active toggle.
 3. **Windows screen** — list of windows. FAB → add window. Tap → edit.
 4. **Window editor** — start/end time pickers, days-of-week chips, frequency slider (1–3), active toggle.
-5. **Locations screen** — "Set my Home" / "Set my Work". Uses current GPS at capture time; stores lat/lng + radius (default 100m). Re-settable.
+5. **Locations screen** — dynamic list of named locations (any label, not restricted to HOME/WORK).
+   FAB opens the map picker; each list item has an Edit button. Map picker shows a full-screen
+   osmdroid map with a draggable pin and a bottom sheet for label, radius (50–500 m), and Save.
+   Location is stored as lat/lng + radius; osmdroid caches tiles automatically (no offline pre-caching UI).
 6. **Recent triggers screen** — last 20 fired triggers with their generated prompts and outcomes. Read-only.
 7. **Settings screen** — notification permission status, background location permission status, a manual "Test trigger now" button, and a button to regenerate tomorrow's scheduled triggers.
 
@@ -154,6 +158,7 @@ No onboarding flow for MVP beyond permission requests on first launch. User is e
 - `ACCESS_BACKGROUND_LOCATION` (requested separately after fine location grant, with clear in-app explanation of why)
 - `SCHEDULE_EXACT_ALARM` (Android 12+)
 - `FOREGROUND_SERVICE` for the geofence service if needed.
+- `INTERNET` — map tile downloads for the location picker (OpenStreetMap; no personal data transmitted).
 
 ---
 
@@ -162,7 +167,7 @@ No onboarding flow for MVP beyond permission requests on first launch. User is e
 ```kotlin
 @Entity Habit(id, name, full_description, low_floor_description, location_tag, active, created_at, updated_at)
 @Entity Window(id, start_time, end_time, days_of_week_bitmask, frequency_per_day, active)
-@Entity Location(id, label /* HOME|WORK */, lat, lng, radius_m)
+@Entity Location(id, label /* user-defined, e.g. "HOME", "WORK", "Gym" */, lat, lng, radius_m)
 @Entity Trigger(id, window_id?, habit_id?, scheduled_at, fired_at?, status, generated_prompt?)
 ```
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
 
     // Play Services Location (geofencing)
     implementation(libs.play.services.location)
+    implementation(libs.osmdroid.android)
 
     // ML Kit GenAI
     implementation(libs.mlkit.genai.prompt)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:name=".UnReminderApp"

--- a/app/src/main/java/com/alexsiri7/unreminder/data/repository/LocationRepository.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/data/repository/LocationRepository.kt
@@ -16,6 +16,8 @@ class LocationRepository @Inject constructor(
 
     suspend fun getByLabel(label: String): LocationEntity? = locationDao.getByLabel(label)
 
+    suspend fun deleteByLabel(label: String) = locationDao.deleteByLabel(label)
+
     suspend fun upsertLocation(label: String, lat: Double, lng: Double, radiusM: Float = 100f) {
         locationDao.deleteByLabel(label)
         locationDao.insert(LocationEntity(label = label, lat = lat, lng = lng, radiusM = radiusM))

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/location/LocationScreen.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/location/LocationScreen.kt
@@ -1,17 +1,19 @@
 package com.alexsiri7.unreminder.ui.location
 
-import android.Manifest
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Button
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -20,9 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -32,20 +32,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 @Composable
 fun LocationScreen(
     onNavigateBack: () -> Unit,
+    onAddLocation: () -> Unit,
+    onEditLocation: (String) -> Unit,
     viewModel: LocationViewModel = hiltViewModel()
 ) {
     val locations by viewModel.locations.collectAsStateWithLifecycle()
-
-    var pendingLabel by remember { mutableStateOf<String?>(null) }
-
-    val locationPermissionLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestMultiplePermissions()
-    ) { permissions ->
-        if (permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true) {
-            pendingLabel?.let { viewModel.setCurrentLocation(it) }
-            pendingLabel = null
-        }
-    }
 
     Scaffold(
         topBar = {
@@ -57,59 +48,52 @@ fun LocationScreen(
                     }
                 }
             )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = onAddLocation) {
+                Icon(Icons.Default.Add, contentDescription = "Add location")
+            }
         }
     ) { padding ->
-        Column(
-            modifier = Modifier
-                .padding(padding)
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+        LazyColumn(
+            modifier = Modifier.padding(padding).padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Text(
-                "Set your locations so the app knows where you are for context-aware triggers.",
-                style = MaterialTheme.typography.bodyMedium
-            )
-
-            listOf("HOME", "WORK").forEach { label ->
-                val saved = locations.find { it.label == label }
+            item {
+                Text(
+                    "Tap + to add a location. The app will trigger habits when you arrive.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+            items(locations) { loc ->
                 Card(modifier = Modifier.fillMaxWidth()) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Text(label, style = MaterialTheme.typography.titleMedium)
-                        if (saved != null) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(loc.label, style = MaterialTheme.typography.titleMedium)
                             Text(
-                                "Lat: %.4f, Lng: %.4f".format(saved.lat, saved.lng),
+                                "%.4f, %.4f \u2014 radius ${loc.radiusM.toInt()} m".format(loc.lat, loc.lng),
                                 style = MaterialTheme.typography.bodySmall
                             )
-                            Text(
-                                "Radius: ${saved.radiusM.toInt()}m",
-                                style = MaterialTheme.typography.bodySmall
-                            )
-                        } else {
-                            Text("Not set", style = MaterialTheme.typography.bodySmall)
                         }
-                        Button(
-                            onClick = {
-                                pendingLabel = label
-                                locationPermissionLauncher.launch(
-                                    arrayOf(
-                                        Manifest.permission.ACCESS_FINE_LOCATION,
-                                        Manifest.permission.ACCESS_COARSE_LOCATION
-                                    )
-                                )
-                            },
-                            modifier = Modifier.padding(top = 8.dp)
-                        ) {
-                            Text("Set to current location")
+                        IconButton(onClick = { onEditLocation(loc.label) }) {
+                            Icon(Icons.Default.Edit, contentDescription = "Edit ${loc.label}")
                         }
                     }
                 }
             }
-
-            Text(
-                "Background location access is needed for geofence triggers. " +
-                    "Grant it in Settings > Location > Allow all the time.",
-                style = MaterialTheme.typography.bodySmall
-            )
+            if (locations.isEmpty()) {
+                item {
+                    Text(
+                        "No locations saved yet.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/location/LocationViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/location/LocationViewModel.kt
@@ -1,52 +1,30 @@
 package com.alexsiri7.unreminder.ui.location
 
-import android.Manifest
-import android.content.Context
-import android.content.pm.PackageManager
-import android.util.Log
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.alexsiri7.unreminder.data.db.LocationEntity
 import com.alexsiri7.unreminder.data.repository.LocationRepository
 import com.alexsiri7.unreminder.service.geofence.GeofenceManager
-import com.google.android.gms.location.LocationServices
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 @HiltViewModel
 class LocationViewModel @Inject constructor(
     private val locationRepository: LocationRepository,
-    private val geofenceManager: GeofenceManager,
-    @ApplicationContext private val context: Context
+    private val geofenceManager: GeofenceManager
 ) : ViewModel() {
 
     val locations: StateFlow<List<LocationEntity>> = locationRepository.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
-    @Suppress("MissingPermission")
-    fun setCurrentLocation(label: String) {
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
-            != PackageManager.PERMISSION_GRANTED
-        ) return
-
+    fun delete(label: String) {
         viewModelScope.launch {
-            try {
-                val fusedClient = LocationServices.getFusedLocationProviderClient(context)
-                val location = fusedClient.lastLocation.await() ?: return@launch
-                val lat = location.latitude
-                val lng = location.longitude
-                locationRepository.upsertLocation(label, lat, lng)
-                geofenceManager.registerGeofence(label, lat, lng, 100f)
-            } catch (e: Exception) {
-                Log.e("LocationViewModel", "Failed to set location for label=$label", e)
-            }
+            locationRepository.deleteByLabel(label)
+            geofenceManager.removeGeofence(label)
         }
     }
 }

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/location/LocationViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/location/LocationViewModel.kt
@@ -1,5 +1,6 @@
 package com.alexsiri7.unreminder.ui.location
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.alexsiri7.unreminder.data.db.LocationEntity
@@ -23,8 +24,12 @@ class LocationViewModel @Inject constructor(
 
     fun delete(label: String) {
         viewModelScope.launch {
-            locationRepository.deleteByLabel(label)
-            geofenceManager.removeGeofence(label)
+            try {
+                locationRepository.deleteByLabel(label)
+                geofenceManager.removeGeofence(label)
+            } catch (e: Exception) {
+                Log.e("LocationViewModel", "Failed to delete location label=$label", e)
+            }
         }
     }
 }

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerScreen.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Slider
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberBottomSheetScaffoldState
@@ -55,6 +57,11 @@ fun MapPickerScreen(
     LaunchedEffect(Unit) { viewModel.initialize(existingLabel) }
 
     val mapViewRef = remember { mutableStateOf<MapView?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.errorMessage) {
+        uiState.errorMessage?.let { snackbarHostState.showSnackbar(it) }
+    }
 
     val scaffoldState = rememberBottomSheetScaffoldState(
         bottomSheetState = rememberStandardBottomSheetState(
@@ -64,6 +71,7 @@ fun MapPickerScreen(
 
     BottomSheetScaffold(
         scaffoldState = scaffoldState,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = { Text(if (existingLabel == null) "Add location" else "Edit location") },
@@ -98,7 +106,7 @@ fun MapPickerScreen(
                     value = uiState.radiusM,
                     onValueChange = viewModel::updateRadius,
                     valueRange = 50f..500f,
-                    steps = 89,
+                    steps = 89,  // 90 positions at 5 m increments (50, 55, ..., 500)
                     modifier = Modifier.fillMaxWidth()
                 )
                 Button(
@@ -170,8 +178,8 @@ fun MapPickerScreen(
                         GeoPoint(uiState.lat, uiState.lng),
                         uiState.radiusM.toDouble()
                     )
-                    circle.fillColor = 0x220000FF
-                    circle.strokeColor = 0xFF0000FF.toInt()
+                    circle.fillColor = 0x220000FF           // ARGB: alpha=0x22 (~13% opaque), blue
+                    circle.strokeColor = 0xFF0000FF.toInt() // ARGB: fully opaque blue
                     circle.strokeWidth = 2f
                     mv.overlays.add(0, circle)
                     mv.invalidate()

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerScreen.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerScreen.kt
@@ -1,0 +1,200 @@
+package com.alexsiri7.unreminder.ui.location
+
+import android.content.Context
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.compose.material3.rememberStandardBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.osmdroid.config.Configuration
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory
+import org.osmdroid.util.GeoPoint
+import org.osmdroid.views.MapView
+import org.osmdroid.views.overlay.Marker
+import org.osmdroid.views.overlay.Polygon
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MapPickerScreen(
+    existingLabel: String? = null,
+    onNavigateBack: () -> Unit,
+    viewModel: MapPickerViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(Unit) { viewModel.initialize(existingLabel) }
+
+    val mapViewRef = remember { mutableStateOf<MapView?>(null) }
+
+    val scaffoldState = rememberBottomSheetScaffoldState(
+        bottomSheetState = rememberStandardBottomSheetState(
+            initialValue = SheetValue.PartiallyExpanded
+        )
+    )
+
+    BottomSheetScaffold(
+        scaffoldState = scaffoldState,
+        topBar = {
+            TopAppBar(
+                title = { Text(if (existingLabel == null) "Add location" else "Edit location") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+                    }
+                }
+            )
+        },
+        sheetPeekHeight = 200.dp,
+        sheetContent = {
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                OutlinedTextField(
+                    value = uiState.name,
+                    onValueChange = viewModel::updateName,
+                    label = { Text("Name") },
+                    placeholder = { Text("e.g. Home, Gym, Office") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+                Text(
+                    "Radius: ${uiState.radiusM.toInt()} m",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Slider(
+                    value = uiState.radiusM,
+                    onValueChange = viewModel::updateRadius,
+                    valueRange = 50f..500f,
+                    steps = 89,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Button(
+                    onClick = { viewModel.save(onComplete = onNavigateBack) },
+                    enabled = uiState.name.isNotBlank(),
+                    modifier = Modifier.fillMaxWidth()
+                ) { Text("Save") }
+                Text(
+                    "\u00a9 OpenStreetMap contributors",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+        }
+    ) { paddingValues ->
+        if (uiState.centerReady) {
+            AndroidView(
+                factory = { ctx ->
+                    Configuration.getInstance().load(
+                        ctx,
+                        ctx.getSharedPreferences("osmdroid", Context.MODE_PRIVATE)
+                    )
+                    MapView(ctx).also { mv ->
+                        mapViewRef.value = mv
+                        mv.setTileSource(TileSourceFactory.MAPNIK)
+                        mv.setMultiTouchControls(true)
+                        mv.controller.setZoom(15.0)
+                        mv.controller.setCenter(
+                            GeoPoint(uiState.initialCenterLat, uiState.initialCenterLng)
+                        )
+                        val marker = Marker(mv)
+                        marker.position = GeoPoint(uiState.lat, uiState.lng)
+                        marker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
+                        marker.isDraggable = true
+                        marker.setOnMarkerDragListener(object : Marker.OnMarkerDragListener {
+                            override fun onMarkerDrag(marker: Marker) {}
+                            override fun onMarkerDragEnd(marker: Marker) {
+                                viewModel.updatePin(
+                                    marker.position.latitude,
+                                    marker.position.longitude
+                                )
+                            }
+                            override fun onMarkerDragStart(marker: Marker) {}
+                        })
+                        mv.overlays.add(marker)
+                        mv.overlays.add(object : org.osmdroid.views.overlay.Overlay() {
+                            override fun onLongPress(
+                                e: android.view.MotionEvent,
+                                mapView: MapView
+                            ): Boolean {
+                                val projection = mapView.projection
+                                val gp = projection.fromPixels(
+                                    e.x.toInt(),
+                                    e.y.toInt()
+                                ) as GeoPoint
+                                marker.position = gp
+                                viewModel.updatePin(gp.latitude, gp.longitude)
+                                mapView.invalidate()
+                                return true
+                            }
+                        })
+                    }
+                },
+                update = { mv ->
+                    mv.overlays.removeIf { it is Polygon }
+                    val circle = Polygon(mv)
+                    circle.points = Polygon.pointsAsCircle(
+                        GeoPoint(uiState.lat, uiState.lng),
+                        uiState.radiusM.toDouble()
+                    )
+                    circle.fillColor = 0x220000FF
+                    circle.strokeColor = 0xFF0000FF.toInt()
+                    circle.strokeWidth = 2f
+                    mv.overlays.add(0, circle)
+                    mv.invalidate()
+                },
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+            )
+        }
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> mapViewRef.value?.onResume()
+                Lifecycle.Event.ON_PAUSE -> mapViewRef.value?.onPause()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            mapViewRef.value?.onDetach()
+        }
+    }
+}

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModel.kt
@@ -9,7 +9,6 @@ import com.alexsiri7.unreminder.service.geofence.GeofenceManager
 import com.google.android.gms.location.LocationServices
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -40,7 +39,7 @@ class MapPickerViewModel @Inject constructor(
     val uiState: StateFlow<MapPickerUiState> = _uiState.asStateFlow()
 
     fun initialize(existingLabel: String?) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             if (existingLabel != null) {
                 val loc = locationRepository.getByLabel(existingLabel)
                 if (loc != null) {

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModel.kt
@@ -55,38 +55,24 @@ class MapPickerViewModel @Inject constructor(
                     return@launch
                 }
             }
-            try {
-                // Permission may not be granted (no explicit request in this flow); lastLocation
-                // returns null gracefully if unavailable — the map falls back to London defaults.
+            // Permission may not be granted (no explicit request in this flow); lastLocation
+            // returns null gracefully if unavailable — the map falls back to London defaults.
+            val loc = try {
                 @Suppress("MissingPermission")
-                val loc = LocationServices.getFusedLocationProviderClient(context)
-                    .lastLocation.await()
-                if (loc != null) {
-                    _uiState.value = _uiState.value.copy(
-                        lat = loc.latitude,
-                        lng = loc.longitude,
-                        initialCenterLat = loc.latitude,
-                        initialCenterLng = loc.longitude,
-                        centerReady = true
-                    )
-                } else {
-                    // No recent GPS fix — use London defaults so pin is visible on screen.
-                    // LocationServices static call cannot be mocked in JVM unit tests;
-                    // this fallback path is intentionally untested at unit level.
-                    _uiState.value = _uiState.value.copy(
-                        lat = _uiState.value.initialCenterLat,
-                        lng = _uiState.value.initialCenterLng,
-                        centerReady = true
-                    )
-                }
+                LocationServices.getFusedLocationProviderClient(context).lastLocation.await()
             } catch (e: Exception) {
                 Log.w("MapPickerViewModel", "Could not get last known location", e)
-                _uiState.value = _uiState.value.copy(
-                    lat = _uiState.value.initialCenterLat,
-                    lng = _uiState.value.initialCenterLng,
-                    centerReady = true
-                )
+                null
             }
+            val lat = loc?.latitude ?: _uiState.value.initialCenterLat
+            val lng = loc?.longitude ?: _uiState.value.initialCenterLng
+            _uiState.value = _uiState.value.copy(
+                lat = lat,
+                lng = lng,
+                initialCenterLat = lat,
+                initialCenterLng = lng,
+                centerReady = true
+            )
         }
     }
 

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModel.kt
@@ -1,0 +1,107 @@
+package com.alexsiri7.unreminder.ui.location
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.alexsiri7.unreminder.data.repository.LocationRepository
+import com.alexsiri7.unreminder.service.geofence.GeofenceManager
+import com.google.android.gms.location.LocationServices
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+data class MapPickerUiState(
+    val name: String = "",
+    val lat: Double = 0.0,
+    val lng: Double = 0.0,
+    val radiusM: Float = 100f,
+    val isLoading: Boolean = false,
+    val isSaved: Boolean = false,
+    val initialCenterLat: Double = 51.5074,
+    val initialCenterLng: Double = -0.1278,
+    val centerReady: Boolean = false
+)
+
+@HiltViewModel
+class MapPickerViewModel @Inject constructor(
+    private val locationRepository: LocationRepository,
+    private val geofenceManager: GeofenceManager,
+    @ApplicationContext private val context: Context
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(MapPickerUiState())
+    val uiState: StateFlow<MapPickerUiState> = _uiState.asStateFlow()
+
+    fun initialize(existingLabel: String?) {
+        viewModelScope.launch(Dispatchers.IO) {
+            if (existingLabel != null) {
+                val loc = locationRepository.getByLabel(existingLabel)
+                if (loc != null) {
+                    _uiState.value = _uiState.value.copy(
+                        name = loc.label,
+                        lat = loc.lat,
+                        lng = loc.lng,
+                        radiusM = loc.radiusM,
+                        initialCenterLat = loc.lat,
+                        initialCenterLng = loc.lng,
+                        centerReady = true
+                    )
+                    return@launch
+                }
+            }
+            try {
+                @Suppress("MissingPermission")
+                val loc = LocationServices.getFusedLocationProviderClient(context)
+                    .lastLocation.await()
+                if (loc != null) {
+                    _uiState.value = _uiState.value.copy(
+                        lat = loc.latitude,
+                        lng = loc.longitude,
+                        initialCenterLat = loc.latitude,
+                        initialCenterLng = loc.longitude,
+                        centerReady = true
+                    )
+                } else {
+                    _uiState.value = _uiState.value.copy(centerReady = true)
+                }
+            } catch (e: Exception) {
+                Log.w("MapPickerViewModel", "Could not get last known location", e)
+                _uiState.value = _uiState.value.copy(centerReady = true)
+            }
+        }
+    }
+
+    fun updateName(name: String) {
+        _uiState.value = _uiState.value.copy(name = name)
+    }
+
+    fun updatePin(lat: Double, lng: Double) {
+        _uiState.value = _uiState.value.copy(lat = lat, lng = lng)
+    }
+
+    fun updateRadius(radiusM: Float) {
+        _uiState.value = _uiState.value.copy(radiusM = radiusM)
+    }
+
+    fun save(onComplete: () -> Unit) {
+        val state = _uiState.value
+        if (state.name.isBlank()) return
+        viewModelScope.launch {
+            try {
+                locationRepository.upsertLocation(state.name, state.lat, state.lng, state.radiusM)
+                geofenceManager.registerGeofence(state.name, state.lat, state.lng, state.radiusM)
+                _uiState.value = _uiState.value.copy(isSaved = true)
+                onComplete()
+            } catch (e: Exception) {
+                Log.e("MapPickerViewModel", "Failed to save location for label=${state.name}", e)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModel.kt
@@ -22,10 +22,10 @@ data class MapPickerUiState(
     val lng: Double = 0.0,
     val radiusM: Float = 100f,
     val isLoading: Boolean = false,
-    val isSaved: Boolean = false,
-    val initialCenterLat: Double = 51.5074,
+    val initialCenterLat: Double = 51.5074,  // London — fallback when no GPS fix is available
     val initialCenterLng: Double = -0.1278,
-    val centerReady: Boolean = false
+    val centerReady: Boolean = false,
+    val errorMessage: String? = null
 )
 
 @HiltViewModel
@@ -56,6 +56,8 @@ class MapPickerViewModel @Inject constructor(
                 }
             }
             try {
+                // Permission may not be granted (no explicit request in this flow); lastLocation
+                // returns null gracefully if unavailable — the map falls back to London defaults.
                 @Suppress("MissingPermission")
                 val loc = LocationServices.getFusedLocationProviderClient(context)
                     .lastLocation.await()
@@ -68,11 +70,22 @@ class MapPickerViewModel @Inject constructor(
                         centerReady = true
                     )
                 } else {
-                    _uiState.value = _uiState.value.copy(centerReady = true)
+                    // No recent GPS fix — use London defaults so pin is visible on screen.
+                    // LocationServices static call cannot be mocked in JVM unit tests;
+                    // this fallback path is intentionally untested at unit level.
+                    _uiState.value = _uiState.value.copy(
+                        lat = _uiState.value.initialCenterLat,
+                        lng = _uiState.value.initialCenterLng,
+                        centerReady = true
+                    )
                 }
             } catch (e: Exception) {
                 Log.w("MapPickerViewModel", "Could not get last known location", e)
-                _uiState.value = _uiState.value.copy(centerReady = true)
+                _uiState.value = _uiState.value.copy(
+                    lat = _uiState.value.initialCenterLat,
+                    lng = _uiState.value.initialCenterLng,
+                    centerReady = true
+                )
             }
         }
     }
@@ -96,10 +109,12 @@ class MapPickerViewModel @Inject constructor(
             try {
                 locationRepository.upsertLocation(state.name, state.lat, state.lng, state.radiusM)
                 geofenceManager.registerGeofence(state.name, state.lat, state.lng, state.radiusM)
-                _uiState.value = _uiState.value.copy(isSaved = true)
                 onComplete()
             } catch (e: Exception) {
                 Log.e("MapPickerViewModel", "Failed to save location for label=${state.name}", e)
+                _uiState.value = _uiState.value.copy(
+                    errorMessage = "Could not save location. Please try again."
+                )
             }
         }
     }

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/navigation/NavGraph.kt
@@ -26,6 +26,7 @@ import androidx.navigation.navArgument
 import com.alexsiri7.unreminder.ui.habit.HabitEditScreen
 import com.alexsiri7.unreminder.ui.habit.HabitListScreen
 import com.alexsiri7.unreminder.ui.location.LocationScreen
+import com.alexsiri7.unreminder.ui.location.MapPickerScreen
 import com.alexsiri7.unreminder.ui.recent.RecentTriggersScreen
 import com.alexsiri7.unreminder.ui.settings.SettingsScreen
 import com.alexsiri7.unreminder.ui.window.WindowEditScreen
@@ -116,7 +117,26 @@ fun NavGraph() {
                 )
             }
             composable("locations") {
-                LocationScreen(onNavigateBack = { navController.popBackStack() })
+                LocationScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onAddLocation = { navController.navigate("location_add") },
+                    onEditLocation = { label -> navController.navigate("location_edit/$label") }
+                )
+            }
+            composable("location_add") {
+                MapPickerScreen(
+                    existingLabel = null,
+                    onNavigateBack = { navController.popBackStack() }
+                )
+            }
+            composable(
+                "location_edit/{label}",
+                arguments = listOf(navArgument("label") { type = NavType.StringType })
+            ) { backStackEntry ->
+                MapPickerScreen(
+                    existingLabel = backStackEntry.arguments?.getString("label"),
+                    onNavigateBack = { navController.popBackStack() }
+                )
             }
             composable(Screen.Recent.route) {
                 RecentTriggersScreen()

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/navigation/NavGraph.kt
@@ -126,7 +126,6 @@ fun NavGraph() {
             }
             composable("location_add") {
                 MapPickerScreen(
-                    existingLabel = null,
                     onNavigateBack = { navController.popBackStack() }
                 )
             }

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/navigation/NavGraph.kt
@@ -1,5 +1,6 @@
 package com.alexsiri7.unreminder.ui.navigation
 
+import android.net.Uri
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
@@ -120,7 +121,7 @@ fun NavGraph() {
                 LocationScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onAddLocation = { navController.navigate("location_add") },
-                    onEditLocation = { label -> navController.navigate("location_edit/$label") }
+                    onEditLocation = { label -> navController.navigate("location_edit/${Uri.encode(label)}") }
                 )
             }
             composable("location_add") {

--- a/app/src/test/java/com/alexsiri7/unreminder/ui/location/LocationViewModelTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/ui/location/LocationViewModelTest.kt
@@ -1,0 +1,51 @@
+package com.alexsiri7.unreminder.ui.location
+
+import com.alexsiri7.unreminder.data.repository.LocationRepository
+import com.alexsiri7.unreminder.service.geofence.GeofenceManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LocationViewModelTest {
+
+    private lateinit var locationRepository: LocationRepository
+    private lateinit var geofenceManager: GeofenceManager
+    private lateinit var viewModel: LocationViewModel
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        locationRepository = mockk(relaxUnitFun = true)
+        geofenceManager = mockk(relaxUnitFun = true)
+        coEvery { locationRepository.getAll() } returns flowOf(emptyList())
+        viewModel = LocationViewModel(locationRepository, geofenceManager)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `delete calls deleteByLabel and removeGeofence`() = runTest {
+        coEvery { locationRepository.deleteByLabel("Home") } returns Unit
+        coEvery { geofenceManager.removeGeofence("Home") } returns Unit
+
+        viewModel.delete("Home")
+
+        coVerify { locationRepository.deleteByLabel("Home") }
+        coVerify { geofenceManager.removeGeofence("Home") }
+    }
+}

--- a/app/src/test/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModelTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModelTest.kt
@@ -1,0 +1,111 @@
+package com.alexsiri7.unreminder.ui.location
+
+import android.content.Context
+import com.alexsiri7.unreminder.data.db.LocationEntity
+import com.alexsiri7.unreminder.data.repository.LocationRepository
+import com.alexsiri7.unreminder.service.geofence.GeofenceManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MapPickerViewModelTest {
+
+    private lateinit var locationRepository: LocationRepository
+    private lateinit var geofenceManager: GeofenceManager
+    private lateinit var viewModel: MapPickerViewModel
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        locationRepository = mockk(relaxUnitFun = true)
+        geofenceManager = mockk(relaxUnitFun = true)
+        val context = mockk<Context>(relaxed = true)
+        viewModel = MapPickerViewModel(locationRepository, geofenceManager, context)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state has empty name and default radius 100m`() {
+        val state = viewModel.uiState.value
+        assertEquals("", state.name)
+        assertEquals(100f, state.radiusM)
+        assertFalse(state.isSaved)
+    }
+
+    @Test
+    fun `updateName updates state`() {
+        viewModel.updateName("Gym")
+        assertEquals("Gym", viewModel.uiState.value.name)
+    }
+
+    @Test
+    fun `updateRadius updates state`() {
+        viewModel.updateRadius(250f)
+        assertEquals(250f, viewModel.uiState.value.radiusM)
+    }
+
+    @Test
+    fun `updatePin updates lat lng`() {
+        viewModel.updatePin(51.5, -0.1)
+        val state = viewModel.uiState.value
+        assertEquals(51.5, state.lat, 0.0001)
+        assertEquals(-0.1, state.lng, 0.0001)
+    }
+
+    @Test
+    fun `save calls upsertLocation and registerGeofence`() = runTest {
+        coEvery { locationRepository.upsertLocation(any(), any(), any(), any()) } returns Unit
+        coEvery { geofenceManager.registerGeofence(any(), any(), any(), any()) } returns Unit
+
+        viewModel.updateName("Home")
+        viewModel.updatePin(51.5, -0.1)
+        viewModel.updateRadius(150f)
+
+        var callbackFired = false
+        viewModel.save { callbackFired = true }
+
+        coVerify { locationRepository.upsertLocation("Home", 51.5, -0.1, 150f) }
+        coVerify { geofenceManager.registerGeofence("Home", 51.5, -0.1, 150f) }
+        assertTrue(callbackFired)
+    }
+
+    @Test
+    fun `save does nothing when name is blank`() = runTest {
+        viewModel.updateName("")
+        viewModel.save { fail("Should not call onComplete") }
+        coVerify(exactly = 0) { locationRepository.upsertLocation(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `initialize with existing label pre-populates state`() = runTest {
+        coEvery { locationRepository.getByLabel("Office") } returns
+            LocationEntity(id = 1, label = "Office", lat = 48.8, lng = 2.3, radiusM = 200f)
+
+        viewModel.initialize("Office")
+
+        val state = viewModel.uiState.value
+        assertEquals("Office", state.name)
+        assertEquals(48.8, state.lat, 0.0001)
+        assertEquals(200f, state.radiusM)
+        assertTrue(state.centerReady)
+    }
+}

--- a/app/src/test/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModelTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModelTest.kt
@@ -6,6 +6,7 @@ import com.alexsiri7.unreminder.data.repository.LocationRepository
 import com.alexsiri7.unreminder.service.geofence.GeofenceManager
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -48,7 +49,7 @@ class MapPickerViewModelTest {
         val state = viewModel.uiState.value
         assertEquals("", state.name)
         assertEquals(100f, state.radiusM)
-        assertFalse(state.isSaved)
+        assertFalse(state.centerReady)
     }
 
     @Test
@@ -107,5 +108,19 @@ class MapPickerViewModelTest {
         assertEquals(48.8, state.lat, 0.0001)
         assertEquals(200f, state.radiusM)
         assertTrue(state.centerReady)
+    }
+
+    @Test
+    fun `save does not invoke onComplete and sets errorMessage when upsertLocation throws`() = runTest {
+        coEvery {
+            locationRepository.upsertLocation(any(), any(), any(), any())
+        } throws RuntimeException("DB error")
+
+        viewModel.updateName("Gym")
+        var callbackFired = false
+        viewModel.save { callbackFired = true }
+
+        assertFalse(callbackFired)
+        assertFalse(viewModel.uiState.value.errorMessage.isNullOrBlank())
     }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,7 @@
 <p>
   The Un-Reminder is a native Android application that stores all user data exclusively on the user's device.
   It does not collect, transmit, share, or sell any personal information.
+  Map tile images are fetched from <a href="https://www.openstreetmap.org">OpenStreetMap</a> tile servers when the location picker is open; these requests contain no personal data.
 </p>
 
 <h2>Data handled on-device</h2>
@@ -43,6 +44,7 @@
   <li><code>POST_NOTIFICATIONS</code> — to display habit prompts.</li>
   <li><code>ACCESS_FINE_LOCATION</code>, <code>ACCESS_BACKGROUND_LOCATION</code> — to detect arrival at locations you configure.</li>
   <li><code>SCHEDULE_EXACT_ALARM</code> — to fire stochastic triggers at their scheduled times.</li>
+  <li><code>INTERNET</code> — to download map tiles from OpenStreetMap when you use the map-based location picker. No personal data is included in these requests.</li>
 </ul>
 
 <h2>Your data</h2>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ junit = "4.13.2"
 androidxJunit = "1.2.1"
 mockk = "1.13.13"
 coroutinesTest = "1.9.0"
+osmdroid = "6.1.20"
 
 [libraries]
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
@@ -49,6 +50,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
+osmdroid-android = { group = "org.osmdroid", name = "osmdroid-android", version.ref = "osmdroid" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Replace the hardcoded HOME/WORK GPS-capture flow with a full-screen osmdroid map picker. Users can now drop a pin anywhere on the map, set a custom radius via a slider, name the location, and save — without being physically present at the location.

- Adds `MapPickerScreen` with an osmdroid `MapView` (draggable pin, translucent radius circle, bottom sheet form)
- Adds `MapPickerViewModel` with `initialize(existingLabel)` for both add and edit modes
- Updates `LocationScreen` to a dynamic list of all saved locations with an Add FAB and per-item Edit button
- Simplifies `LocationViewModel` (removes `setCurrentLocation()`, adds `delete()`)
- Adds `deleteByLabel()` to `LocationRepository`
- Extends `NavGraph` with `location_add` and `location_edit/{label}` routes
- Adds `MapPickerViewModelTest` (7 tests, all passing)

## Changes

| File | Action |
|------|--------|
| `gradle/libs.versions.toml` | Add osmdroid 6.1.20 |
| `app/build.gradle.kts` | Add osmdroid-android dependency |
| `AndroidManifest.xml` | Add INTERNET permission (osmdroid tile download) |
| `ui/location/MapPickerViewModel.kt` | New ViewModel with UiState, GPS init, save logic |
| `ui/location/MapPickerScreen.kt` | New full-screen map screen + bottom sheet |
| `ui/location/LocationScreen.kt` | Rewrite: dynamic list + FAB + edit callbacks |
| `ui/location/LocationViewModel.kt` | Simplify: remove setCurrentLocation, add delete |
| `data/repository/LocationRepository.kt` | Add public deleteByLabel() |
| `ui/navigation/NavGraph.kt` | Add location_add and location_edit/{label} routes |
| `ui/location/MapPickerViewModelTest.kt` | 7 unit tests |

## Validation

- **Tests**: 39 passed, 0 failed (`./gradlew testDebugUnitTest` with JDK 17)
- **Build**: Compiles cleanly; 4 non-blocking deprecation warnings from osmdroid API
- **No schema migration needed**: `LocationEntity` is unchanged; `label` was already an arbitrary String

## Notes

- osmdroid requires INTERNET permission for tile download; without it the map is blank (no crash)
- `MapView` lifecycle (onResume/onPause/onDetach) is wired via `DisposableEffect` to prevent memory leaks
- Falls back to London (51.5074, -0.1278) if `fusedLocationClient.lastLocation` returns null
- OpenStreetMap attribution ("© OpenStreetMap contributors") is shown in the bottom sheet per tile license requirements
- Issue #7 (many-to-many location↔habit mapping) builds on this; no `LocationTag` wiring added here

Fixes #6