### PR TITLE
feat: surface model-download progress in UI

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/llm/PromptGenerator.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/llm/PromptGenerator.kt
@@ -2,10 +2,56 @@ package net.interstellarai.unreminder.service.llm
 
 import net.interstellarai.unreminder.data.db.HabitEntity
 import net.interstellarai.unreminder.domain.model.AiHabitFields
+import kotlinx.coroutines.flow.StateFlow
 
 interface PromptGenerator {
+    /**
+     * Fractional progress (0.0..1.0) of the on-device model download, or `null`
+     * when no download is in flight. UI layers observe this to show a banner /
+     * disable Autofill while the ~2 GB model is streaming down.
+     */
+    val downloadProgress: StateFlow<Float?>
+
+    /**
+     * Current high-level AI readiness — distinguishes "still downloading" from
+     * "built without a model URL" from "ready to generate". The habit editor
+     * uses this to pick the right Autofill-button helper copy.
+     */
+    val aiStatus: StateFlow<AiStatus>
+
     suspend fun initialize()
     suspend fun generate(habit: HabitEntity, locationName: String, timeOfDay: String): String
     suspend fun generateHabitFields(title: String): AiHabitFields
     suspend fun previewHabitNotification(habit: HabitEntity, locationName: String = "Anywhere"): String
+
+    /**
+     * Re-enqueue the model download worker (idempotent via unique work).
+     * Called from the "AI unavailable — tap to retry" banner action.
+     */
+    fun retryModelDownload()
+}
+
+/**
+ * Coarse readiness states surfaced to UI. `Downloading` carries the current
+ * fraction so callers that want a single StateFlow for the button state can
+ * read it here too; `downloadProgress` remains the canonical progress source.
+ */
+sealed interface AiStatus {
+    /** Build was shipped without a real MODEL_CDN_URL — AI permanently off. */
+    object Unavailable : AiStatus
+
+    /** Model not present and download is in flight. */
+    data class Downloading(val fraction: Float) : AiStatus
+
+    /** Model present, engine initialised — generation calls will work. */
+    object Ready : AiStatus
+
+    /**
+     * Model file present (or download reached SUCCEEDED) but engine init failed.
+     * User should see a retry-style affordance.
+     */
+    object Failed : AiStatus
+
+    /** Initial / not-yet-started state. */
+    object Idle : AiStatus
 }

--- a/app/src/main/java/net/interstellarai/unreminder/service/llm/PromptGeneratorImpl.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/llm/PromptGeneratorImpl.kt
@@ -6,11 +6,11 @@ import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import net.interstellarai.unreminder.BuildConfig
 import net.interstellarai.unreminder.data.db.HabitEntity
 import net.interstellarai.unreminder.domain.model.AiHabitFields
-import net.interstellarai.unreminder.service.llm.ModelConfig
 import net.interstellarai.unreminder.worker.ModelDownloadWorker
 import com.google.ai.edge.litertlm.Content
 import com.google.ai.edge.litertlm.ConversationConfig
@@ -19,13 +19,36 @@ import com.google.ai.edge.litertlm.EngineConfig
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import java.io.File
 
