### PR TITLE
fix: pass SENTRY_AUTH_TOKEN to release.yml build steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: ./gradlew bundleRelease --stacktrace
 
       - name: Build signed universal APK (for sideload)
@@ -74,6 +75,7 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: ./gradlew assembleRelease --stacktrace
 
       - name: Upload AAB artifact


### PR DESCRIPTION
## Summary
- PR #52 wired up the Sentry Gradle plugin and added `SENTRY_AUTH_TOKEN` to `ci.yml`'s `assembleRelease` step, but the separate `release.yml` workflow (which runs on main pushes and tag pushes) was not updated, so the post-merge Release run failed with `error: Auth token is required for this request` in `:app:sentryBundleSourcesRelease`.
- This adds `SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}` to both the `Build signed AAB` and `Build signed universal APK (for sideload)` steps in `release.yml` so the Sentry plugin can bundle and upload source context.

## Test plan
- [ ] CI workflow stays green on this PR
- [ ] Post-merge Release workflow on main succeeds and produces AAB + APK artifacts
- [ ] Source bundle visible in Sentry for the next commit's release tag

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>