### PR TITLE
security: remove PAT from APK, route feedback through feedback worker

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,13 @@ android {
 
         buildConfigField(
             "String",
-            "GITHUB_FEEDBACK_TOKEN",
-            "\"${System.getenv("GITHUB_FEEDBACK_TOKEN") ?: project.findProperty("githubFeedbackToken") ?: ""}\""
+            "FEEDBACK_ENDPOINT_URL",
+            "\"${System.getenv("FEEDBACK_ENDPOINT_URL") ?: "https://feedback.alexsiri7.workers.dev/"}\""
+        )
+        buildConfigField(
+            "String",
+            "FEEDBACK_REPO",
+            "\"alexsiri7/un-reminder\""
         )
         buildConfigField("String", "SENTRY_DSN", "\"${System.getenv("SENTRY_DSN") ?: ""}\"")
 

--- a/app/src/main/java/com/alexsiri7/unreminder/service/github/GitHubApiService.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/github/GitHubApiService.kt
@@ -10,67 +10,58 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
 import java.io.File
-import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
+// Forwards feedback submissions to the feedback Cloudflare Worker, which
+// holds the GitHub PAT server-side and creates the issue on our behalf.
+// The app used to embed a PAT in BuildConfig — that was extractable from
+// the signed APK, so it was removed.
 @Singleton
 class GitHubApiService @Inject constructor(
     private val okHttpClient: OkHttpClient
 ) {
-    companion object {
-        private const val REPO = "alexsiri7/un-reminder"
-        private const val BRANCH = "main"
-        private const val SCREENSHOTS_PATH = "docs/feedback-screenshots"
-        private const val PAGES_BASE = "https://alexsiri7.github.io/un-reminder/feedback-screenshots"
-    }
+    suspend fun submit(
+        title: String,
+        body: String,
+        screenshotFile: File? = null,
+    ): Unit = withContext(Dispatchers.IO) {
+        val endpoint = BuildConfig.FEEDBACK_ENDPOINT_URL
+        if (endpoint.isBlank()) {
+            throw IllegalStateException("FEEDBACK_ENDPOINT_URL not configured")
+        }
 
-    suspend fun uploadImage(imageFile: File): String = withContext(Dispatchers.IO) {
-        val uuid = UUID.randomUUID().toString()
-        val fileName = "$uuid.png"
-        val base64Content = Base64.encodeToString(imageFile.readBytes(), Base64.NO_WRAP)
+        // Worker derives the issue title from the first line of message;
+        // prepend the title so the issue reads naturally.
+        val message = if (title.isNotBlank() && !body.startsWith(title)) {
+            "$title\n\n$body"
+        } else {
+            body
+        }
 
-        val json = JSONObject().apply {
-            put("message", "Add feedback screenshot $uuid")
-            put("content", base64Content)
-            put("branch", BRANCH)
+        val screenshotB64 = screenshotFile
+            ?.takeIf { it.exists() }
+            ?.let { Base64.encodeToString(it.readBytes(), Base64.NO_WRAP) }
+
+        val payload = JSONObject().apply {
+            put("repo", BuildConfig.FEEDBACK_REPO)
+            put("type", "other")
+            put("message", message)
+            if (screenshotB64 != null) put("screenshot", screenshotB64)
         }
 
         val request = Request.Builder()
-            .url("https://api.github.com/repos/$REPO/contents/$SCREENSHOTS_PATH/$fileName")
-            .addGitHubHeaders()
-            .put(json.toString().toRequestBody("application/json".toMediaType()))
+            .url(endpoint)
+            .addHeader("Accept", "application/json")
+            .post(payload.toString().toRequestBody("application/json".toMediaType()))
             .build()
 
         okHttpClient.newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
-                throw RuntimeException("Image upload failed: ${response.code} ${response.body?.string()}")
-            }
-        }
-        "$PAGES_BASE/$fileName"
-    }
-
-    suspend fun createIssue(title: String, body: String) = withContext(Dispatchers.IO) {
-        val json = JSONObject().apply {
-            put("title", title)
-            put("body", body)
-            put("labels", org.json.JSONArray().put("feedback"))
-        }
-
-        val request = Request.Builder()
-            .url("https://api.github.com/repos/$REPO/issues")
-            .addGitHubHeaders()
-            .post(json.toString().toRequestBody("application/json".toMediaType()))
-            .build()
-
-        okHttpClient.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) {
-                throw RuntimeException("Issue creation failed: ${response.code} ${response.body?.string()}")
+                throw RuntimeException(
+                    "Feedback submission failed: ${response.code} ${response.body?.string()}"
+                )
             }
         }
     }
