### PR TITLE
Feat: Surprise Me button and launcher shortcut

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,7 +39,15 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
+
+        <activity
+            android:name=".ui.shortcut.SurpriseMeActivity"
+            android:exported="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
 
         <receiver
             android:name=".service.alarm.AlarmReceiver"

--- a/app/src/main/java/com/alexsiri7/unreminder/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/data/db/AppDatabase.kt
@@ -12,7 +12,7 @@ import androidx.room.TypeConverters
         LocationEntity::class,
         HabitLocationCrossRef::class
     ],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/alexsiri7/unreminder/data/db/Migration2To3.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/data/db/Migration2To3.kt
@@ -1,0 +1,10 @@
+package com.alexsiri7.unreminder.data.db
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_2_3 = object : Migration(2, 3) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `triggers` ADD COLUMN `source` TEXT")
+    }
+}

--- a/app/src/main/java/com/alexsiri7/unreminder/data/db/TriggerEntity.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/data/db/TriggerEntity.kt
@@ -20,5 +20,7 @@ data class TriggerEntity(
     val firedAt: Instant? = null,
     val status: TriggerStatus = TriggerStatus.SCHEDULED,
     @ColumnInfo(name = "generated_prompt")
-    val generatedPrompt: String? = null
+    val generatedPrompt: String? = null,
+    @ColumnInfo(name = "source")
+    val source: String? = null
 )

--- a/app/src/main/java/com/alexsiri7/unreminder/di/AppModule.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/di/AppModule.kt
@@ -7,6 +7,7 @@ import com.alexsiri7.unreminder.data.db.HabitDao
 import com.alexsiri7.unreminder.data.db.HabitLocationCrossRefDao
 import com.alexsiri7.unreminder.data.db.LocationDao
 import com.alexsiri7.unreminder.data.db.MIGRATION_1_2
+import com.alexsiri7.unreminder.data.db.MIGRATION_2_3
 import com.alexsiri7.unreminder.data.db.TriggerDao
 import com.alexsiri7.unreminder.data.db.WindowDao
 import dagger.Module
