### PR TITLE
Feat: auto-pause habit after 3 consecutive dismissals

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ A repeatable thing the user wants to do. Each habit has:
 - `full_description` — the full version (e.g. "20-minute guided meditation").
 - `low_floor_description` — the minimum-viable version (e.g. "3 deep breaths"). **Completing this counts as a win.**
 - `locations` — zero or more named `Location` records associated via the `habit_location` junction table. A habit with **no** associated locations is eligible everywhere ("Anywhere" semantics). A habit with one or more locations is only eligible when the user is at one of those locations.
-- `active` — boolean. Inactive habits are never selected.
+- `active` — boolean. Inactive habits are never selected. Can be toggled manually in the habit editor.
+  The system also sets this to `false` automatically after 3 consecutive `DISMISSED` triggers
+  (see [Trigger Logic §5](#5-trigger-logic)).
 - `created_at`, `updated_at`.
 
 ### HabitLocationCrossRef
@@ -126,6 +128,8 @@ updated by geofence `ENTER`/`EXIT` callbacks. Empty set means no known location.
 4. Call Gemma 4 E2B with a structured prompt (see below) to generate a fresh, actionable one-liner for this habit instance.
 5. Post the notification with the generated text. Action buttons: **Did the full version**, **Did the low-floor**, **Dismiss**.
 6. Record the trigger row with the generated prompt and the outcome when the user responds.
+   If the last 3 triggers for the same habit are all `DISMISSED`, the habit is automatically set to
+   `active = false` (auto-paused). The user can re-activate it by editing the habit.
 
 ### LLM prompt shape (on-device Gemma 4)
 
@@ -243,7 +247,6 @@ Tracked manually by glancing at the Recent triggers screen. Not a feature.
 ## 11. Out of Scope for MVP (explicit v0.2+ backlog)
 
 - Emoji/icon shuffling on notifications.
-- Dismissal tracking → auto-inactivate after 3 consecutive dismissals.
 - Cloud sync & multi-device (would re-introduce Supabase + Google OAuth).
 - iOS version.
 - A "Surprise Me" quick-pick screen.

--- a/app/src/main/java/com/alexsiri7/unreminder/data/db/HabitDao.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/data/db/HabitDao.kt
@@ -22,6 +22,7 @@ interface HabitDao {
     @Query("SELECT * FROM habits WHERE id = :id")
     fun getById(id: Long): Flow<HabitEntity?>
 
+    /** One-shot suspend read; use when a reactive Flow is not needed (e.g., background coroutine). */
     @Query("SELECT * FROM habits WHERE id = :id")
     suspend fun getByIdOnce(id: Long): HabitEntity?
 

--- a/app/src/main/java/com/alexsiri7/unreminder/data/db/HabitDao.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/data/db/HabitDao.kt
@@ -22,6 +22,9 @@ interface HabitDao {
     @Query("SELECT * FROM habits WHERE id = :id")
     fun getById(id: Long): Flow<HabitEntity?>
 
+    @Query("SELECT * FROM habits WHERE id = :id")
+    suspend fun getByIdOnce(id: Long): HabitEntity?
+
     @Query("SELECT * FROM habits ORDER BY name ASC")
     fun getAll(): Flow<List<HabitEntity>>
 

--- a/app/src/main/java/com/alexsiri7/unreminder/data/db/TriggerDao.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/data/db/TriggerDao.kt
@@ -38,4 +38,7 @@ interface TriggerDao {
 
     @Query("SELECT fired_at FROM triggers WHERE habit_id = :habitId AND fired_at IS NOT NULL ORDER BY fired_at DESC LIMIT 1")
     suspend fun getLastFiredForHabit(habitId: Long): Long?
+
+    @Query("SELECT * FROM triggers WHERE habit_id = :habitId AND fired_at IS NOT NULL ORDER BY fired_at DESC LIMIT :limit")
+    suspend fun getLastNForHabit(habitId: Long, limit: Int): List<TriggerEntity>
 }

--- a/app/src/main/java/com/alexsiri7/unreminder/data/repository/HabitRepository.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/data/repository/HabitRepository.kt
@@ -26,6 +26,8 @@ class HabitRepository @Inject constructor(
 
     suspend fun delete(habit: HabitEntity) = habitDao.delete(habit)
 
+    suspend fun getByIdOnce(id: Long): HabitEntity? = habitDao.getByIdOnce(id)
+
     suspend fun getEligibleHabits(
         currentLocationIds: Set<Long>,
         excludeRecentMinutes: Long = 90

--- a/app/src/main/java/com/alexsiri7/unreminder/data/repository/TriggerRepository.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/data/repository/TriggerRepository.kt
@@ -40,4 +40,7 @@ class TriggerRepository @Inject constructor(
     }
 
     suspend fun deleteAllScheduled() = triggerDao.deleteAllScheduled()
+
+    suspend fun getLastNForHabit(habitId: Long, n: Int): List<TriggerEntity> =
+        triggerDao.getLastNForHabit(habitId, n)
 }

--- a/app/src/main/java/com/alexsiri7/unreminder/service/notification/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/notification/NotificationActionReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import com.alexsiri7.unreminder.data.repository.TriggerRepository
 import com.alexsiri7.unreminder.domain.model.TriggerStatus
+import com.alexsiri7.unreminder.service.trigger.DismissalTracker
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -17,6 +18,9 @@ class NotificationActionReceiver : BroadcastReceiver() {
 
     @Inject
     lateinit var triggerRepository: TriggerRepository
+
+    @Inject
+    lateinit var dismissalTracker: DismissalTracker
 
     override fun onReceive(context: Context, intent: Intent) {
         val triggerId = intent.getLongExtra(NotificationHelper.EXTRA_TRIGGER_ID, -1)
@@ -35,6 +39,9 @@ class NotificationActionReceiver : BroadcastReceiver() {
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 triggerRepository.updateOutcome(triggerId, status)
+                if (status == TriggerStatus.DISMISSED) {
+                    dismissalTracker.onDismissed(triggerId)
+                }
                 val manager = context.getSystemService(NotificationManager::class.java)
                 manager.cancel(triggerId.toInt())
             } finally {

--- a/app/src/main/java/com/alexsiri7/unreminder/service/notification/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/notification/NotificationActionReceiver.kt
@@ -4,10 +4,12 @@ import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import com.alexsiri7.unreminder.data.repository.TriggerRepository
 import com.alexsiri7.unreminder.domain.model.TriggerStatus
 import com.alexsiri7.unreminder.service.trigger.DismissalTracker
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -15,6 +17,10 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class NotificationActionReceiver : BroadcastReceiver() {
+
+    companion object {
+        private const val TAG = "NotificationActionReceiver"
+    }
 
     @Inject
     lateinit var triggerRepository: TriggerRepository
@@ -44,6 +50,9 @@ class NotificationActionReceiver : BroadcastReceiver() {
                 }
                 val manager = context.getSystemService(NotificationManager::class.java)
                 manager.cancel(triggerId.toInt())
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Log.e(TAG, "onReceive: failed for trigger=$triggerId action=$action", e)
             } finally {
                 pendingResult.finish()
             }

--- a/app/src/main/java/com/alexsiri7/unreminder/service/notification/NotificationHelper.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/notification/NotificationHelper.kt
@@ -24,7 +24,9 @@ class NotificationHelper @Inject constructor(
         const val ACTION_DISMISSED = "DISMISSED"
         const val CHANNEL_ID_SYSTEM = "un_reminder_system"
         const val CHANNEL_NAME_SYSTEM = "Habit Status"
-        const val NOTIFICATION_ID_PAUSED_BASE = 900_000
+        // Paused-habit notifications use habitId as offset.
+        // Base chosen well above realistic trigger ID values to avoid collisions.
+        const val NOTIFICATION_ID_PAUSED_BASE = 900_000L
     }
 
     fun createNotificationChannel() {

--- a/app/src/main/java/com/alexsiri7/unreminder/service/notification/NotificationHelper.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/notification/NotificationHelper.kt
@@ -14,6 +14,7 @@ import javax.inject.Singleton
 class NotificationHelper @Inject constructor(
     private val context: Context
 ) {
+    private val notificationManager = context.getSystemService(NotificationManager::class.java)
     companion object {
         const val CHANNEL_ID = "un_reminder_triggers"
         const val CHANNEL_NAME = "Habit Triggers"
@@ -37,8 +38,7 @@ class NotificationHelper @Inject constructor(
         ).apply {
             description = "Stochastic habit nudges"
         }
-        val manager = context.getSystemService(NotificationManager::class.java)
-        manager.createNotificationChannel(channel)
+        notificationManager.createNotificationChannel(channel)
 
         val systemChannel = NotificationChannel(
             CHANNEL_ID_SYSTEM,
@@ -49,7 +49,7 @@ class NotificationHelper @Inject constructor(
             setSound(null, null)
             enableVibration(false)
         }
-        manager.createNotificationChannel(systemChannel)
+        notificationManager.createNotificationChannel(systemChannel)
     }
 
     fun postTriggerNotification(triggerId: Long, promptText: String, habitName: String) {
@@ -69,8 +69,7 @@ class NotificationHelper @Inject constructor(
             .addAction(0, "Dismiss", dismissIntent)
             .build()
 
-        val manager = context.getSystemService(NotificationManager::class.java)
-        manager.notify(triggerId.toInt(), notification)
+        notificationManager.notify(triggerId.toInt(), notification)
     }
 
     fun postHabitPausedNotification(habitId: Long, habitName: String) {
@@ -81,8 +80,7 @@ class NotificationHelper @Inject constructor(
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
             .build()
-        val manager = context.getSystemService(NotificationManager::class.java)
-        manager.notify((NOTIFICATION_ID_PAUSED_BASE + habitId).toInt(), notification)
+        notificationManager.notify((NOTIFICATION_ID_PAUSED_BASE + habitId).toInt(), notification)
     }
 
     private fun createActionIntent(triggerId: Long, action: String, requestCodeOffset: Int): PendingIntent {

--- a/app/src/main/java/com/alexsiri7/unreminder/service/notification/NotificationHelper.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/notification/NotificationHelper.kt
@@ -22,6 +22,9 @@ class NotificationHelper @Inject constructor(
         const val ACTION_COMPLETED_FULL = "COMPLETED_FULL"
         const val ACTION_COMPLETED_LOW_FLOOR = "COMPLETED_LOW_FLOOR"
         const val ACTION_DISMISSED = "DISMISSED"
+        const val CHANNEL_ID_SYSTEM = "un_reminder_system"
+        const val CHANNEL_NAME_SYSTEM = "Habit Status"
+        const val NOTIFICATION_ID_PAUSED_BASE = 900_000
     }
 
     fun createNotificationChannel() {
@@ -34,6 +37,17 @@ class NotificationHelper @Inject constructor(
         }
         val manager = context.getSystemService(NotificationManager::class.java)
         manager.createNotificationChannel(channel)
+
+        val systemChannel = NotificationChannel(
+            CHANNEL_ID_SYSTEM,
+            CHANNEL_NAME_SYSTEM,
+            NotificationManager.IMPORTANCE_DEFAULT
+        ).apply {
+            description = "Habit lifecycle status updates"
+            setSound(null, null)
+            enableVibration(false)
+        }
+        manager.createNotificationChannel(systemChannel)
     }
 
     fun postTriggerNotification(triggerId: Long, promptText: String, habitName: String) {
@@ -55,6 +69,18 @@ class NotificationHelper @Inject constructor(
 
         val manager = context.getSystemService(NotificationManager::class.java)
         manager.notify(triggerId.toInt(), notification)
+    }
+
+    fun postHabitPausedNotification(habitId: Long, habitName: String) {
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID_SYSTEM)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle("Paused $habitName")
+            .setContentText("Rewrite its low-floor description to re-activate.")
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+            .build()
+        val manager = context.getSystemService(NotificationManager::class.java)
+        manager.notify((NOTIFICATION_ID_PAUSED_BASE + habitId).toInt(), notification)
     }
 
     private fun createActionIntent(triggerId: Long, action: String, requestCodeOffset: Int): PendingIntent {

--- a/app/src/main/java/com/alexsiri7/unreminder/service/trigger/DismissalTracker.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/trigger/DismissalTracker.kt
@@ -36,10 +36,18 @@ class DismissalTracker @Inject constructor(
         }
 
         val allDismissed = recent.all { it.status == TriggerStatus.DISMISSED }
-        if (!allDismissed) return
+        if (!allDismissed) {
+            Log.d(TAG, "Habit $habitId streak broken (not all of last $STREAK_THRESHOLD are DISMISSED), skipping")
+            return
+        }
 
         val habit = habitRepository.getByIdOnce(habitId) ?: run {
             Log.w(TAG, "Habit $habitId not found, cannot deactivate")
+            return
+        }
+
+        if (!habit.active) {
+            Log.d(TAG, "Habit $habitId is already paused, skipping")
             return
         }
 

--- a/app/src/main/java/com/alexsiri7/unreminder/service/trigger/DismissalTracker.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/trigger/DismissalTracker.kt
@@ -1,0 +1,50 @@
+package com.alexsiri7.unreminder.service.trigger
+
+import android.util.Log
+import com.alexsiri7.unreminder.data.repository.HabitRepository
+import com.alexsiri7.unreminder.data.repository.TriggerRepository
+import com.alexsiri7.unreminder.domain.model.TriggerStatus
+import com.alexsiri7.unreminder.service.notification.NotificationHelper
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DismissalTracker @Inject constructor(
+    private val triggerRepository: TriggerRepository,
+    private val habitRepository: HabitRepository,
+    private val notificationHelper: NotificationHelper
+) {
+    companion object {
+        private const val TAG = "DismissalTracker"
+        const val STREAK_THRESHOLD = 3
+    }
+
+    suspend fun onDismissed(triggerId: Long) {
+        val trigger = triggerRepository.getById(triggerId) ?: run {
+            Log.w(TAG, "Trigger $triggerId not found, skipping dismissal check")
+            return
+        }
+        val habitId = trigger.habitId ?: run {
+            Log.d(TAG, "Trigger $triggerId has no habitId, skipping dismissal check")
+            return
+        }
+
+        val recent = triggerRepository.getLastNForHabit(habitId, STREAK_THRESHOLD)
+        if (recent.size < STREAK_THRESHOLD) {
+            Log.d(TAG, "Habit $habitId has fewer than $STREAK_THRESHOLD recorded triggers, skipping")
+            return
+        }
+
+        val allDismissed = recent.all { it.status == TriggerStatus.DISMISSED }
+        if (!allDismissed) return
+
+        val habit = habitRepository.getByIdOnce(habitId) ?: run {
+            Log.w(TAG, "Habit $habitId not found, cannot deactivate")
+            return
+        }
+
+        Log.i(TAG, "Habit ${habit.name} has $STREAK_THRESHOLD consecutive DISMISSEDs — pausing")
+        habitRepository.update(habit.copy(active = false))
+        notificationHelper.postHabitPausedNotification(habitId, habit.name)
+    }
+}

--- a/app/src/test/java/com/alexsiri7/unreminder/data/repository/HabitRepositoryTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/data/repository/HabitRepositoryTest.kt
@@ -32,6 +32,15 @@ class HabitRepositoryTest {
     }
 
     @Test
+    fun `getByIdOnce delegates to dao with correct id`() = runTest {
+        coEvery { habitDao.getByIdOnce(5L) } returns null
+
+        repo.getByIdOnce(5L)
+
+        coVerify { habitDao.getByIdOnce(5L) }
+    }
+
+    @Test
     fun `getEligibleHabits with non-empty set passes ids directly`() = runTest {
         coEvery { habitDao.getEligibleHabits(listOf(1L, 2L), any()) } returns emptyList()
 

--- a/app/src/test/java/com/alexsiri7/unreminder/service/trigger/DismissalTrackerTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/service/trigger/DismissalTrackerTest.kt
@@ -115,6 +115,19 @@ class DismissalTrackerTest {
     }
 
     @Test
+    fun `3 consecutive dismissals but habit already paused - no notification`() = runTest {
+        coEvery { triggerRepository.getById(triggerId) } returns makeTrigger(TriggerStatus.DISMISSED)
+        coEvery { triggerRepository.getLastNForHabit(habitId, 3) } returns
+            listOf(makeDismissedTrigger(42), makeDismissedTrigger(41), makeDismissedTrigger(40))
+        coEvery { habitRepository.getByIdOnce(habitId) } returns testHabit.copy(active = false)
+
+        tracker.onDismissed(triggerId)
+
+        coVerify(exactly = 0) { habitRepository.update(any()) }
+        coVerify(exactly = 0) { notificationHelper.postHabitPausedNotification(any(), any()) }
+    }
+
+    @Test
     fun `3 consecutive dismissals but habit not found - no crash`() = runTest {
         coEvery { triggerRepository.getById(triggerId) } returns makeTrigger(TriggerStatus.DISMISSED)
         coEvery { triggerRepository.getLastNForHabit(habitId, 3) } returns

--- a/app/src/test/java/com/alexsiri7/unreminder/service/trigger/DismissalTrackerTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/service/trigger/DismissalTrackerTest.kt
@@ -1,0 +1,129 @@
+package com.alexsiri7.unreminder.service.trigger
+
+import com.alexsiri7.unreminder.data.db.HabitEntity
+import com.alexsiri7.unreminder.data.db.TriggerEntity
+import com.alexsiri7.unreminder.data.repository.HabitRepository
+import com.alexsiri7.unreminder.data.repository.TriggerRepository
+import com.alexsiri7.unreminder.domain.model.TriggerStatus
+import com.alexsiri7.unreminder.service.notification.NotificationHelper
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.time.Instant
+
+class DismissalTrackerTest {
+
+    private lateinit var triggerRepository: TriggerRepository
+    private lateinit var habitRepository: HabitRepository
+    private lateinit var notificationHelper: NotificationHelper
+    private lateinit var tracker: DismissalTracker
+
+    private val habitId = 5L
+    private val triggerId = 42L
+
+    private fun makeTrigger(status: TriggerStatus, hId: Long? = habitId) = TriggerEntity(
+        id = triggerId,
+        scheduledAt = Instant.now(),
+        firedAt = Instant.now(),
+        status = status,
+        habitId = hId
+    )
+
+    private fun makeDismissedTrigger(id: Long = triggerId) = TriggerEntity(
+        id = id,
+        scheduledAt = Instant.now(),
+        firedAt = Instant.now(),
+        status = TriggerStatus.DISMISSED,
+        habitId = habitId
+    )
+
+    private val testHabit = HabitEntity(
+        id = habitId,
+        name = "meditation",
+        fullDescription = "20-minute session",
+        lowFloorDescription = "3 deep breaths",
+        active = true,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now()
+    )
+
+    @Before
+    fun setup() {
+        triggerRepository = mockk(relaxUnitFun = true)
+        habitRepository = mockk(relaxUnitFun = true)
+        notificationHelper = mockk(relaxUnitFun = true)
+        tracker = DismissalTracker(triggerRepository, habitRepository, notificationHelper)
+    }
+
+    @Test
+    fun `trigger not found - skips check`() = runTest {
+        coEvery { triggerRepository.getById(triggerId) } returns null
+
+        tracker.onDismissed(triggerId)
+
+        coVerify(exactly = 0) { triggerRepository.getLastNForHabit(any(), any()) }
+    }
+
+    @Test
+    fun `trigger has no habitId - skips check`() = runTest {
+        coEvery { triggerRepository.getById(triggerId) } returns makeTrigger(TriggerStatus.DISMISSED, hId = null)
+
+        tracker.onDismissed(triggerId)
+
+        coVerify(exactly = 0) { triggerRepository.getLastNForHabit(any(), any()) }
+    }
+
+    @Test
+    fun `fewer than 3 triggers - no deactivation`() = runTest {
+        coEvery { triggerRepository.getById(triggerId) } returns makeTrigger(TriggerStatus.DISMISSED)
+        coEvery { triggerRepository.getLastNForHabit(habitId, 3) } returns
+            listOf(makeDismissedTrigger(42), makeDismissedTrigger(41))
+
+        tracker.onDismissed(triggerId)
+
+        coVerify(exactly = 0) { habitRepository.update(any()) }
+    }
+
+    @Test
+    fun `3 triggers but not all dismissed - no deactivation`() = runTest {
+        coEvery { triggerRepository.getById(triggerId) } returns makeTrigger(TriggerStatus.DISMISSED)
+        coEvery { triggerRepository.getLastNForHabit(habitId, 3) } returns listOf(
+            makeDismissedTrigger(42),
+            TriggerEntity(id = 41, scheduledAt = Instant.now(), firedAt = Instant.now(), status = TriggerStatus.COMPLETED_FULL, habitId = habitId),
+            makeDismissedTrigger(40)
+        )
+
+        tracker.onDismissed(triggerId)
+
+        coVerify(exactly = 0) { habitRepository.update(any()) }
+    }
+
+    @Test
+    fun `3 consecutive dismissals - habit deactivated and notification posted`() = runTest {
+        coEvery { triggerRepository.getById(triggerId) } returns makeTrigger(TriggerStatus.DISMISSED)
+        coEvery { triggerRepository.getLastNForHabit(habitId, 3) } returns
+            listOf(makeDismissedTrigger(42), makeDismissedTrigger(41), makeDismissedTrigger(40))
+        coEvery { habitRepository.getByIdOnce(habitId) } returns testHabit
+
+        tracker.onDismissed(triggerId)
+
+        coVerify { habitRepository.update(match { !it.active }) }
+        coVerify { notificationHelper.postHabitPausedNotification(habitId, "meditation") }
+    }
+
+    @Test
+    fun `3 consecutive dismissals but habit not found - no crash`() = runTest {
+        coEvery { triggerRepository.getById(triggerId) } returns makeTrigger(TriggerStatus.DISMISSED)
+        coEvery { triggerRepository.getLastNForHabit(habitId, 3) } returns
+            listOf(makeDismissedTrigger(42), makeDismissedTrigger(41), makeDismissedTrigger(40))
+        coEvery { habitRepository.getByIdOnce(habitId) } returns null
+
+        tracker.onDismissed(triggerId)
+
+        coVerify(exactly = 0) { habitRepository.update(any()) }
+        coVerify(exactly = 0) { notificationHelper.postHabitPausedNotification(any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `getLastNForHabit` query to `TriggerDao` / `TriggerRepository` to fetch the N most recent fired triggers for a given habit
- Introduces `DismissalTracker` — a `@Singleton` Hilt service that detects 3 consecutive `DISMISSED` outcomes and deactivates the habit
- Wires `DismissalTracker` into `NotificationActionReceiver`: after persisting a `DISMISSED` status, calls `dismissalTracker.onDismissed(triggerId)`
- Adds a silent notification channel (`un_reminder_system`) and `postHabitPausedNotification()` in `NotificationHelper` so the user sees a tray card: _"Paused {habit}. Rewrite its low-floor description to re-activate."_
- Adds `HabitDao.getByIdOnce` (suspend variant) and exposes it via `HabitRepository` for use in coroutine contexts

## Changes

| File | Action |
|------|--------|
| `TriggerDao.kt` | +`getLastNForHabit` Room query |
| `HabitDao.kt` | +`getByIdOnce` suspend Room query |
| `TriggerRepository.kt` | +`getLastNForHabit` delegation |
| `HabitRepository.kt` | +`getByIdOnce` delegation |
| `NotificationHelper.kt` | +silent system channel + `postHabitPausedNotification()` |
| `NotificationActionReceiver.kt` | Inject `DismissalTracker`, call on DISMISSED |
| `DismissalTracker.kt` | **NEW** — 3-in-a-row detection logic |
| `DismissalTrackerTest.kt` | **NEW** — 6 unit test cases |

No database migration required — `getLastNForHabit` queries existing columns (`habit_id`, `fired_at`, `status`) present since migration 1→2.

## Validation

Local Gradle commands are blocked by a pre-existing environment issue (JDK 25.0.2 incompatible with the Kotlin DSL compiler in Gradle). This affects `main` equally and is unrelated to these changes.

All 8 files were reviewed manually against existing patterns:

| File | Static Review |
|------|--------------|
| `TriggerDao.kt` | ✅ Correct Room SQL, mirrors existing `getLastFiredForHabit` |
| `HabitDao.kt` | ✅ Standard suspend Room query, coexists with Flow variant |
| `TriggerRepository.kt` | ✅ Delegation matches existing style |
| `HabitRepository.kt` | ✅ Delegation matches existing style |
| `NotificationHelper.kt` | ✅ Channel + notification builder mirrors existing patterns |
| `DismissalTracker.kt` | ✅ Logic correct; mirrors `TriggerPipeline` structure |
| `NotificationActionReceiver.kt` | ✅ Called after `updateOutcome` so DISMISSED is already persisted when streak check runs |
| `DismissalTrackerTest.kt` | ✅ 6 cases: null trigger, null habitId, <3 triggers, mixed outcomes, happy path, missing habit |

CI will validate compilation, tests, and build on a compatible JDK environment.

## Out of scope

- Re-activation flow (user editing `lowFloorDescription` to set `active=true`)
- Configurable dismissal threshold (hardcoded at 3)
- Undo / snooze for auto-pause

Fixes #19