### PR TITLE
Feat: weighted habit selection biased by recency

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,10 @@ updated by geofence `ENTER`/`EXIT` callbacks. Empty set means no known location.
    - Has **no** entries in `habit_location` (eligible everywhere), OR has at least one
      `location_id` matching a geofence the user is currently inside.
    - Not fired within the last N minutes (configurable, default 90m) to avoid tight repeats.
-3. Pick **one** habit uniformly at random from eligible set. If the set is empty, skip silently.
+3. Pick **one** habit by weighted-random selection from the eligible set, biased toward habits
+   not recently prompted. Weight formula: `1 + min(minutesSince, 1440) / 120`, where
+   `minutesSince` is minutes since the habit was last fired (cap: 1440 min = 24 h). A habit
+   never fired receives the maximum weight (~13×). If the eligible set is empty, skip silently.
 4. Call Gemma 4 E2B with a structured prompt (see below) to generate a fresh, actionable one-liner for this habit instance.
 5. Post the notification with the generated text. Action buttons: **Did the full version**, **Did the low-floor**, **Dismiss**.
 6. Record the trigger row with the generated prompt and the outcome when the user responds.
@@ -251,7 +254,6 @@ Tracked manually by glancing at the Recent triggers screen. Not a feature.
 - Cloud sync & multi-device (would re-introduce Supabase + Google OAuth).
 - iOS version.
 - A "Surprise Me" quick-pick screen.
-- Weighted habit selection based on history.
 - Multi-modal habits (image/audio prompts from Gemma 4 multimodal).
 - Tasker/IFTTT webhooks for external triggers.
 - Habit templates / suggested habits library.

--- a/app/src/main/java/com/alexsiri7/unreminder/data/repository/TriggerRepository.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/data/repository/TriggerRepository.kt
@@ -43,4 +43,6 @@ class TriggerRepository @Inject constructor(
 
     suspend fun getLastNForHabit(habitId: Long, n: Int): List<TriggerEntity> =
         triggerDao.getLastNForHabit(habitId, n)
+
+    suspend fun getLastFiredForHabit(habitId: Long): Long? = triggerDao.getLastFiredForHabit(habitId)
 }

--- a/app/src/main/java/com/alexsiri7/unreminder/service/trigger/TriggerPipeline.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/trigger/TriggerPipeline.kt
@@ -1,6 +1,7 @@
 package com.alexsiri7.unreminder.service.trigger
 
 import android.util.Log
+import com.alexsiri7.unreminder.data.db.HabitEntity
 import com.alexsiri7.unreminder.data.repository.HabitRepository
 import com.alexsiri7.unreminder.data.repository.LocationRepository
 import com.alexsiri7.unreminder.data.repository.TriggerRepository