-
-    private fun Request.Builder.addGitHubHeaders(): Request.Builder =
-        addHeader("Authorization", "Bearer ${BuildConfig.GITHUB_FEEDBACK_TOKEN}")
-            .addHeader("Accept", "application/vnd.github+json")
 }

--- a/app/src/main/java/com/alexsiri7/unreminder/ui/feedback/FeedbackViewModel.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/ui/feedback/FeedbackViewModel.kt
@@ -68,22 +68,20 @@ class FeedbackViewModel @Inject constructor(
                 val merged = mergeAnnotations(annotationBitmap)
                 val screenshotPath = merged?.let { saveToCacheDir(it) }
 
-                if (BuildConfig.GITHUB_FEEDBACK_TOKEN.isBlank()) {
+                if (BuildConfig.FEEDBACK_ENDPOINT_URL.isBlank()) {
                     _uiState.value = _uiState.value.copy(
                         isSubmitting = false,
-                        errorMessage = "Feedback token not configured — copy logs to clipboard instead."
+                        errorMessage = "Feedback endpoint not configured."
                     )
                     return@launch
                 }
 
                 try {
-                    val screenshotUrl = screenshotPath?.let { path ->
-                        gitHubApiService.uploadImage(File(path))
-                    }
                     val desc = _uiState.value.description
                     val title = desc.take(60).ifBlank { "Feedback from app" }
-                    val body = buildIssueBody(desc, screenshotUrl)
-                    gitHubApiService.createIssue(title, body)
+                    val body = buildIssueBody(desc)
+                    val screenshotFile = screenshotPath?.let { File(it) }
+                    gitHubApiService.submit(title, body, screenshotFile)
                     screenshotPath?.let { File(it).delete() }
                     _uiState.value = _uiState.value.copy(isSubmitting = false, submitted = true)
                 } catch (e: IOException) {
@@ -97,11 +95,10 @@ class FeedbackViewModel @Inject constructor(
                     )
                 } catch (e: Exception) {
                     if (e is CancellationException) throw e
-                    // Permanent failure (e.g. auth error) — do not queue; inform the user.
                     Log.e(TAG, "Direct submit failed (permanent)", e)
                     _uiState.value = _uiState.value.copy(
                         isSubmitting = false,
-                        errorMessage = "Submission failed — please check your feedback token."
+                        errorMessage = "Submission failed."
                     )
                 }
             } catch (e: Exception) {
@@ -131,10 +128,9 @@ class FeedbackViewModel @Inject constructor(
         return file.absolutePath
     }
 
-    private fun buildIssueBody(description: String, screenshotUrl: String?): String =
+    private fun buildIssueBody(description: String): String =
         buildString {
             if (description.isNotBlank()) appendLine(description).appendLine()
-            if (screenshotUrl != null) appendLine("![screenshot]($screenshotUrl)").appendLine()
             appendLine("---")
             appendLine("Device: ${Build.MANUFACTURER} ${Build.MODEL}")
             appendLine("Android: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")

--- a/app/src/main/java/com/alexsiri7/unreminder/worker/FeedbackUploadWorker.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/worker/FeedbackUploadWorker.kt
@@ -32,26 +32,24 @@ class FeedbackUploadWorker @AssistedInject constructor(
         val pending = feedbackRepository.getPending()
         if (pending.isEmpty()) return Result.success()
 
-        if (BuildConfig.GITHUB_FEEDBACK_TOKEN.isBlank()) return Result.failure()
+        if (BuildConfig.FEEDBACK_ENDPOINT_URL.isBlank()) return Result.failure()
 
         for (item in pending) {
             try {
-                val screenshotUrl = item.screenshotPath?.let { path ->
-                    val file = File(path)
-                    if (file.exists()) gitHubApiService.uploadImage(file) else null
-                }
-
                 val title = item.description.take(60).ifBlank { "Feedback from app" }
                 val body = buildString {
                     if (item.description.isNotBlank()) appendLine(item.description).appendLine()
-                    if (screenshotUrl != null) appendLine("![screenshot]($screenshotUrl)").appendLine()
                     appendLine("---")
                     appendLine("Device: ${Build.MANUFACTURER} ${Build.MODEL}")
                     appendLine("Android: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
                     appendLine("App: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
                 }
 
-                gitHubApiService.createIssue(title, body)
+                val screenshotFile = item.screenshotPath
+                    ?.let { File(it) }
+                    ?.takeIf { it.exists() }
+
+                gitHubApiService.submit(title, body, screenshotFile)
                 feedbackRepository.deleteById(item.id)
                 item.screenshotPath?.let { File(it).delete() }
             } catch (e: Exception) {

--- a/app/src/test/java/com/alexsiri7/unreminder/ui/feedback/FeedbackViewModelTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/ui/feedback/FeedbackViewModelTest.kt
@@ -34,7 +34,7 @@ class FeedbackViewModelTest {
     }
     @After fun tearDown() { Dispatchers.resetMain() }
 
-    @Test fun `submit sets errorMessage when token is blank`() = runTest {
+    @Test fun `submit sets errorMessage when endpoint URL is blank`() = runTest {
         viewModel.updateDescription("app crashed on tap")
         viewModel.submit(mockk(relaxed = true))
         advanceUntilIdle()
@@ -44,19 +44,19 @@ class FeedbackViewModelTest {
         assertNotNull(state.errorMessage)
     }
 
-    @Test fun `updateDescription updates description in state`() {
-        viewModel.updateDescription("some description")
-        assertEquals("some description", viewModel.uiState.value.description)
-    }
-
     @Test fun `clearError clears errorMessage in state`() = runTest {
-        // Trigger an error first via blank-token submit path
+        // Trigger an error first via blank-endpoint submit path
         viewModel.submit(mockk(relaxed = true))
         advanceUntilIdle()
         assertNotNull(viewModel.uiState.value.errorMessage)
 
         viewModel.clearError()
         assertNull(viewModel.uiState.value.errorMessage)
+    }
+
+    @Test fun `updateDescription updates description in state`() {
+        viewModel.updateDescription("some description")
+        assertEquals("some description", viewModel.uiState.value.description)
     }
 
     @Test fun `setScreenshot updates screenshotBitmap in state`() {

--- a/app/src/test/java/com/alexsiri7/unreminder/ui/feedback/FeedbackViewModelTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/ui/feedback/FeedbackViewModelTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import com.alexsiri7.unreminder.data.repository.FeedbackRepository
 import com.alexsiri7.unreminder.service.github.GitHubApiService
+import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -34,7 +35,8 @@ class FeedbackViewModelTest {
     }
     @After fun tearDown() { Dispatchers.resetMain() }
 
-    @Test fun `submit sets errorMessage when endpoint URL is blank`() = runTest {
+    @Test fun `submit sets errorMessage when submission throws`() = runTest {
+        coEvery { mockGitHubApiService.submit(any(), any(), any()) } throws RuntimeException("boom")
         viewModel.updateDescription("app crashed on tap")
         viewModel.submit(mockk(relaxed = true))
         advanceUntilIdle()
@@ -45,7 +47,7 @@ class FeedbackViewModelTest {
     }
 
     @Test fun `clearError clears errorMessage in state`() = runTest {
-        // Trigger an error first via blank-endpoint submit path
+        coEvery { mockGitHubApiService.submit(any(), any(), any()) } throws RuntimeException("boom")
         viewModel.submit(mockk(relaxed = true))
         advanceUntilIdle()
         assertNotNull(viewModel.uiState.value.errorMessage)

--- a/app/src/test/java/com/alexsiri7/unreminder/worker/FeedbackUploadWorkerTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/worker/FeedbackUploadWorkerTest.kt
@@ -6,11 +6,11 @@ import androidx.work.WorkerParameters
 import com.alexsiri7.unreminder.data.db.PendingFeedbackEntity
 import com.alexsiri7.unreminder.data.repository.FeedbackRepository
 import com.alexsiri7.unreminder.service.github.GitHubApiService
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.Runs
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -44,10 +44,7 @@ class FeedbackUploadWorkerTest {
         assertEquals(Result.success(), result)
     }
 
-    @Test fun `doWork returns failure when endpoint URL is blank`() = runTest {
-        // Under unitTests.isReturnDefaultValues = true, BuildConfig fields
-        // are empty strings, so the endpoint guard fires and doWork returns
-        // failure without calling the service.
+    @Test fun `doWork submits queued item and deletes on success`() = runTest {
         val item = PendingFeedbackEntity(
             id = 1L,
             screenshotPath = null,
@@ -59,11 +56,12 @@ class FeedbackUploadWorkerTest {
 
         val result = worker.doWork()
 
-        assertEquals(Result.failure(), result)
-        coVerify(exactly = 0) { mockGitHubApiService.submit(any(), any(), any()) }
+        assertEquals(Result.success(), result)
+        coVerify(exactly = 1) { mockGitHubApiService.submit(any(), any(), any()) }
+        coVerify(exactly = 1) { mockRepository.deleteById(1L) }
     }
 
-    @Test fun `doWork returns failure when the endpoint guard prevents IO attempts`() = runTest {
+    @Test fun `doWork returns retry on IOException`() = runTest {
         val item = PendingFeedbackEntity(
             id = 2L,
             screenshotPath = null,
@@ -73,9 +71,26 @@ class FeedbackUploadWorkerTest {
         coEvery { mockRepository.getPending() } returns listOf(item)
         coEvery { mockGitHubApiService.submit(any(), any(), any()) } throws IOException("network unreachable")
 
-        // Guard fires before any submit attempt, so we never reach the IOException path.
         val result = worker.doWork()
+
+        assertEquals(Result.retry(), result)
+        coVerify(exactly = 0) { mockRepository.deleteById(any()) }
+    }
+
+    @Test fun `doWork returns failure on non-transient exception`() = runTest {
+        val item = PendingFeedbackEntity(
+            id = 3L,
+            screenshotPath = null,
+            description = "weird failure",
+            queuedAt = Instant.now()
+        )
+        coEvery { mockRepository.getPending() } returns listOf(item)
+        coEvery { mockGitHubApiService.submit(any(), any(), any()) } throws RuntimeException("400 bad request")
+
+        val result = worker.doWork()
+
         assertEquals(Result.failure(), result)
+        coVerify(exactly = 0) { mockRepository.deleteById(any()) }
     }
 
     @Test fun `WORK_NAME constant is defined`() {

--- a/app/src/test/java/com/alexsiri7/unreminder/worker/FeedbackUploadWorkerTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/worker/FeedbackUploadWorkerTest.kt
@@ -44,7 +44,10 @@ class FeedbackUploadWorkerTest {
         assertEquals(Result.success(), result)
     }
 
-    @Test fun `doWork calls deleteById after successful upload`() = runTest {
+    @Test fun `doWork returns failure when endpoint URL is blank`() = runTest {
+        // Under unitTests.isReturnDefaultValues = true, BuildConfig fields
+        // are empty strings, so the endpoint guard fires and doWork returns
+        // failure without calling the service.
         val item = PendingFeedbackEntity(
             id = 1L,
             screenshotPath = null,
@@ -52,18 +55,15 @@ class FeedbackUploadWorkerTest {
             queuedAt = Instant.now()
         )
         coEvery { mockRepository.getPending() } returns listOf(item)
-        coEvery { mockGitHubApiService.createIssue(any(), any()) } just Runs
+        coEvery { mockGitHubApiService.submit(any(), any(), any()) } just Runs
 
-        // Token is blank in tests so we get failure — this verifies the guard works.
-        // For the success path, coverage is ensured by FeedbackViewModelTest.
         val result = worker.doWork()
 
-        // With blank token the worker returns failure without calling the API
         assertEquals(Result.failure(), result)
-        coVerify(exactly = 0) { mockGitHubApiService.createIssue(any(), any()) }
+        coVerify(exactly = 0) { mockGitHubApiService.submit(any(), any(), any()) }
     }
 
-    @Test fun `doWork returns retry on IOException`() = runTest {
+    @Test fun `doWork returns failure when the endpoint guard prevents IO attempts`() = runTest {
         val item = PendingFeedbackEntity(
             id = 2L,
             screenshotPath = null,
@@ -71,10 +71,9 @@ class FeedbackUploadWorkerTest {
             queuedAt = Instant.now()
         )
         coEvery { mockRepository.getPending() } returns listOf(item)
-        coEvery { mockGitHubApiService.createIssue(any(), any()) } throws IOException("network unreachable")
+        coEvery { mockGitHubApiService.submit(any(), any(), any()) } throws IOException("network unreachable")
 
-        // Worker will hit token-blank guard and return failure without calling API,
-        // so we verify the IOException path indirectly by ensuring the guard is first.
+        // Guard fires before any submit attempt, so we never reach the IOException path.
         val result = worker.doWork()
         assertEquals(Result.failure(), result)
     }


### PR DESCRIPTION
## Summary
- Removes \`BuildConfig.GITHUB_FEEDBACK_TOKEN\` — anyone with the signed APK could extract the PAT and push to this repo.
- Feedback submissions now POST to the [feedback worker](https://github.com/alexsiri7/interstellarai.net/tree/main/workers/feedback) (\`feedback.alexsiri7.workers.dev\`), which holds the PAT server-side.
- Screenshot is sent as base64 in the same request; the worker uses GitHub's issue-attachment endpoint (needs only \`issues:write\`), not the Contents API.
- Adds \`BuildConfig.FEEDBACK_ENDPOINT_URL\` (default: the workers.dev URL, overridable via env var) and \`BuildConfig.FEEDBACK_REPO\`.

## Verification

Smoke-tested the deployed worker end-to-end: submitting via curl created real issue #38 (now closed), confirming the PAT, allowlist, and issue-creation path work.

## Test plan
- [ ] CI green.
- [ ] After merge, trigger feedback from the app (Settings → Send Feedback or FAB on Recent Triggers). A new issue appears on this repo with the screenshot attached.
- [ ] Offline submit queues locally and replays on reconnect (existing \`FeedbackUploadWorker\` path, now hitting the worker instead of GitHub directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)