@@ -27,7 +28,7 @@ object AppModule {
             context,
             AppDatabase::class.java,
             "unreminder.db"
-        ).addMigrations(MIGRATION_1_2).build()
+        ).addMigrations(MIGRATION_1_2, MIGRATION_2_3).build()
     }
 
     @Provides

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/settings/SettingsScreen.kt
@@ -108,6 +108,13 @@ fun SettingsScreen(
             }
 
             OutlinedButton(
+                onClick = { viewModel.surpriseMe() },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Surprise me")
+            }
+
+            OutlinedButton(
                 onClick = { viewModel.testTriggerNow() },
                 modifier = Modifier.fillMaxWidth()
             ) {

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/settings/SettingsViewModel.kt
@@ -69,6 +69,18 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun surpriseMe() {
+        viewModelScope.launch {
+            val trigger = TriggerEntity(
+                scheduledAt = Instant.now(),
+                status = TriggerStatus.SCHEDULED,
+                source = "MANUAL"
+            )
+            val id = triggerRepository.insert(trigger)
+            triggerPipeline.execute(id)
+        }
+    }
+
     fun regenerateTriggers() {
         viewModelScope.launch {
             triggerRepository.deleteAllScheduled()

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/shortcut/SurpriseMeActivity.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/shortcut/SurpriseMeActivity.kt
@@ -1,0 +1,35 @@
+package com.alexsiri7.unreminder.ui.shortcut
+
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import com.alexsiri7.unreminder.data.db.TriggerEntity
+import com.alexsiri7.unreminder.data.repository.TriggerRepository
+import com.alexsiri7.unreminder.domain.model.TriggerStatus
+import com.alexsiri7.unreminder.service.trigger.TriggerPipeline
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class SurpriseMeActivity : ComponentActivity() {
+
+    @Inject lateinit var triggerRepository: TriggerRepository
+    @Inject lateinit var triggerPipeline: TriggerPipeline
+
+    override fun onCreate(savedInstanceState: android.os.Bundle?) {
+        super.onCreate(savedInstanceState)
+        lifecycleScope.launch(Dispatchers.IO) {
+            val trigger = TriggerEntity(
+                scheduledAt = Instant.now(),
+                status = TriggerStatus.SCHEDULED,
+                source = "MANUAL"
+            )
+            val id = triggerRepository.insert(trigger)
+            triggerPipeline.execute(id)
+            withContext(Dispatchers.Main) { finish() }
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_surprise_me.xml
+++ b/app/src/main/res/drawable/ic_surprise_me.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Shuffle icon representing random surprise -->
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10.59,9.17L5.41,4 4,5.41l5.17,5.17 1.42,-1.41zM14.5,4l2.04,2.04L4,18.59 5.41,20 17.96,7.46 20,9.5V4h-5.5zM14.83,13.41l-1.41,1.41 3.13,3.13L14.5,20H20v-5.5l-2.04,2.04 -3.13,-3.13z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Un-Reminder</string>
+    <string name="shortcut_surprise_short">Surprise</string>
+    <string name="shortcut_surprise_long">Surprise me</string>
 </resources>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="surprise_me"
+        android:enabled="true"
+        android:icon="@drawable/ic_surprise_me"
+        android:shortcutShortLabel="@string/shortcut_surprise_short"
+        android:shortcutLongLabel="@string/shortcut_surprise_long">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.alexsiri7.unreminder"
+            android:targetClass="com.alexsiri7.unreminder.ui.shortcut.SurpriseMeActivity" />
+        <categories android:name="android.shortcut.conversation" />
+    </shortcut>
+</shortcuts>

--- a/app/src/test/java/com/alexsiri7/unreminder/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/ui/settings/SettingsViewModelTest.kt
@@ -1,0 +1,79 @@
+package com.alexsiri7.unreminder.ui.settings
+
+import android.app.AlarmManager
+import android.content.Context
+import com.alexsiri7.unreminder.data.db.TriggerEntity
+import com.alexsiri7.unreminder.data.repository.TriggerRepository
+import com.alexsiri7.unreminder.domain.model.TriggerStatus
+import com.alexsiri7.unreminder.service.trigger.TriggerPipeline
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsViewModelTest {
+
+    private lateinit var triggerRepository: TriggerRepository
+    private lateinit var triggerPipeline: TriggerPipeline
+    private lateinit var context: Context
+    private lateinit var viewModel: SettingsViewModel
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        triggerRepository = mockk(relaxUnitFun = true)
+        triggerPipeline = mockk(relaxUnitFun = true)
+        context = mockk(relaxed = true)
+        every { context.getSystemService(Context.ALARM_SERVICE) } returns mockk<AlarmManager>(relaxed = true)
+
+        viewModel = SettingsViewModel(
+            context = context,
+            triggerPipeline = triggerPipeline,
+            triggerRepository = triggerRepository
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `surpriseMe inserts trigger with MANUAL source and null windowId`() = runTest {
+        coEvery { triggerRepository.insert(any()) } returns 1L
+
+        viewModel.surpriseMe()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify {
+            triggerRepository.insert(match { trigger ->
+                trigger.source == "MANUAL" &&
+                trigger.windowId == null &&
+                trigger.status == TriggerStatus.SCHEDULED
+            })
+        }
+    }
+
+    @Test
+    fun `surpriseMe executes pipeline with inserted trigger id`() = runTest {
+        val triggerId = 7L
+        coEvery { triggerRepository.insert(any()) } returns triggerId
+
+        viewModel.surpriseMe()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { triggerPipeline.execute(triggerId) }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

- Adds a **"Surprise me"** button to the Settings screen that immediately fires the `TriggerPipeline` on demand, without waiting for a scheduled alarm window
- Adds a **launcher shortcut** (long-press app icon → "Surprise me") via a static `shortcuts.xml` and a lightweight transparent `SurpriseMeActivity`
- Introduces a `source` column (`TEXT`, nullable) to the `triggers` Room table via a new DB migration (v2→v3), so manually-triggered entries are distinguishable from scheduled ones (`source = "MANUAL"` vs `NULL`)
- Upgrades Gradle wrapper from 8.9 → 8.14.1 to resolve a `JavaVersion.parse` incompatibility with Java 25 in CI

## Changes

### DB layer
- `TriggerEntity.kt` — adds `@ColumnInfo(name = "source") val source: String? = null`
- `Migration2To3.kt` — new file; `ALTER TABLE triggers ADD COLUMN source TEXT`
- `AppDatabase.kt` — bumps `version = 2` → `version = 3`
- `AppModule.kt` — registers `MIGRATION_2_3` in `addMigrations()`

### ViewModel / UI
- `SettingsViewModel.kt` — adds `surpriseMe()` coroutine that inserts a `TriggerEntity(source="MANUAL")` and calls `triggerPipeline.execute(id)`
- `SettingsScreen.kt` — adds an `OutlinedButton("Surprise me")` above the existing "Test Trigger Now" button

### Launcher shortcut
- `ic_surprise_me.xml` — shuffle vector drawable (48dp) used as the shortcut icon
- `shortcuts.xml` — static shortcut declaration targeting `SurpriseMeActivity`
- `strings.xml` — adds `shortcut_surprise_short` ("Surprise") and `shortcut_surprise_long` ("Surprise me")
- `SurpriseMeActivity.kt` — transparent `@AndroidEntryPoint ComponentActivity`; injects `TriggerRepository` + `TriggerPipeline`, fires pipeline, then finishes
- `AndroidManifest.xml` — adds `<meta-data android:name="android.app.shortcuts">` to `MainActivity`; registers `SurpriseMeActivity` with `Theme.Translucent.NoTitleBar`

### Build
- `gradle/wrapper/gradle-wrapper.properties` — Gradle 8.9 → 8.14.1 (Java 25 compatibility fix)

### Tests
- `SettingsViewModelTest.kt` — 2 unit tests verifying `surpriseMe()` inserts with `source="MANUAL"` + `windowId=null` and calls `triggerPipeline.execute(id)`

## Validation

| Check | Result |
|-------|--------|
| `compileDebugKotlin` | ✅ Pass (4 pre-existing deprecation warnings, unrelated) |
| `lintDebug` | ✅ Pass |
| `testDebugUnitTest` | ✅ 52 passed, 0 failed |
| `assembleDebug` | ✅ APK produced |

All checks run with `JAVA_HOME=~/.sdkman/candidates/java/17.0.10-tem` (Java 17 Temurin via sdkman) against Gradle 8.14.1.

## Design decisions

- **`SurpriseMeActivity` calls `finish()` inside the coroutine** (after `execute()` returns) so the lifecycle scope stays alive throughout the pipeline — preventing premature cancellation during LLM generation.
- **Static shortcut** (not dynamic) — simpler to maintain; no `ShortcutManagerCompat` bookkeeping needed.
- **"Test Trigger Now" left unchanged** — it remains a developer debugging tool; `surpriseMe()` is the user-facing counterpart that adds the `MANUAL` source tag.
- **`source` column not added to `AlarmReceiver` / `GeofenceReceiver`** — out of scope per issue #20; column is nullable so existing rows are unaffected.

Fixes #20