### PR TITLE
CI: produce signed release APKs (stable signature, in-place updates)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,15 +33,35 @@ jobs:
       - name: Unit tests
         run: ./gradlew test --stacktrace
 
-      - name: Assemble debug APK
-        run: ./gradlew assembleDebug --stacktrace
+      - name: Decode release keystore
+        env:
+          KEYSTORE_B64: ${{ secrets.KEYSTORE_B64 }}
+        run: |
+          if [ -z "$KEYSTORE_B64" ]; then
+            echo "::error::KEYSTORE_B64 secret is not set — release APK cannot be signed."
+            exit 1
+          fi
+          echo "$KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/keystore.jks"
+          echo "KEYSTORE_PATH=$RUNNER_TEMP/keystore.jks" >> "$GITHUB_ENV"
 
-      - name: Upload debug APK
+      - name: Resolve version
+        run: |
+          VERSION_CODE=$(git rev-list --count HEAD)
+          echo "VERSION_CODE=$VERSION_CODE" >> "$GITHUB_ENV"
+
+      - name: Assemble signed release APK
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Upload signed release APK
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: app-debug-${{ github.sha }}
-          path: app/build/outputs/apk/debug/*.apk
+          name: app-release-${{ github.sha }}
+          path: app/build/outputs/apk/release/*.apk
           if-no-files-found: error
           retention-days: 14
 


### PR DESCRIPTION
## Summary
Every CI run previously generated a fresh random debug-signing key, so each APK had a different signature. Android refuses to update an installed app when the signature changes — so every new APK required uninstall-first, wiping all local data.

This PR switches the primary CI artifact from `assembleDebug` to `assembleRelease`, signed with the release keystore (secrets already wired in PR #3). Every CI-built APK now shares the same stable signature. Installs update in place; habits, windows, and trigger logs survive.

## Notes
- The 3 in-flight archon draft PRs (#10/#11/#12) don't touch `ci.yml` or `app/build.gradle.kts`, so no rebase drama expected.
- Package rename to `net.interstellarai.unreminder` is deferred until those 3 PRs merge — it'll cause conflicts across ~56 files otherwise.