@@ -23,6 +24,29 @@ class TriggerPipeline @Inject constructor(
 ) {
     companion object {
         private const val TAG = "TriggerPipeline"
+        internal const val CAP_MINUTES = 1440L
+        internal val MAX_WEIGHT = 1.0 + CAP_MINUTES / 120.0
+
+        internal fun computeWeight(lastFiredMillis: Long?, nowMillis: Long): Double {
+            lastFiredMillis ?: return MAX_WEIGHT
+            val minutesSince = (nowMillis - lastFiredMillis) / 60_000L
+            return 1.0 + minOf(minutesSince, CAP_MINUTES) / 120.0
+        }
+
+        internal fun pickWeighted(
+            habits: List<HabitEntity>,
+            lastFiredMillisById: Map<Long, Long?>,
+            nowMillis: Long
+        ): HabitEntity {
+            val weights = habits.map { computeWeight(lastFiredMillisById[it.id], nowMillis) }
+            val total = weights.sum()
+            var r = Math.random() * total
+            for ((habit, weight) in habits.zip(weights)) {
+                r -= weight
+                if (r <= 0.0) return habit
+            }
+            return habits.last()
+        }
     }
 
     suspend fun execute(triggerId: Long) {
@@ -41,7 +65,11 @@ class TriggerPipeline @Inject constructor(
             return
         }
 
-        val habit = eligibleHabits.random()
+        val nowMillis = System.currentTimeMillis()
+        val lastFiredMap = eligibleHabits.associate { h ->
+            h.id to triggerRepository.getLastFiredForHabit(h.id)
+        }
+        val habit = pickWeighted(eligibleHabits, lastFiredMap, nowMillis)
         try {
             val timeOfDay = resolveTimeOfDay()
             val locationName = resolveLocationName(locationIds)

--- a/app/src/main/java/com/alexsiri7/unreminder/service/trigger/TriggerPipeline.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/trigger/TriggerPipeline.kt
@@ -12,6 +12,7 @@ import com.alexsiri7.unreminder.service.notification.NotificationHelper
 import java.time.LocalTime
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.random.Random
 
 @Singleton
 class TriggerPipeline @Inject constructor(
@@ -25,12 +26,13 @@ class TriggerPipeline @Inject constructor(
     companion object {
         private const val TAG = "TriggerPipeline"
         internal const val CAP_MINUTES = 1440L
-        internal val MAX_WEIGHT = 1.0 + CAP_MINUTES / 120.0
+        internal const val MINUTES_PER_WEIGHT_UNIT = 120L // weight increases by 1 per 2 hours
+        internal val MAX_WEIGHT = 1.0 + CAP_MINUTES / MINUTES_PER_WEIGHT_UNIT.toDouble()
 
         internal fun computeWeight(lastFiredMillis: Long?, nowMillis: Long): Double {
             lastFiredMillis ?: return MAX_WEIGHT
-            val minutesSince = (nowMillis - lastFiredMillis) / 60_000L
-            return 1.0 + minOf(minutesSince, CAP_MINUTES) / 120.0
+            val minutesSince = maxOf(0L, (nowMillis - lastFiredMillis) / 60_000L)
+            return 1.0 + minOf(minutesSince, CAP_MINUTES) / MINUTES_PER_WEIGHT_UNIT.toDouble()
         }
 
         internal fun pickWeighted(
@@ -40,12 +42,12 @@ class TriggerPipeline @Inject constructor(
         ): HabitEntity {
             val weights = habits.map { computeWeight(lastFiredMillisById[it.id], nowMillis) }
             val total = weights.sum()
-            var r = Math.random() * total
+            var r = Random.nextDouble() * total
             for ((habit, weight) in habits.zip(weights)) {
                 r -= weight
                 if (r <= 0.0) return habit
             }
-            return habits.last()
+            return habits.last() // floating-point safety: loop always exits above for positive weights
         }
     }
 

--- a/app/src/test/java/com/alexsiri7/unreminder/service/trigger/TriggerPipelineTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/service/trigger/TriggerPipelineTest.kt
@@ -229,9 +229,18 @@ class TriggerPipelineWeightTest {
         )
         val lastFiredMap = mapOf(1L to null, 2L to 0L)
         val now = 91 * 60_000L
+        // Expected neverDone rate ≈ 88% (MAX_WEIGHT / (MAX_WEIGHT + ~1.76)); threshold 600 gives 28pt margin
         val neverDoneCount = (1..1000).count {
             TriggerPipeline.pickWeighted(listOf(neverDone, recentlyDone), lastFiredMap, now) == neverDone
         }
         assertTrue("Expected >600/1000 picks for never-done, got $neverDoneCount", neverDoneCount > 600)
+    }
+
+    @Test
+    fun `weight floors at 1_0 when lastFired is in the future (clock skew)`() {
+        val now = 60 * 60_000L
+        val futureLastFired = now + 30 * 60_000L // 30 minutes in the future
+        val w = TriggerPipeline.computeWeight(futureLastFired, now)
+        assertTrue("Expected weight >= 1.0 for future lastFired, got $w", w >= 1.0)
     }
 }

--- a/app/src/test/java/com/alexsiri7/unreminder/service/trigger/TriggerPipelineTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/service/trigger/TriggerPipelineTest.kt
@@ -16,6 +16,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.time.Instant
@@ -65,6 +67,7 @@ class TriggerPipelineTest {
 
         every { geofenceManager.currentLocationIds } returns setOf(1L)
         coEvery { locationRepository.getByIds(any()) } returns emptyList()
+        coEvery { triggerRepository.getLastFiredForHabit(any()) } returns null
     }
 
     @Test
@@ -161,5 +164,74 @@ class TriggerPipelineTest {
         pipeline.execute(42L)
 
         coVerify { promptGenerator.generate(testHabit, "any location", any()) }
+    }
+}
+
+class TriggerPipelineWeightTest {
+
+    @Test
+    fun `habit never fired gets max weight`() {
+        val w = TriggerPipeline.computeWeight(null, nowMillis = 0L)
+        assertEquals(TriggerPipeline.MAX_WEIGHT, w, 0.001)
+    }
+
+    @Test
+    fun `weight formula at 120 minutes gives 2_0`() {
+        val now = 120 * 60_000L
+        val w = TriggerPipeline.computeWeight(lastFiredMillis = 0L, nowMillis = now)
+        assertEquals(2.0, w, 0.001)
+    }
+
+    @Test
+    fun `more recent completion gives lower weight`() {
+        val now = 1_000_000L
+        val recent = TriggerPipeline.computeWeight(now - 100 * 60_000L, now)
+        val older = TriggerPipeline.computeWeight(now - 500 * 60_000L, now)
+        assertTrue(recent < older)
+    }
+
+    @Test
+    fun `weight is capped at MAX_WEIGHT for very old completions`() {
+        val now = 100_000 * 60_000L
+        val w = TriggerPipeline.computeWeight(lastFiredMillis = 0L, nowMillis = now)
+        assertEquals(TriggerPipeline.MAX_WEIGHT, w, 0.001)
+    }
+
+    @Test
+    fun `weight is at least 1_0 for recently eligible habit`() {
+        val now = 90 * 60_000L
+        val w = TriggerPipeline.computeWeight(lastFiredMillis = 0L, nowMillis = now)
+        assertTrue(w >= 1.0)
+    }
+
+    @Test
+    fun `pickWeighted with single habit always returns that habit`() {
+        val habit = HabitEntity(
+            id = 1L, name = "test",
+            fullDescription = "full", lowFloorDescription = "low",
+            createdAt = Instant.EPOCH, updatedAt = Instant.EPOCH
+        )
+        val result = TriggerPipeline.pickWeighted(listOf(habit), emptyMap(), nowMillis = 0L)
+        assertEquals(habit, result)
+    }
+
+    @Test
+    fun `pickWeighted with null lastFired biases toward never-done habit`() {
+        val neverDone = HabitEntity(
+            id = 1L, name = "never",
+            fullDescription = "f", lowFloorDescription = "l",
+            createdAt = Instant.EPOCH, updatedAt = Instant.EPOCH
+        )
+        val recentlyDone = HabitEntity(
+            id = 2L, name = "recent",
+            fullDescription = "f", lowFloorDescription = "l",
+            createdAt = Instant.EPOCH, updatedAt = Instant.EPOCH
+        )
+        val lastFiredMap = mapOf(1L to null, 2L to 0L)
+        val now = 91 * 60_000L
+        val neverDoneCount = (1..1000).count {
+            TriggerPipeline.pickWeighted(listOf(neverDone, recentlyDone), lastFiredMap, now) == neverDone
+        }
+        assertTrue("Expected >600/1000 picks for never-done, got $neverDoneCount", neverDoneCount > 600)
     }
 }


### PR DESCRIPTION
## Summary

Replace uniform-random habit selection in `TriggerPipeline` with a recency-weighted pick that biases toward habits not completed recently. The weight formula `weight = 1 + min(minutesSinceLastFired, 1440) / 120` gives habits never fired the maximum weight (13.0), while habits fired just at the 90-minute eligibility boundary get the minimum weight (~1.75) — a ~7.4× bias toward stale habits.

## Changes

- **`TriggerRepository.kt`** — expose `getLastFiredForHabit(habitId)` delegating to the already-existing DAO method
- **`TriggerPipeline.kt`** — add `computeWeight()` and `pickWeighted()` as `internal` companion object functions; replace `eligibleHabits.random()` with `pickWeighted(eligibleHabits, lastFiredMap, nowMillis)` in `execute()`
- **`TriggerPipelineTest.kt`** — add `TriggerPipelineWeightTest` class with 7 unit tests covering the weight formula, cap, determinism with a single habit, and statistical bias toward never-done habits

## Validation

All checks pass with Java 17 (Temurin via sdkman):

| Check | Result |
|-------|--------|
| `compileDebugKotlin` | ✅ Pass (4 pre-existing deprecation warnings, unrelated) |
| `lintDebug` | ✅ Pass |
| `testDebugUnitTest` | ✅ 57 passed, 0 failed |

## Notes

- No UI changes — purely backend selection logic
- No database schema changes — uses existing `fired_at` column via pre-existing DAO query
- Cap is hardcoded at 1440 minutes per the issue specification
- N+1 query per eligible habit is acceptable; typical eligible list is <10 habits

Fixes #21