### PR TITLE
Fix: Autofill-with-AI progress indicator and completion flash

### DIFF
--- a/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditScreen.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -41,6 +42,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -74,9 +76,12 @@ fun HabitEditScreen(
 
     LaunchedEffect(uiState.fieldsFlashing) {
         if (uiState.fieldsFlashing) {
-            flashAlpha.snapTo(0.3f)
-            flashAlpha.animateTo(0f, animationSpec = tween(durationMillis = 600))
-            viewModel.clearFieldsFlash()
+            try {
+                flashAlpha.snapTo(0.3f)
+                flashAlpha.animateTo(0f, animationSpec = tween(durationMillis = 600))
+            } finally {
+                viewModel.clearFieldsFlash()
+            }
         }
     }
 
@@ -125,6 +130,7 @@ fun HabitEditScreen(
             )
             Box(modifier = Modifier
                 .fillMaxWidth()
+                .clip(OutlinedTextFieldDefaults.shape)
                 .background(MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = flashAlpha.value))
             ) {
                 OutlinedTextField(
@@ -137,6 +143,7 @@ fun HabitEditScreen(
             }
             Box(modifier = Modifier
                 .fillMaxWidth()
+                .clip(OutlinedTextFieldDefaults.shape)
                 .background(MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = flashAlpha.value))
             ) {
                 OutlinedTextField(

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditScreen.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditScreen.kt
@@ -1,10 +1,15 @@
 package com.alexsiri7.unreminder.ui.habit
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -14,8 +19,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -47,6 +54,7 @@ fun HabitEditScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val allLocations by viewModel.allLocations.collectAsStateWithLifecycle()
+    val flashAlpha = remember { Animatable(0f) }
 
     LaunchedEffect(habitId) {
         if (habitId != null) viewModel.loadHabit(habitId)
@@ -62,6 +70,14 @@ fun HabitEditScreen(
         val msg = uiState.errorMessage ?: return@LaunchedEffect
         snackbarHostState.showSnackbar(msg)
         viewModel.clearError()
+    }
+
+    LaunchedEffect(uiState.fieldsFlashing) {
+        if (uiState.fieldsFlashing) {
+            flashAlpha.snapTo(0.3f)
+            flashAlpha.animateTo(0f, animationSpec = tween(durationMillis = 600))
+            viewModel.clearFieldsFlash()
+        }
     }
 
     val previewText = uiState.previewNotification
@@ -107,20 +123,30 @@ fun HabitEditScreen(
                 label = { Text("Name") },
                 modifier = Modifier.fillMaxWidth()
             )
-            OutlinedTextField(
-                value = uiState.fullDescription,
-                onValueChange = viewModel::updateFullDescription,
-                label = { Text("Full description") },
-                modifier = Modifier.fillMaxWidth(),
-                minLines = 2
-            )
-            OutlinedTextField(
-                value = uiState.lowFloorDescription,
-                onValueChange = viewModel::updateLowFloorDescription,
-                label = { Text("Low-floor description (minimum viable)") },
-                modifier = Modifier.fillMaxWidth(),
-                minLines = 2
-            )
+            Box(modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = flashAlpha.value))
+            ) {
+                OutlinedTextField(
+                    value = uiState.fullDescription,
+                    onValueChange = viewModel::updateFullDescription,
+                    label = { Text("Full description") },
+                    modifier = Modifier.fillMaxWidth(),
+                    minLines = 2
+                )
+            }
+            Box(modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = flashAlpha.value))
+            ) {
+                OutlinedTextField(
+                    value = uiState.lowFloorDescription,
+                    onValueChange = viewModel::updateLowFloorDescription,
+                    label = { Text("Low-floor description (minimum viable)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    minLines = 2
+                )
+            }
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -136,6 +162,8 @@ fun HabitEditScreen(
                             modifier = Modifier.size(16.dp),
                             strokeWidth = 2.dp
                         )
+                        Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
+                        Text("Generating\u2026")
                     } else {
                         Text("Autofill with AI")
                     }
@@ -148,6 +176,13 @@ fun HabitEditScreen(
                               !uiState.isGeneratingFields,
                     modifier = Modifier.weight(1f)
                 ) {
+                    if (uiState.isGeneratingFields) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp
+                        )
+                        Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
+                    }
                     Text("Preview notification")
                 }
             }

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModel.kt
@@ -113,8 +113,12 @@ class HabitEditViewModel @Inject constructor(
                     existing.id
                 } else {
                     habitRepository.insert(
-                        HabitEntity(name = state.name, fullDescription = state.fullDescription,
-                            lowFloorDescription = state.lowFloorDescription, active = state.active)
+                        HabitEntity(
+                            name = state.name,
+                            fullDescription = state.fullDescription,
+                            lowFloorDescription = state.lowFloorDescription,
+                            active = state.active
+                        )
                     )
                 }
                 habitRepository.setLocations(habitId, state.selectedLocationIds)

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModel.kt
@@ -28,6 +28,7 @@ data class HabitEditUiState(
     val isLoading: Boolean = false,
     val isSaved: Boolean = false,
     val isGeneratingFields: Boolean = false,
+    val fieldsFlashing: Boolean = false,
     val previewNotification: String? = null,
     val showPreviewDialog: Boolean = false,
     val errorMessage: String? = null
@@ -141,7 +142,8 @@ class HabitEditViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(
             fullDescription = fields.fullDescription,
             lowFloorDescription = fields.lowFloorDescription,
-            isGeneratingFields = false
+            isGeneratingFields = false,
+            fieldsFlashing = true
         )
     }
 
