### PR TITLE
fix: resolve BuildConfig.MODEL_CDN_URL via providers (config-cache-safe, blank-safe)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,18 @@ plugins {
     alias(libs.plugins.sentry)
 }
 
+// Reads an environment variable via gradle's `providers` API so the lookup is
+// tracked by the configuration cache (plain `System.getenv` is not tracked and
+// can cause the cached value to be reused across CI builds). Also treats a
+// blank/empty string as "unset" so `?:` style fallbacks actually fire when the
+// env var exists but was exported as "" — otherwise BuildConfig ends up with a
+// literal empty string. Bug history: `BuildConfig.MODEL_CDN_URL` was resolving
+// to "" at runtime even though CI logs showed `MODEL_CDN_URL: ***` masked.
+fun envOrDefault(name: String, default: String): String =
+    providers.environmentVariable(name).orNull
+        ?.takeUnless { it.isBlank() }
+        ?: default
+
 android {
     namespace = "net.interstellarai.unreminder"
     compileSdk = 35
@@ -20,21 +32,35 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
+        val resolvedFeedbackUrl = envOrDefault(
+            "FEEDBACK_ENDPOINT_URL",
+            "https://feedback.alexsiri7.workers.dev/"
+        )
+        val resolvedSentryDsn = envOrDefault("SENTRY_DSN", "")
+        val resolvedModelUrl = envOrDefault(
+            "MODEL_CDN_URL",
+            "https://placeholder.invalid/model.task"
+        )
+
+        println("[gradle] FEEDBACK_ENDPOINT_URL resolved at configuration: ${resolvedFeedbackUrl.take(60)}…")
+        println("[gradle] SENTRY_DSN resolved at configuration: ${if (resolvedSentryDsn.isBlank()) "empty" else "set"}")
+        println("[gradle] MODEL_CDN_URL resolved at configuration: ${resolvedModelUrl.take(60)}…")
+
         buildConfigField(
             "String",
             "FEEDBACK_ENDPOINT_URL",
-            "\"${System.getenv("FEEDBACK_ENDPOINT_URL") ?: "https://feedback.alexsiri7.workers.dev/"}\""
+            "\"${resolvedFeedbackUrl}\""
         )
         buildConfigField(
             "String",
             "FEEDBACK_REPO",
             "\"alexsiri7/un-reminder\""
         )
-        buildConfigField("String", "SENTRY_DSN", "\"${System.getenv("SENTRY_DSN") ?: ""}\"")
+        buildConfigField("String", "SENTRY_DSN", "\"${resolvedSentryDsn}\"")
         buildConfigField(
             "String",
             "MODEL_CDN_URL",
-            "\"${System.getenv("MODEL_CDN_URL") ?: "https://placeholder.invalid/model.task"}\""
+            "\"${resolvedModelUrl}\""
         )
 
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,10 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
+# Explicitly disable the configuration cache. Rationale: `System.getenv(...)`
+# calls in our build scripts are not tracked by the configuration cache, so a
+# cached configuration could reuse a stale env-var value (e.g. MODEL_CDN_URL)
+# across CI runs. We migrated the env-var reads in app/build.gradle.kts to the
+# tracked `providers.environmentVariable(...)` API, but we keep the cache off
+# for simpler reasoning until the team explicitly opts in.
+org.gradle.configuration-cache=false


### PR DESCRIPTION
## Context / production evidence

A recent signed-release CI run showed `MODEL_CDN_URL: ***` in the `Build signed universal APK` step (the mask means the secret was set), and `ModelDownloadWorker` successfully downloaded the 2 GB model file at install time — so the URL reached *some* code path correctly.

However, an emulator smoke test of that same APK logged on launch:

```
W PromptGenerator: MODEL_CDN_URL is a placeholder () — AI features disabled.
```

Note the empty `()`: `BuildConfig.MODEL_CDN_URL` is literally `""` at runtime — not the placeholder default, and not the HF URL. The runtime guard in `PromptGeneratorImpl` / `ModelConfig` is working correctly; the bug is upstream in the gradle build.

## Two plausible root causes — both addressed here

### H1: Elvis (`?:`) doesn't catch empty strings

`System.getenv("X") ?: default` only fires the fallback when the env var is null. If CI somehow exports the var as `""` (a masked secret not visible to the step, a broken workflow wiring, etc.), `""` is what ends up inlined into `BuildConfig`.

### H2: Gradle configuration cache captures `System.getenv` at cache-build time

`System.getenv(...)` is **not** tracked by gradle's configuration cache. If the configuration was ever cached during a build where `MODEL_CDN_URL` was unset, every subsequent build reuses the cached value — even if CI sets the var fresh on the next run. The documented-supported API is `providers.environmentVariable(name).orNull`, which IS tracked.

## The fix

1. New helper in `app/build.gradle.kts`:

    ```kotlin
    fun envOrDefault(name: String, default: String): String =
        providers.environmentVariable(name).orNull
            ?.takeUnless { it.isBlank() }
            ?: default
    ```

   Handles H2 (tracked lookup) and H1 (blank-safe) at once.

2. Applied to all three env-var-backed `buildConfigField` calls: `MODEL_CDN_URL`, `SENTRY_DSN`, `FEEDBACK_ENDPOINT_URL`.

3. Gradle prints a one-line diagnostic per field at configuration time:

    ```
    [gradle] FEEDBACK_ENDPOINT_URL resolved at configuration: https://feedback.alexsiri7.workers.dev/…
    [gradle] SENTRY_DSN resolved at configuration: set            # or "empty" — never the value
    [gradle] MODEL_CDN_URL resolved at configuration: https://huggingface.co/google/…
    ```

   SENTRY_DSN intentionally only logs `set`/`empty`.

4. Explicit `org.gradle.configuration-cache=false` in `gradle.properties`.

### Why disable configuration cache?

I chose **off** (the default option outlined in the task). Rationale:

- There are other `System.getenv(...)` calls in the build script that I did not migrate (`versionCode`, `versionName`, signing-config env lookups, sentry autoUpload guard). Those are lower-impact but would still be cached incorrectly if cache were on.
- We currently have no measured need for configuration-cache speedups; CI is fast enough.
- Keeping it off removes a whole class of hard-to-reproduce cache-staleness bugs from the team's mental model. If/when someone wants to flip it back on, they already have the `providers.environmentVariable` helper to pattern-match against.

## Validation (local, all four builds pass)

| Scenario | Expected | Actual BuildConfig.MODEL_CDN_URL |
|---|---|---|
| `./gradlew assembleDebug` (no env) | placeholder | `https://placeholder.invalid/model.task` |
| `MODEL_CDN_URL=https://example.com/test.task` | that URL | `https://example.com/test.task` |
| `MODEL_CDN_URL=''` (empty string) | placeholder | `https://placeholder.invalid/model.task` |
| normal HF URL | HF URL | `https://huggingface.co/google/gemma-3n-E2B-it-litert-preview/resolve/main/gemma-3n-E2B-it-int4.task` |

`./gradlew lint test --stacktrace` → BUILD SUCCESSFUL.
The `[gradle] MODEL_CDN_URL resolved at configuration: …` line printed visibly in every run.
No Sentry DSN value ever appears in gradle stdout (grepped the output for the test DSN; zero hits).

## Out of scope / deliberately untouched

- Runtime guard logic in `PromptGeneratorImpl` / `ModelConfig` — was doing exactly what it should.
- Placeholder fallback value — unchanged.
- Other `System.getenv` sites in the build script (versionCode/versionName/signing config) — low blast radius; can be migrated later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)