### PR TITLE
feat: wire Sentry Gradle plugin for source context upload + launch smoke-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: ./gradlew assembleRelease --stacktrace
 
       - name: Upload signed release APK

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.sentry)
 }
 
 android {
@@ -80,6 +81,17 @@ android {
     testOptions {
         unitTests.isReturnDefaultValues = true
     }
+}
+
+sentry {
+    autoInstallation { enabled.set(false) }
+    org.set("alex-siri")
+    projectName.set("un-reminder")
+    includeProguardMapping.set(false)
+    includeSourceContext.set(true)
+    autoUploadProguardMapping.set(false)
+    autoUploadSourceContext.set(!System.getenv("SENTRY_AUTH_TOKEN").isNullOrBlank())
+    uploadNativeSymbols.set(false)
 }
 
 dependencies {

--- a/app/src/main/java/com/alexsiri7/unreminder/UnReminderApp.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/UnReminderApp.kt
@@ -9,6 +9,7 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.alexsiri7.unreminder.service.llm.PromptGenerator
 import com.alexsiri7.unreminder.service.notification.NotificationHelper
+import com.alexsiri7.unreminder.service.sentry.LaunchSmokeTest
 import com.alexsiri7.unreminder.service.sentry.applyOptions
 import com.alexsiri7.unreminder.service.sentry.shouldInitSentry
 import com.alexsiri7.unreminder.worker.DailySchedulerWorker
@@ -62,6 +63,11 @@ class UnReminderApp : Application(), Configuration.Provider {
                     versionCode = BuildConfig.VERSION_CODE
                 )
             }
+            LaunchSmokeTest.maybeFire(
+                context = this,
+                versionName = BuildConfig.VERSION_NAME,
+                versionCode = BuildConfig.VERSION_CODE
+            )
         } catch (e: Throwable) {
             Log.w(TAG, "Sentry init failed", e)
         }

--- a/app/src/main/java/com/alexsiri7/unreminder/service/sentry/LaunchSmokeTest.kt
+++ b/app/src/main/java/com/alexsiri7/unreminder/service/sentry/LaunchSmokeTest.kt
@@ -1,0 +1,57 @@
+package com.alexsiri7.unreminder.service.sentry
+
+import android.content.Context
+import android.content.SharedPreferences
+import io.sentry.Sentry
+
+/**
+ * Fires a "launch-smoke" Sentry message once per install per versionCode.
+ *
+ * Purpose: give us a verifiable Sentry event on the first launch after install/upgrade so we
+ * can confirm the DSN, source-context upload, and release tag plumbing for each new APK.
+ * Subsequent launches on the same versionCode are no-ops so real users aren't spammed.
+ */
+object LaunchSmokeTest {
+
+    private const val PREFS_NAME = "sentry_launch_smoke"
+    private const val KEY_LAST_REPORTED_VERSION_CODE = "last_reported_version_code"
+    private const val UNSET = -1
+
+    /**
+     * Fires the smoke event for [versionCode] if not already reported. Uses [Sentry.captureMessage]
+     * by default; the [capture] and [store] parameters exist for dependency injection in tests.
+     *
+     * @return true if a message was fired, false if already reported for this versionCode.
+     */
+    fun maybeFire(
+        context: Context,
+        versionName: String,
+        versionCode: Int,
+        capture: (String) -> Unit = { Sentry.captureMessage(it) },
+        store: SmokeStore = SharedPrefsSmokeStore(context)
+    ): Boolean {
+        val last = store.lastReportedVersionCode()
+        if (last == versionCode) return false
+        capture("launch-smoke v$versionName+$versionCode")
+        store.setLastReportedVersionCode(versionCode)
+        return true
+    }
+
+    /** Pluggable storage surface so tests can avoid Android framework types. */
+    interface SmokeStore {
+        fun lastReportedVersionCode(): Int
+        fun setLastReportedVersionCode(value: Int)
+    }
+
+    private class SharedPrefsSmokeStore(context: Context) : SmokeStore {
+        private val prefs: SharedPreferences =
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+        override fun lastReportedVersionCode(): Int =
+            prefs.getInt(KEY_LAST_REPORTED_VERSION_CODE, UNSET)
+
+        override fun setLastReportedVersionCode(value: Int) {
+            prefs.edit().putInt(KEY_LAST_REPORTED_VERSION_CODE, value).apply()
+        }
+    }
+}