@@ -171,4 +173,5 @@ class HabitEditViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(showPreviewDialog = false, previewNotification = null)
     }
     fun clearError() { _uiState.value = _uiState.value.copy(errorMessage = null) }
+    fun clearFieldsFlash() { _uiState.value = _uiState.value.copy(fieldsFlashing = false) }
 }

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/location/MapPickerViewModel.kt
@@ -35,6 +35,10 @@ class MapPickerViewModel @Inject constructor(
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
+    companion object {
+        private const val TAG = "MapPickerViewModel"
+    }
+
     private val _uiState = MutableStateFlow(MapPickerUiState())
     val uiState: StateFlow<MapPickerUiState> = _uiState.asStateFlow()
 
@@ -61,7 +65,7 @@ class MapPickerViewModel @Inject constructor(
                 @Suppress("MissingPermission")
                 LocationServices.getFusedLocationProviderClient(context).lastLocation.await()
             } catch (e: Exception) {
-                Log.w("MapPickerViewModel", "Could not get last known location", e)
+                Log.w(TAG, "Could not get last known location", e)
                 null
             }
             val lat = loc?.latitude ?: _uiState.value.initialCenterLat
@@ -97,7 +101,7 @@ class MapPickerViewModel @Inject constructor(
                 geofenceManager.registerGeofence(id, state.name, state.lat, state.lng, state.radiusM)
                 onComplete()
             } catch (e: Exception) {
-                Log.e("MapPickerViewModel", "Failed to save location for name=${state.name}", e)
+                Log.e(TAG, "Failed to save location for name=${state.name}", e)
                 _uiState.value = _uiState.value.copy(
                     errorMessage = "Could not save location. Please try again."
                 )

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/onboarding/OnboardingScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
+import java.time.LocalTime
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -155,7 +156,7 @@ fun OnboardingScreen(
                     OutlinedButton(
                         onClick = {
                             TimePickerDialog(context, { _, h, m ->
-                                viewModel.updateWindowStartTime(java.time.LocalTime.of(h, m))
+                                viewModel.updateWindowStartTime(LocalTime.of(h, m))
                             }, uiState.windowStartTime.hour, uiState.windowStartTime.minute, true).show()
                         },
                         modifier = Modifier.weight(1f)
@@ -163,7 +164,7 @@ fun OnboardingScreen(
                     OutlinedButton(
                         onClick = {
                             TimePickerDialog(context, { _, h, m ->
-                                viewModel.updateWindowEndTime(java.time.LocalTime.of(h, m))
+                                viewModel.updateWindowEndTime(LocalTime.of(h, m))
                             }, uiState.windowEndTime.hour, uiState.windowEndTime.minute, true).show()
                         },
                         modifier = Modifier.weight(1f)

--- a/app/src/test/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModelTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModelTest.kt
@@ -86,6 +86,7 @@ class HabitEditViewModelTest {
 
         val state = viewModel.uiState.value
         assertFalse(state.isGeneratingFields)
+        assertFalse(state.fieldsFlashing)
         assertEquals("AI unavailable — fill in manually.", state.errorMessage)
     }
 

--- a/app/src/test/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModelTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/ui/habit/HabitEditViewModelTest.kt
@@ -151,4 +151,31 @@ class HabitEditViewModelTest {
 
         assertNull(viewModel.uiState.value.errorMessage)
     }
+
+    // --- fieldsFlashing ---
+
+    @Test
+    fun `autofillWithAi success sets fieldsFlashing to true`() = runTest {
+        coEvery { mockPromptGenerator.generateHabitFields("meditation") } returns
+            AiHabitFields("desc", "low")
+
+        viewModel.autofillWithAi()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.fieldsFlashing)
+    }
+
+    @Test
+    fun `clearFieldsFlash resets fieldsFlashing to false`() = runTest {
+        coEvery { mockPromptGenerator.generateHabitFields("meditation") } returns
+            AiHabitFields("desc", "low")
+
+        viewModel.autofillWithAi()
+        advanceUntilIdle()
+        assertTrue(viewModel.uiState.value.fieldsFlashing)
+
+        viewModel.clearFieldsFlash()
+
+        assertFalse(viewModel.uiState.value.fieldsFlashing)
+    }
 }


### PR DESCRIPTION
## Summary

Improves the 'Autofill with AI' UX in the habit editor by adding a loading spinner with label during generation, disabling both AI buttons while the LLM call is in-flight, and flashing the description fields when autofill completes.

**Before:** Button shows only a spinner with no text; "Preview notification" button gives no visual feedback; fields update silently.

**After:** Button shows `◌ Generating…` (spinner + label); "Preview notification" button also shows a spinner while disabled; both description fields flash with `tertiaryContainer` at 30% opacity for 600ms on successful autofill.

## Changes

- **`HabitEditViewModel.kt`** (+3/-1): Added `fieldsFlashing: Boolean = false` to `HabitEditUiState`; set it to `true` on autofill success; added `clearFieldsFlash()` to reset it.
- **`HabitEditScreen.kt`** (+51/-14): Updated "Autofill with AI" button content to show spinner + "Generating…" label side-by-side; updated "Preview notification" button to show spinner when generating; added `Animatable`-driven flash (snap to 0.3f → animate to 0f over 600ms) on both description `OutlinedTextField`s.
- **`HabitEditViewModelTest.kt`** (+26/-0): Added 2 unit tests covering `fieldsFlashing` state transitions (`autofillWithAi success sets fieldsFlashing to true`, `clearFieldsFlash resets fieldsFlashing to false`).

## Validation

- Type check (`compileDebugUnitTestKotlin`): ✅ BUILD SUCCESSFUL
- Unit tests (`HabitEditViewModelTest` — 8 tests, 6 existing + 2 new): ✅ All passed
- Full test suite (`testDebugUnitTest`): ✅ All passed, no regressions

## Notes

- The `isGeneratingFields` flag already disabled buttons; no change to the disable logic itself.
- `fieldsFlashing` is only set in `autofillWithAi()`, not `previewNotification()`.
- Error path still shows the existing Snackbar and re-enables buttons — no regression.

Fixes #16