### PR TITLE
fix: disable Sentry auto-init providers (app crashes when DSN empty)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,19 @@
                 tools:node="remove" />
         </provider>
 
+        <!-- Sentry auto-init requires a DSN in meta-data; we init manually in
+             UnReminderApp so the app can run without a DSN (local/dev builds,
+             or release builds where the SENTRY_DSN secret isn't wired). -->
+        <provider
+            android:name="io.sentry.android.core.SentryInitProvider"
+            android:authorities="${applicationId}.SentryInitProvider"
+            tools:node="remove" />
+
+        <provider
+            android:name="io.sentry.android.core.SentryPerformanceProvider"
+            android:authorities="${applicationId}.SentryPerformanceProvider"
+            tools:node="remove" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Summary

The installed APK (\`main-e91fc0f\`) crashes on launch with:

\`\`\`
FATAL EXCEPTION: main
Caused by: java.lang.IllegalArgumentException: DSN is required.
  at io.sentry.Sentry.initConfigurations
  at io.sentry.android.core.SentryInitProvider.onCreate
\`\`\`

Root cause: Sentry's SDK registers \`SentryInitProvider\` + \`SentryPerformanceProvider\` as ContentProviders. Android starts all ContentProviders before \`Application.onCreate()\`, so the auto-init runs first. With no DSN in manifest meta-data, it throws.

\`UnReminderApp.onCreate()\` already does a guarded manual init. Disable the auto-init providers with \`tools:node="remove"\` so manual init is the only path.

Regression from #28.

## Test plan
- [ ] Merge → signed APK builds.
- [ ] Install on device — app launches without crashing.
- [ ] With SENTRY_DSN secret wired (already the case), crash events still reach Sentry via manual init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)