### PR TITLE
fix: wire MODEL_CDN_URL through CI + fail loudly when placeholder is baked in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          MODEL_CDN_URL: ${{ secrets.MODEL_CDN_URL }}
         run: ./gradlew assembleRelease --stacktrace
 
       - name: Upload signed release APK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          MODEL_CDN_URL: ${{ secrets.MODEL_CDN_URL }}
         run: ./gradlew bundleRelease --stacktrace
 
       - name: Build signed universal APK (for sideload)
@@ -76,6 +77,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          MODEL_CDN_URL: ${{ secrets.MODEL_CDN_URL }}
         run: ./gradlew assembleRelease --stacktrace
 
       - name: Upload AAB artifact

--- a/app/src/main/java/net/interstellarai/unreminder/di/ServiceModule.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/di/ServiceModule.kt
@@ -1,6 +1,7 @@
 package net.interstellarai.unreminder.di
 
 import android.content.Context
+import net.interstellarai.unreminder.BuildConfig
 import net.interstellarai.unreminder.data.repository.LocationRepository
 import net.interstellarai.unreminder.service.alarm.AlarmScheduler
 import net.interstellarai.unreminder.service.geofence.GeofenceManager
@@ -14,6 +15,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -47,4 +49,8 @@ object ServiceModule {
     @Singleton
     fun providePromptGenerator(@ApplicationContext context: Context): PromptGenerator =
         PromptGeneratorImpl(context)
+
+    @Provides
+    @Named("modelCdnUrl")
+    fun provideModelCdnUrl(): String = BuildConfig.MODEL_CDN_URL
 }

--- a/app/src/main/java/net/interstellarai/unreminder/service/llm/ModelConfig.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/llm/ModelConfig.kt
@@ -1,0 +1,22 @@
+package net.interstellarai.unreminder.service.llm
+
+/**
+ * Model-download configuration helpers.
+ *
+ * The on-device LLM model is downloaded on first launch from a CDN URL baked into
+ * the APK at build time via `BuildConfig.MODEL_CDN_URL`. When CI is missing the
+ * `MODEL_CDN_URL` secret, the build falls back to a placeholder host that will
+ * never resolve — this helper lets callers detect that misconfiguration and fail
+ * loudly instead of silently attempting a download that can never succeed.
+ */
+object ModelConfig {
+    /** Matches the fallback in `app/build.gradle.kts` when `MODEL_CDN_URL` is unset. */
+    const val PLACEHOLDER_URL = "https://placeholder.invalid/model.task"
+
+    /**
+     * @return true when [url] is blank or equals the build-time placeholder, indicating
+     * that no real model URL was wired through CI and AI features cannot work.
+     */
+    fun isPlaceholderUrl(url: String?): Boolean =
+        url.isNullOrBlank() || url == PLACEHOLDER_URL
+}

--- a/app/src/main/java/net/interstellarai/unreminder/service/llm/PromptGeneratorImpl.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/llm/PromptGeneratorImpl.kt
@@ -7,14 +7,17 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
+import net.interstellarai.unreminder.BuildConfig
 import net.interstellarai.unreminder.data.db.HabitEntity
 import net.interstellarai.unreminder.domain.model.AiHabitFields
+import net.interstellarai.unreminder.service.llm.ModelConfig
 import net.interstellarai.unreminder.worker.ModelDownloadWorker
 import com.google.ai.edge.litertlm.Content
 import com.google.ai.edge.litertlm.ConversationConfig
 import com.google.ai.edge.litertlm.Engine
 import com.google.ai.edge.litertlm.EngineConfig
 import io.sentry.Sentry
