### PR TITLE
ci: build signed APK on every main push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   push:
+    branches: [main]
     tags:
       - 'v*'
   workflow_dispatch:
@@ -48,8 +49,11 @@ jobs:
         run: |
           if [ "${GITHUB_REF#refs/tags/}" != "$GITHUB_REF" ]; then
             VERSION_NAME="${GITHUB_REF#refs/tags/v}"
-          else
+          elif [ -n "${{ inputs.version }}" ]; then
             VERSION_NAME="${{ inputs.version }}"
+          else
+            # main push: versionName derived from short SHA
+            VERSION_NAME="main-$(git rev-parse --short HEAD)"
           fi
           VERSION_CODE=$(git rev-list --count HEAD)
           echo "VERSION_NAME=$VERSION_NAME" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- Release workflow now triggers on push to main in addition to v* tags.
- Each main push produces a signed APK + AAB artifact (real keystore), installable on dev phones with in-place updates.
- versionName on main push derives from short SHA (e.g. \`main-ab2e3e5\`); tag + workflow_dispatch behavior unchanged.

## Test plan
- [ ] On merge, the Release workflow triggers and produces \`app-release-main-<sha>-apk\` and \`app-release-main-<sha>-aab\` artifacts.
- [ ] The APK installs cleanly on a test phone via \`adb install -r\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)