--- a/app/src/test/java/com/alexsiri7/unreminder/service/sentry/LaunchSmokeTestTest.kt
+++ b/app/src/test/java/com/alexsiri7/unreminder/service/sentry/LaunchSmokeTestTest.kt
@@ -1,0 +1,86 @@
+package com.alexsiri7.unreminder.service.sentry
+
+import android.content.Context
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LaunchSmokeTestTest {
+
+    /** In-memory fake implementation of SmokeStore for tests. */
+    private class FakeStore(initial: Int = -1) : LaunchSmokeTest.SmokeStore {
+        var stored: Int = initial
+        override fun lastReportedVersionCode(): Int = stored
+        override fun setLastReportedVersionCode(value: Int) {
+            stored = value
+        }
+    }
+
+    private val ctx: Context = mockk(relaxed = true)
+
+    @Test
+    fun `fires on first run for a versionCode`() {
+        val store = FakeStore(initial = -1)
+        val captured = mutableListOf<String>()
+
+        val fired = LaunchSmokeTest.maybeFire(
+            context = ctx,
+            versionName = "1.2.3",
+            versionCode = 42,
+            capture = { captured.add(it) },
+            store = store
+        )
+
+        assertTrue(fired)
+        assertEquals(listOf("launch-smoke v1.2.3+42"), captured)
+        assertEquals(42, store.stored)
+    }
+
+    @Test
+    fun `does not fire twice for the same versionCode`() {
+        val store = FakeStore(initial = -1)
+        val captured = mutableListOf<String>()
+
+        LaunchSmokeTest.maybeFire(ctx, "1.2.3", 42, { captured.add(it) }, store)
+        val secondFired = LaunchSmokeTest.maybeFire(ctx, "1.2.3", 42, { captured.add(it) }, store)
+
+        assertFalse(secondFired)
+        assertEquals(1, captured.size)
+    }
+
+    @Test
+    fun `fires again after versionCode bumps`() {
+        val store = FakeStore(initial = -1)
+        val captured = mutableListOf<String>()
+
+        LaunchSmokeTest.maybeFire(ctx, "1.0.0", 1, { captured.add(it) }, store)
+        LaunchSmokeTest.maybeFire(ctx, "1.0.0", 1, { captured.add(it) }, store)
+        val upgradeFired = LaunchSmokeTest.maybeFire(ctx, "1.0.1", 2, { captured.add(it) }, store)
+
+        assertTrue(upgradeFired)
+        assertEquals(
+            listOf("launch-smoke v1.0.0+1", "launch-smoke v1.0.1+2"),
+            captured
+        )
+        assertEquals(2, store.stored)
+    }
+
+    @Test
+    fun `does not fire when store already has matching versionCode`() {
+        val store = FakeStore(initial = 7)
+        val captured = mutableListOf<String>()
+
+        val fired = LaunchSmokeTest.maybeFire(
+            context = ctx,
+            versionName = "2.0.0",
+            versionCode = 7,
+            capture = { captured.add(it) },
+            store = store
+        )
+
+        assertFalse(fired)
+        assertTrue(captured.isEmpty())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ mockk = "1.13.13"
 coroutinesTest = "1.9.0"
 osmdroid = "6.1.20"
 sentry = "7.14.0"
+sentryGradle = "4.14.1"
 datastore = "1.1.1"
 okhttp = "4.12.0"
 
@@ -64,3 +65,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+sentry = { id = "io.sentry.android.gradle", version.ref = "sentryGradle" }


### PR DESCRIPTION
## Summary
- Apply `io.sentry.android.gradle` (4.14.1) so release builds upload source context to Sentry — stack traces will show actual source lines. Mapping upload is disabled (app has `isMinifyEnabled = false`). Source context upload only runs when `SENTRY_AUTH_TOKEN` is present (CI only).
- Add a `LaunchSmokeTest` that fires `launch-smoke v<name>+<code>` to Sentry once per install per versionCode, persisted in SharedPreferences. Lets us verify the DSN, release tag, and source-context plumbing on each new APK without spamming users on every launch.
- CI: add `SENTRY_AUTH_TOKEN` secret to the `assembleRelease` step's env so the plugin can upload source bundles.

## Test plan
- [x] `./gradlew lint test --stacktrace` passes locally (JDK 17)
- [x] `./gradlew assembleDebug --stacktrace` succeeds locally
- [x] Unit tests for `LaunchSmokeTest` cover: first-fire, no-double-fire, refire-on-version-bump, no-fire-when-already-stored
- [ ] CI green on this PR
- [ ] After merge, install the resulting signed APK on device and confirm `launch-smoke` event appears in Sentry with source context

🤖 Generated with [Claude Code](https://claude.com/claude-code)