+import io.sentry.SentryLevel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -34,6 +37,22 @@ class PromptGeneratorImpl(private val context: Context) : PromptGenerator {
     val downloadProgress: StateFlow<Float?> = _downloadProgress.asStateFlow()
 
     override suspend fun initialize() {
+        if (ModelConfig.isPlaceholderUrl(BuildConfig.MODEL_CDN_URL)) {
+            // Build misconfiguration: the MODEL_CDN_URL env var was not supplied at build time,
+            // so the APK was built with the "https://placeholder.invalid/model.task" default.
+            // Any download attempt would fail with UnknownHostException and AI features would
+            // silently do nothing. Log, flag to Sentry, and skip enqueueing the download.
+            Log.w(
+                TAG,
+                "MODEL_CDN_URL is a placeholder (${BuildConfig.MODEL_CDN_URL}) — " +
+                    "AI features disabled. Set the MODEL_CDN_URL secret in CI to fix."
+            )
+            Sentry.captureMessage(
+                "MODEL_CDN_URL is a placeholder — AI features disabled",
+                SentryLevel.WARNING
+            ) { scope -> scope.setTag("component", "litert-lm-init") }
+            return
+        }
         val modelFile = File(context.filesDir, ModelDownloadWorker.MODEL_FILENAME)
         if (!modelFile.exists()) {
             try {

--- a/app/src/main/java/net/interstellarai/unreminder/worker/ModelDownloadWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/worker/ModelDownloadWorker.kt
@@ -6,26 +6,27 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
-import net.interstellarai.unreminder.BuildConfig
+import net.interstellarai.unreminder.service.llm.ModelConfig
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CancellationException
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
+import javax.inject.Named
 
 @HiltWorker
 class ModelDownloadWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
-    private val okHttpClient: OkHttpClient
+    private val okHttpClient: OkHttpClient,
+    @Named("modelCdnUrl") private val modelUrl: String
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
         const val WORK_NAME = "model_download"
         const val KEY_PROGRESS = "progress"
         const val MODEL_FILENAME = "gemma3-1b-it-int4.task"
-        private const val MODEL_URL = BuildConfig.MODEL_CDN_URL
         private const val TAG = "ModelDownloadWorker"
     }
 
@@ -33,9 +34,18 @@ class ModelDownloadWorker @AssistedInject constructor(
         val modelFile = File(applicationContext.filesDir, MODEL_FILENAME)
         if (modelFile.exists()) return Result.success()
 
+        if (ModelConfig.isPlaceholderUrl(modelUrl)) {
+            Log.w(
+                TAG,
+                "MODEL_CDN_URL is a placeholder ($modelUrl) — skipping download. " +
+                    "Set the MODEL_CDN_URL secret in CI."
+            )
+            return Result.failure()
+        }
+
         val tmpFile = File(applicationContext.filesDir, "$MODEL_FILENAME.tmp")
         return try {
-            val request = Request.Builder().url(MODEL_URL).build()
+            val request = Request.Builder().url(modelUrl).build()
             okHttpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
                     Log.w(TAG, "Download failed: HTTP ${response.code}")

--- a/app/src/test/java/net/interstellarai/unreminder/service/llm/ModelConfigTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/llm/ModelConfigTest.kt
@@ -1,0 +1,36 @@
+package net.interstellarai.unreminder.service.llm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ModelConfigTest {
+
+    @Test
+    fun `PLACEHOLDER_URL matches build gradle fallback`() {
+        // Must stay in sync with the `?:` fallback in app/build.gradle.kts.
+        assertEquals("https://placeholder.invalid/model.task", ModelConfig.PLACEHOLDER_URL)
+    }
+
+    @Test
+    fun `isPlaceholderUrl returns true for placeholder`() {
+        assertTrue(ModelConfig.isPlaceholderUrl("https://placeholder.invalid/model.task"))
+    }
+
+    @Test
+    fun `isPlaceholderUrl returns true for null`() {
+        assertTrue(ModelConfig.isPlaceholderUrl(null))
+    }
+
+    @Test
+    fun `isPlaceholderUrl returns true for blank`() {
+        assertTrue(ModelConfig.isPlaceholderUrl(""))
+        assertTrue(ModelConfig.isPlaceholderUrl("   "))
+    }
+
+    @Test
+    fun `isPlaceholderUrl returns false for a real URL`() {
+        assertFalse(ModelConfig.isPlaceholderUrl("https://cdn.example.com/gemma3-1b-it-int4.task"))
+    }
+}

--- a/app/src/test/java/net/interstellarai/unreminder/worker/ModelDownloadWorkerTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/worker/ModelDownloadWorkerTest.kt
@@ -11,6 +11,7 @@ import io.mockk.Runs
 import io.mockk.verify
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
+import net.interstellarai.unreminder.service.llm.ModelConfig
 import okhttp3.Call
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -30,6 +31,7 @@ class ModelDownloadWorkerTest {
     private val mockContext: Context = mockk(relaxed = true)
     private val mockWorkerParams: WorkerParameters = mockk(relaxed = true)
     private val mockOkHttpClient: OkHttpClient = mockk()
+    private val testModelUrl = "https://example.test/model.task"
 
     private lateinit var filesDir: File
     private lateinit var worker: ModelDownloadWorker
@@ -38,7 +40,7 @@ class ModelDownloadWorkerTest {
     fun setup() {
         filesDir = createTempDir()
         every { mockContext.filesDir } returns filesDir
-        worker = ModelDownloadWorker(mockContext, mockWorkerParams, mockOkHttpClient)
+        worker = ModelDownloadWorker(mockContext, mockWorkerParams, mockOkHttpClient, testModelUrl)
     }
 
     @After
@@ -174,5 +176,37 @@ class ModelDownloadWorkerTest {
     @Test
     fun `MODEL_FILENAME constant is defined`() {
         assertEquals("gemma3-1b-it-int4.task", ModelDownloadWorker.MODEL_FILENAME)
+    }
+
+    // --- placeholder URL guard ---
+
+    @Test
+    fun `doWork returns failure and skips network when URL is the placeholder`() = runTest {
+        val placeholderWorker = ModelDownloadWorker(
+            mockContext,
+            mockWorkerParams,
+            mockOkHttpClient,
+            ModelConfig.PLACEHOLDER_URL
+        )
+
+        val result = placeholderWorker.doWork()
+
+        assertEquals(Result.failure(), result)
+        verify { mockOkHttpClient wasNot Called }
+    }
+
+    @Test
+    fun `doWork returns failure and skips network when URL is blank`() = runTest {
+        val blankWorker = ModelDownloadWorker(
+            mockContext,
+            mockWorkerParams,
+            mockOkHttpClient,
+            ""
+        )
+
+        val result = blankWorker.doWork()
+
+        assertEquals(Result.failure(), result)
+        verify { mockOkHttpClient wasNot Called }
     }
 }


### PR DESCRIPTION
## Summary
- AI features on installed APKs have been silently doing nothing because CI builds bake the `https://placeholder.invalid/model.task` fallback into `BuildConfig.MODEL_CDN_URL` — the `MODEL_CDN_URL` env var was not passed to any gradle build step in `ci.yml` / `release.yml`, and the secret wasn't set either. `ModelDownloadWorker` then tries to download from the unresolvable placeholder on first launch, the `PromptGenerator` engine stays null, and every UI call either returns the fallback template or throws `IllegalStateException("LLM unavailable")` with no telemetry.
- Wire `MODEL_CDN_URL: ${{ secrets.MODEL_CDN_URL }}` into every `assembleRelease` / `bundleRelease` step so the secret (once set) reaches the build.
- Add `ModelConfig.isPlaceholderUrl(...)` as a single source of truth. `PromptGeneratorImpl.initialize()` now detects the placeholder at startup, logs a WARN, and fires `Sentry.captureMessage("MODEL_CDN_URL is a placeholder — AI features disabled", WARNING)` so the misconfig surfaces in the Sentry dashboard. `ModelDownloadWorker` also short-circuits to `Result.failure()` when the URL is the placeholder/blank (defence in depth, and no wasted WorkManager slots).
- The worker's URL is now injected via Hilt `@Named("modelCdnUrl")` so tests can pass real URLs independently of `BuildConfig` state.

## Maintainer action required
For AI features to actually work, set the secret in GitHub:

```
gh secret set MODEL_CDN_URL --repo alexsiri7/un-reminder --body '<https URL that serves gemma3-1b-it-int4.task>'
```

I couldn't find the canonical model host documented anywhere in the repo (no ADR, README "Build Configuration" only lists `KEYSTORE_*`, `GITHUB_FEEDBACK_TOKEN`, `SENTRY_DSN`). The model file the worker expects is `gemma3-1b-it-int4.task` (~530 MB int4 quant of Gemma 3 1B). Typical hosts for this kind of asset: Cloudflare R2, Google Cloud Storage bucket with public read, Hugging Face LFS, etc. Whichever one you're using — drop its HTTPS URL into the secret and the next release build will embed it. Builds without the secret still produce working APKs for everything except AI (no regression).

## Test plan
- [x] `./gradlew lint test assembleDebug` passes locally under Java 17 (`~/.sdkman/candidates/java/17.0.10-tem`).
- [x] New `ModelConfigTest` covers placeholder / blank / null / real URL cases.
- [x] New cases in `ModelDownloadWorkerTest` verify the worker returns `Result.failure()` and never touches OkHttp when the URL is the placeholder or blank.
- [x] Existing `PromptGeneratorTest` still passes — `initialize()` with the placeholder URL now returns early without touching WorkManager, and `downloadProgress.value` stays null as asserted.
- [ ] After merge: set the `MODEL_CDN_URL` secret, trigger a release build, install, and verify that tapping "Autofill with AI" in the habit editor produces a real AI-generated description (not the "AI unavailable" error banner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)