-class PromptGeneratorImpl(private val context: Context) : PromptGenerator {
+class PromptGeneratorImpl(
+    private val context: Context,
+    /**
+     * Supplier for the [WorkInfo] progress stream. Defaults to the real
+     * [WorkManager] unique-work flow; tests inject a fake to drive state
+     * transitions without needing a live WorkManager.
+     */
+    private val workInfoFlowProvider: () -> Flow<List<WorkInfo>> = {
+        WorkManager.getInstance(context)
+            .getWorkInfosForUniqueWorkFlow(ModelDownloadWorker.WORK_NAME)
+    },
+    /**
+     * Scope the progress collector runs in. Defaults to a long-lived
+     * application-scoped supervisor; tests pass a TestScope so collection
+     * can be driven and cancelled deterministically.
+     */
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+) : PromptGenerator {
 
     companion object {
         private const val TAG = "PromptGenerator"
@@ -34,7 +57,12 @@ class PromptGeneratorImpl(private val context: Context) : PromptGenerator {
     private var engine: Engine? = null
 
     private val _downloadProgress = MutableStateFlow<Float?>(null)
-    val downloadProgress: StateFlow<Float?> = _downloadProgress.asStateFlow()
+    override val downloadProgress: StateFlow<Float?> = _downloadProgress.asStateFlow()
+
+    private val _aiStatus = MutableStateFlow<AiStatus>(AiStatus.Idle)
+    override val aiStatus: StateFlow<AiStatus> = _aiStatus.asStateFlow()
+
+    private var progressCollectorJob: Job? = null
 
     override suspend fun initialize() {
         if (ModelConfig.isPlaceholderUrl(BuildConfig.MODEL_CDN_URL)) {
@@ -51,6 +79,7 @@ class PromptGeneratorImpl(private val context: Context) : PromptGenerator {
                 "MODEL_CDN_URL is a placeholder — AI features disabled",
                 SentryLevel.WARNING
             ) { scope -> scope.setTag("component", "litert-lm-init") }
+            _aiStatus.value = AiStatus.Unavailable
             return
         }
         val modelFile = File(context.filesDir, ModelDownloadWorker.MODEL_FILENAME)
@@ -61,9 +90,15 @@ class PromptGeneratorImpl(private val context: Context) : PromptGenerator {
             } catch (e: Throwable) {
                 Log.w(TAG, "WorkManager unavailable in this environment; model download skipped", e)
             }
-            // Model not yet available — initialize() completes with engine = null
+            // Model not yet available — initialize() completes with engine = null.
+            // The progress collector will re-trigger initializeEngineFromFile() on SUCCEEDED.
             return
         }
+        initializeEngineFromFile(modelFile)
+    }
+
+    private fun initializeEngineFromFile(modelFile: File) {
+        if (engine != null) return
         try {
             val config = EngineConfig(
                 modelPath = modelFile.absolutePath,
@@ -73,12 +108,15 @@ class PromptGeneratorImpl(private val context: Context) : PromptGenerator {
             e.initialize()
             engine = e
             _downloadProgress.value = null
+            _aiStatus.value = AiStatus.Ready
         } catch (e: Exception) {
             Log.w(TAG, "LiteRT-LM initialization failed; AI features will be unavailable", e)
             Sentry.captureException(e) { scope ->
                 scope.setTag("component", "litert-lm-init")
             }
             engine = null
+            _downloadProgress.value = null
+            _aiStatus.value = AiStatus.Failed
         }
     }
 
@@ -94,9 +132,112 @@ class PromptGeneratorImpl(private val context: Context) : PromptGenerator {
             .enqueueUniqueWork(ModelDownloadWorker.WORK_NAME, ExistingWorkPolicy.KEEP, request)
     }
 
-    private fun observeDownloadProgress() {
-        // TODO: observe WorkInfo flow and call initialize() on SUCCEEDED state so the
-        // engine activates without requiring an app restart (follow-up issue).
+    override fun retryModelDownload() {
+        if (ModelConfig.isPlaceholderUrl(BuildConfig.MODEL_CDN_URL)) {
+            Log.w(TAG, "retryModelDownload: placeholder URL — ignoring")
+            return
+        }
+        val modelFile = File(context.filesDir, ModelDownloadWorker.MODEL_FILENAME)
+        if (modelFile.exists()) {
+            // File already on disk — re-attempt engine init instead of re-downloading.
+            initializeEngineFromFile(modelFile)
+            return
+        }
+        try {
+            // REPLACE so a failed/cancelled prior run doesn't block the retry.
+            val request = OneTimeWorkRequestBuilder<ModelDownloadWorker>()
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                ModelDownloadWorker.WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                request,
+            )
+            observeDownloadProgress()
+        } catch (e: Throwable) {
+            Log.w(TAG, "retryModelDownload: WorkManager unavailable", e)
+        }
+    }
+
+    /**
+     * Wires WorkManager's per-worker progress + state stream into [_downloadProgress]
+     * and [_aiStatus]. Idempotent — if a collector is already running, does nothing.
+     *
+     * Progress key note: [ModelDownloadWorker] emits an Int percent (0..100) under
+     * [ModelDownloadWorker.KEY_PROGRESS], not a float fraction. We normalise to
+     * a 0.0..1.0 Float here so UI can drive [androidx.compose.material3.LinearProgressIndicator]
+     * directly.
+     */
+    internal fun observeDownloadProgress() {
+        val existing = progressCollectorJob
+        if (existing != null && existing.isActive) return
+        progressCollectorJob = scope.launch {
+            try {
+                workInfoFlowProvider().collect { infos ->
+                    // getWorkInfosForUniqueWorkFlow returns the list for this unique-work
+                    // name; under normal operation there is at most one active entry.
+                    val info = infos.firstOrNull() ?: return@collect
+                    when (info.state) {
+                        WorkInfo.State.RUNNING -> {
+                            val pct = info.progress.getInt(ModelDownloadWorker.KEY_PROGRESS, -1)
+                            if (pct in 0..100) {
+                                val fraction = pct / 100f
+                                _downloadProgress.value = fraction
+                                _aiStatus.value = AiStatus.Downloading(fraction)
+                            } else {
+                                // RUNNING but no progress datum yet (initial HTTP handshake);
+                                // show an indeterminate 0% so the banner can render.
+                                if (_downloadProgress.value == null) {
+                                    _downloadProgress.value = 0f
+                                    _aiStatus.value = AiStatus.Downloading(0f)
+                                }
+                            }
+                        }
+                        WorkInfo.State.ENQUEUED, WorkInfo.State.BLOCKED -> {
+                            // Not yet started (e.g. waiting for network). Keep banner hidden
+                            // unless we were already showing one.
+                            if (_downloadProgress.value == null) {
+                                _aiStatus.value = AiStatus.Downloading(0f)
+                                _downloadProgress.value = 0f
+                            }
+                        }
+                        WorkInfo.State.SUCCEEDED -> {
+                            _downloadProgress.value = null
+                            // Transition to engine init. initializeEngineFromFile guards
+                            // against double-init.
+                            val modelFile = File(
+                                context.filesDir,
+                                ModelDownloadWorker.MODEL_FILENAME,
+                            )
+                            if (modelFile.exists()) {
+                                initializeEngineFromFile(modelFile)
+                            } else {
+                                // Unusual: worker reported success but file is missing.
+                                Log.w(TAG, "Download SUCCEEDED but model file missing")
+                                _aiStatus.value = AiStatus.Failed
+                            }
+                        }
+                        WorkInfo.State.FAILED, WorkInfo.State.CANCELLED -> {
+                            Log.w(
+                                TAG,
+                                "Model download ${info.state} — AI remains unavailable " +
+                                    "(WorkManager's own retry policy applies for FAILED)",
+                            )
+                            _downloadProgress.value = null
+                            _aiStatus.value = AiStatus.Failed
+                        }
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                Log.w(TAG, "observeDownloadProgress: collector crashed", e)
+            }
+        }
     }
 
     override suspend fun generate(habit: HabitEntity, locationName: String, timeOfDay: String): String {

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import net.interstellarai.unreminder.service.llm.AiStatus
 import net.interstellarai.unreminder.ui.theme.Dimens
 import net.interstellarai.unreminder.ui.theme.DisplayLarge
 import net.interstellarai.unreminder.ui.theme.DisplayMedium
@@ -76,6 +77,8 @@ fun HabitEditScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val allLocations by viewModel.allLocations.collectAsStateWithLifecycle()
+    val downloadProgress by viewModel.downloadProgress.collectAsStateWithLifecycle()
+    val aiStatus by viewModel.aiStatus.collectAsStateWithLifecycle()
     val flashAlpha = remember { Animatable(0f) }
 
     LaunchedEffect(habitId) {
@@ -143,9 +146,22 @@ fun HabitEditScreen(
                 )
             }
 
+            val aiHelper: String? = when {
+                downloadProgress != null -> {
+                    val pct = ((downloadProgress ?: 0f).coerceIn(0f, 1f) * 100).toInt()
+                    "Model downloading… ${pct}%"
+                }
+                aiStatus is AiStatus.Unavailable -> "AI unavailable on this build"
+                aiStatus is AiStatus.Failed -> "AI unavailable on this build"
+                else -> null
+            }
             AiAssistStrip(
-                enabled = uiState.name.length >= 2 && !uiState.isGeneratingFields,
+                enabled = uiState.name.length >= 2 &&
+                    !uiState.isGeneratingFields &&
+                    downloadProgress == null &&
+                    aiStatus is AiStatus.Ready,
                 loading = uiState.isGeneratingFields,
+                helperText = aiHelper,
                 onAutofill = { viewModel.autofillWithAi() },
                 modifier = Modifier.padding(horizontal = Dimens.xl),
             )
@@ -308,47 +324,63 @@ private fun UnderlinedDisplayField(
 private fun AiAssistStrip(
     enabled: Boolean,
     loading: Boolean,
+    helperText: String?,
     onAutofill: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surfaceVariant, UnReminderShapes.small)
-            .padding(horizontal = Dimens.lg, vertical = Dimens.md + 2.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
-            MonoSectionLabel("gemma · on-device")
-            Spacer(Modifier.height(2.dp))
-            Text(
-                "Autofill descriptions",
-                style = SansBodyStrong,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        Box(
+    val buttonAlpha = if (enabled) 1f else 0.4f
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
             modifier = Modifier
-                .background(MaterialTheme.colorScheme.primary, UnReminderShapes.small)
-                .let {
-                    if (enabled) it.clickable(onClick = onAutofill) else it
-                }
-                .padding(horizontal = Dimens.md + 2.dp, vertical = Dimens.sm),
-            contentAlignment = Alignment.Center,
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant, UnReminderShapes.small)
+                .padding(horizontal = Dimens.lg, vertical = Dimens.md + 2.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            if (loading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(14.dp),
-                    strokeWidth = 2.dp,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                )
-            } else {
+            Column(modifier = Modifier.weight(1f)) {
+                MonoSectionLabel("gemma · on-device")
+                Spacer(Modifier.height(2.dp))
                 Text(
-                    "\u2726 autofill",
-                    style = MonoLabel.copy(fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold),
-                    color = MaterialTheme.colorScheme.onPrimary,
+                    "Autofill descriptions",
+                    style = SansBodyStrong,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+            Box(
+                modifier = Modifier
+                    .background(
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = buttonAlpha),
+                        shape = UnReminderShapes.small,
+                    )
+                    .let {
+                        if (enabled) it.clickable(onClick = onAutofill) else it
+                    }
+                    .padding(horizontal = Dimens.md + 2.dp, vertical = Dimens.sm),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (loading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(14.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Text(
+                        "\u2726 autofill",
+                        style = MonoLabel.copy(fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold),
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                }
+            }
+        }
+        if (helperText != null) {
+            Spacer(Modifier.height(Dimens.xs))
+            Text(
+                text = helperText,
+                style = MonoLabelTiny,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.55f),
+                modifier = Modifier.padding(start = Dimens.md + 2.dp),
+            )
         }
     }
 }

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
@@ -7,6 +7,7 @@ import net.interstellarai.unreminder.data.db.HabitEntity
 import net.interstellarai.unreminder.data.db.LocationEntity
 import net.interstellarai.unreminder.data.repository.HabitRepository
 import net.interstellarai.unreminder.data.repository.LocationRepository
+import net.interstellarai.unreminder.service.llm.AiStatus
 import net.interstellarai.unreminder.service.llm.PromptGenerator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.sentry.Sentry
@@ -47,6 +48,12 @@ class HabitEditViewModel @Inject constructor(
 
     val allLocations: StateFlow<List<LocationEntity>> = locationRepository.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /** Pass-through of the model download fraction (0..1), or null when idle. */
+    val downloadProgress: StateFlow<Float?> = promptGenerator.downloadProgress
+
+    /** Pass-through of the coarse AI readiness state, used to pick Autofill helper copy. */
+    val aiStatus: StateFlow<AiStatus> = promptGenerator.aiStatus
 
     companion object {
         private const val TAG = "HabitEditViewModel"

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitListScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitListScreen.kt
@@ -23,18 +23,26 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.delay
+import net.interstellarai.unreminder.service.llm.AiStatus
 import net.interstellarai.unreminder.ui.theme.Dimens
 import net.interstellarai.unreminder.ui.theme.DisplayHuge
 import net.interstellarai.unreminder.ui.theme.DisplaySmall
@@ -44,6 +52,7 @@ import net.interstellarai.unreminder.ui.theme.MonoLabelTiny
 import net.interstellarai.unreminder.ui.theme.MonoSectionLabel
 import net.interstellarai.unreminder.ui.theme.NavPill
 import net.interstellarai.unreminder.ui.theme.UnReminderShapes
+import net.interstellarai.unreminder.ui.theme.UnReminderTheme
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -65,6 +74,8 @@ fun HabitListScreen(
     viewModel: HabitListViewModel = hiltViewModel(),
 ) {
     val habits by viewModel.habits.collectAsStateWithLifecycle()
+    val downloadProgress by viewModel.downloadProgress.collectAsStateWithLifecycle()
+    val aiStatus by viewModel.aiStatus.collectAsStateWithLifecycle()
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
@@ -84,6 +95,12 @@ fun HabitListScreen(
                 .fillMaxSize()
                 .padding(padding),
         ) {
+            AiDownloadBanner(
+                progress = downloadProgress,
+                aiStatus = aiStatus,
+                onRetry = viewModel::retryModelDownload,
+            )
+
             HabitListHeader()
 
             if (habits.isEmpty()) {
@@ -167,6 +184,91 @@ private fun HabitListHeader() {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// AI download banner — renders at the top of the list when the on-device
+// model is streaming down, or for a short "AI ready" flash after it
+// finishes. Collapsed (0dp) when idle so it doesn't shove content.
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun AiDownloadBanner(
+    progress: Float?,
+    aiStatus: AiStatus,
+    onRetry: () -> Unit,
+) {
+    // Track progress→null transitions so we can flash an "AI ready" label for
+    // ~2s after download completes. `rememberSaveable` isn't needed — on
+    // config-change we re-read the VM state; on app restart the banner should
+    // not persist.
+    var showReadyFlash by remember { mutableStateOf(false) }
+    var lastProgress by remember { mutableStateOf<Float?>(null) }
+
+    LaunchedEffect(progress, aiStatus) {
+        val prev = lastProgress
+        lastProgress = progress
+        if (prev != null && progress == null && aiStatus is AiStatus.Ready) {
+            showReadyFlash = true
+            delay(2_000)
+            showReadyFlash = false
+        }
+    }
+
+    val isDownloading = progress != null
+    val isUnavailableRetryable = progress == null && aiStatus is AiStatus.Failed
+    val shouldRender = isDownloading || showReadyFlash || isUnavailableRetryable
+    if (!shouldRender) return
+
+    val clickMod = if (isUnavailableRetryable) {
+        Modifier.clickable(onClick = onRetry)
+    } else {
+        Modifier
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .then(clickMod)
+            .padding(horizontal = Dimens.xxl, vertical = Dimens.md),
+    ) {
+        when {
+            isDownloading -> {
+                val pct = ((progress ?: 0f).coerceIn(0f, 1f) * 100).toInt()
+                MonoSectionLabel("Downloading AI model · ${pct}%")
+                Spacer(Modifier.height(Dimens.xs + 2.dp))
+                LinearProgressIndicator(
+                    progress = { (progress ?: 0f).coerceIn(0f, 1f) },
+                    color = MaterialTheme.colorScheme.primary,
+                    trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(2.dp),
+                )
+            }
+            showReadyFlash -> {
+                MonoSectionLabel("AI ready")
+                Spacer(Modifier.height(Dimens.xs + 2.dp))
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(2.dp)
+                        .background(MaterialTheme.colorScheme.primary),
+                )
+            }
+            isUnavailableRetryable -> {
+                MonoSectionLabel("AI unavailable — tap to retry")
+                Spacer(Modifier.height(Dimens.xs + 2.dp))
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(2.dp)
+                        .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)),
+                )
+            }
+        }
+    }
+}
+
 @Composable
 private fun HabitRow(
     name: String,
@@ -230,6 +332,46 @@ private fun GlyphBubble() {
                 .size(10.dp)
                 .clip(CircleShape)
                 .background(MaterialTheme.colorScheme.primary),
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Previews — designer / reviewer can eyeball all 3 banner variants.
+// ─────────────────────────────────────────────────────────────────────────
+
+@Preview(name = "banner · downloading 45%", showBackground = true)
+@Composable
+private fun PreviewBannerDownloading() {
+    UnReminderTheme {
+        AiDownloadBanner(
+            progress = 0.45f,
+            aiStatus = AiStatus.Downloading(0.45f),
+            onRetry = {},
+        )
+    }
+}
+
+@Preview(name = "banner · unavailable", showBackground = true)
+@Composable
+private fun PreviewBannerUnavailable() {
+    UnReminderTheme {
+        AiDownloadBanner(
+            progress = null,
+            aiStatus = AiStatus.Failed,
+            onRetry = {},
+        )
+    }
+}
+
+@Preview(name = "banner · idle (renders nothing)", showBackground = true)
+@Composable
+private fun PreviewBannerIdle() {
+    UnReminderTheme {
+        AiDownloadBanner(
+            progress = null,
+            aiStatus = AiStatus.Ready,
+            onRetry = {},
         )
     }
 }

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitListViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitListViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import net.interstellarai.unreminder.data.db.HabitEntity
 import net.interstellarai.unreminder.data.repository.HabitRepository
+import net.interstellarai.unreminder.service.llm.AiStatus
+import net.interstellarai.unreminder.service.llm.PromptGenerator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -13,11 +15,18 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HabitListViewModel @Inject constructor(
-    private val habitRepository: HabitRepository
+    private val habitRepository: HabitRepository,
+    private val promptGenerator: PromptGenerator,
 ) : ViewModel() {
 
     val habits: StateFlow<List<HabitEntity>> = habitRepository.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /** Fractional 0..1 progress of the on-device model download, or null when not downloading. */
+    val downloadProgress: StateFlow<Float?> = promptGenerator.downloadProgress
+
+    /** Coarse AI readiness — drives the "AI unavailable — tap to retry" variant of the banner. */
+    val aiStatus: StateFlow<AiStatus> = promptGenerator.aiStatus
 
     fun toggleActive(habit: HabitEntity) {
         viewModelScope.launch {
@@ -29,5 +38,10 @@ class HabitListViewModel @Inject constructor(
         viewModelScope.launch {
             habitRepository.delete(habit)
         }
+    }
+
+    /** Wired to the retry action on the "AI unavailable" banner variant. */
+    fun retryModelDownload() {
+        promptGenerator.retryModelDownload()
     }
 }

--- a/app/src/test/java/net/interstellarai/unreminder/service/llm/PromptGeneratorTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/llm/PromptGeneratorTest.kt
@@ -1,9 +1,17 @@
 package net.interstellarai.unreminder.service.llm
 
 import android.content.Context
+import androidx.work.Data
+import androidx.work.WorkInfo
 import net.interstellarai.unreminder.data.db.HabitEntity
+import net.interstellarai.unreminder.worker.ModelDownloadWorker
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -13,6 +21,7 @@ import org.junit.Before
 import org.junit.Test
 import java.io.File
 import java.time.Instant
+import java.util.UUID
 
 class PromptGeneratorTest {
 
@@ -85,5 +94,109 @@ class PromptGeneratorTest {
         assertNull(generator.downloadProgress.value)
         generator.initialize()
         assertNull(generator.downloadProgress.value)
+    }
+
+    // --- observeDownloadProgress: WorkManager flow wiring ---
+    //
+    // PromptGeneratorImpl takes an injectable workInfoFlowProvider so tests can
+    // drive the state-transition logic without a live WorkManager. The test
+    // mirrors the collection contract documented on observeDownloadProgress and
+    // asserts the RUNNING-percent → Float-fraction mapping plus the SUCCESS → null
+    // transition the spec calls out.
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `observeDownloadProgress maps WorkInfo stream to Float fraction and nulls on SUCCESS`() = runTest {
+        val fakeFlow = MutableSharedFlow<List<WorkInfo>>(replay = 1, extraBufferCapacity = 8)
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val gen = PromptGeneratorImpl(
+            context = context,
+            workInfoFlowProvider = { fakeFlow },
+            scope = CoroutineScope(dispatcher),
+        )
+
+        val progressSamples = mutableListOf<Float?>()
+        val statusSamples = mutableListOf<AiStatus>()
+        val watchJob = launch(dispatcher) { gen.downloadProgress.collect { progressSamples.add(it) } }
+        val statusJob = launch(dispatcher) { gen.aiStatus.collect { statusSamples.add(it) } }
+
+        gen.observeDownloadProgress()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val id = UUID.randomUUID()
+        fakeFlow.emit(listOf(buildWorkInfo(id, WorkInfo.State.RUNNING, percent = 0)))
+        dispatcher.scheduler.advanceUntilIdle()
+        fakeFlow.emit(listOf(buildWorkInfo(id, WorkInfo.State.RUNNING, percent = 50)))
+        dispatcher.scheduler.advanceUntilIdle()
+        fakeFlow.emit(listOf(buildWorkInfo(id, WorkInfo.State.RUNNING, percent = 100)))
+        dispatcher.scheduler.advanceUntilIdle()
+        fakeFlow.emit(listOf(buildWorkInfo(id, WorkInfo.State.SUCCEEDED, percent = null)))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        // First sample is the initial null state from the StateFlow.
+        assertEquals(null, progressSamples.first())
+        // Fractions 0.0, 0.5, 1.0 should all have been pushed in order.
+        assertTrue(
+            "expected 0.0f in progress samples but got $progressSamples",
+            progressSamples.contains(0.0f),
+        )
+        assertTrue(
+            "expected 0.5f in progress samples but got $progressSamples",
+            progressSamples.contains(0.5f),
+        )
+        assertTrue(
+            "expected 1.0f in progress samples but got $progressSamples",
+            progressSamples.contains(1.0f),
+        )
+        // SUCCESS nulls out downloadProgress.
+        assertNull("progress should be null after SUCCEEDED", progressSamples.last())
+        // Status transitions: Downloading(.5f) → Downloading(1f) → Ready
+        // (engine init will fail because the model file isn't real, so status
+        // ends at Failed, not Ready — that's fine, we just assert the
+        // Downloading fractions show up).
+        assertTrue(
+            "expected Downloading(0.5f) in status samples but got $statusSamples",
+            statusSamples.any { it is AiStatus.Downloading && it.fraction == 0.5f },
+        )
+
+        watchJob.cancel()
+        statusJob.cancel()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `observeDownloadProgress sets AiStatus Failed on FAILED terminal state`() = runTest {
+        val fakeFlow = MutableSharedFlow<List<WorkInfo>>(replay = 1, extraBufferCapacity = 8)
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val gen = PromptGeneratorImpl(
+            context = context,
+            workInfoFlowProvider = { fakeFlow },
+            scope = CoroutineScope(dispatcher),
+        )
+
+        gen.observeDownloadProgress()
+        dispatcher.scheduler.advanceUntilIdle()
+        fakeFlow.emit(listOf(buildWorkInfo(UUID.randomUUID(), WorkInfo.State.FAILED, percent = null)))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(gen.downloadProgress.value)
+        assertEquals(AiStatus.Failed, gen.aiStatus.value)
+    }
+
+    private fun buildWorkInfo(
+        id: UUID,
+        state: WorkInfo.State,
+        percent: Int?,
+    ): WorkInfo {
+        val info: WorkInfo = mockk(relaxed = true)
+        every { info.id } returns id
+        every { info.state } returns state
+        val progressData = if (percent != null) {
+            Data.Builder().putInt(ModelDownloadWorker.KEY_PROGRESS, percent).build()
+        } else {
+            Data.EMPTY
+        }
+        every { info.progress } returns progressData
+        return info
     }
 }

--- a/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModelTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModelTest.kt
@@ -4,6 +4,7 @@ import net.interstellarai.unreminder.data.db.HabitEntity
 import net.interstellarai.unreminder.data.repository.HabitRepository
 import net.interstellarai.unreminder.data.repository.LocationRepository
 import net.interstellarai.unreminder.domain.model.AiHabitFields
+import net.interstellarai.unreminder.service.llm.AiStatus
 import net.interstellarai.unreminder.service.llm.PromptGenerator
 import io.mockk.coEvery
 import io.mockk.every
@@ -16,6 +17,7 @@ import io.sentry.protocol.SentryId
 import io.sentry.ScopeCallback
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -54,6 +56,8 @@ class HabitEditViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         every { mockLocationRepository.getAll() } returns flowOf(emptyList())
+        every { mockPromptGenerator.downloadProgress } returns MutableStateFlow<Float?>(null)
+        every { mockPromptGenerator.aiStatus } returns MutableStateFlow<AiStatus>(AiStatus.Ready)
         viewModel = HabitEditViewModel(mockHabitRepository, mockLocationRepository, mockPromptGenerator)
         viewModel.updateName("meditation")
         viewModel.updateFullDescription("20-minute guided meditation")


### PR DESCRIPTION
## Summary

- Wires `PromptGeneratorImpl.observeDownloadProgress()` to collect `WorkManager.getWorkInfosForUniqueWorkFlow()` and push fractional progress (0..1) into `_downloadProgress`, with `SUCCEEDED` → engine init and `FAILED`/`CANCELLED` → `AiStatus.Failed`.
- Adds a non-intrusive banner on `HabitListScreen` that shows "Downloading AI model · N%" with a thin `LinearProgressIndicator`, briefly flashes "AI ready" for ~2s on completion, and shows "AI unavailable — tap to retry" wired to a fresh `WorkManager` enqueue when a download fails.
- Disables the "Autofill with AI" button on `HabitEditScreen` when the model is downloading (helper: "Model downloading… N%") or unavailable (helper: "AI unavailable on this build"), keeping today's behaviour when the engine is ready.

## Test plan

- [x] `./gradlew clean lint test` passes (JDK 17).
- [x] `./gradlew assembleDebug` builds successfully.
- [x] New `PromptGeneratorTest.observeDownloadProgress maps WorkInfo stream to Float fraction and nulls on SUCCESS` asserts 0.0f / 0.5f / 1.0f → null transitions.
- [x] New `PromptGeneratorTest.observeDownloadProgress sets AiStatus Failed on FAILED terminal state` asserts the terminal-state path.
- [x] `@Preview`-annotated `AiDownloadBanner` variants for downloading / unavailable / idle so the banner can be eyeballed in Android Studio.
- [ ] Manual smoke on a device with a real `MODEL_CDN_URL` (requires CI secret — not doable in worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)