### PR TITLE
fix: verify model download integrity (size + magic bytes) before marking success

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/llm/PromptGeneratorImpl.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/llm/PromptGeneratorImpl.kt
@@ -97,8 +97,35 @@ class PromptGeneratorImpl(
         initializeEngineFromFile(modelFile)
     }
 
-    private fun initializeEngineFromFile(modelFile: File) {
+    internal fun initializeEngineFromFile(modelFile: File) {
         if (engine != null) return
+
+        // Pre-flight magic-byte check. The LiteRT-LM engine throws a cryptic
+        // `LiteRtLmJniException: Unable to open zip archive` on any corrupt
+        // model file, without ever deleting it — so the next app start would
+        // simply re-throw the same JNI exception. Catch obvious corruption
+        // here (HTML error body, truncated download that somehow slipped past
+        // the worker, leftover partial from a previous build) and re-enqueue
+        // the download cleanly.
+        if (!modelFileLooksValid(modelFile)) {
+            val hex = readFirst8(modelFile).joinToString(" ") { "%02x".format(it) }
+            Log.w(
+                TAG,
+                "Model file magic looks wrong (got: $hex) — deleting and re-enqueuing download",
+            )
+            modelFile.delete()
+            try {
+                enqueueModelDownload()
+                observeDownloadProgress()
+                _aiStatus.value = AiStatus.Downloading(0f)
+                _downloadProgress.value = 0f
+            } catch (e: Throwable) {
+                Log.w(TAG, "Failed to re-enqueue model download after magic-byte mismatch", e)
+                _aiStatus.value = AiStatus.Failed
+            }
+            return
+        }
+
         try {
             val config = EngineConfig(
                 modelPath = modelFile.absolutePath,
@@ -117,6 +144,32 @@ class PromptGeneratorImpl(
             engine = null
             _downloadProgress.value = null
             _aiStatus.value = AiStatus.Failed
+        }
+    }
+
+    /**
+     * Cheap pre-check: does [modelFile] start with `LITE…` or `PK`? A negative
+     * result is a strong signal that the file on disk is not a LiteRT-LM
+     * container (see ModelDownloadWorker for the full magic-byte list and
+     * rationale).
+     */
+    private fun modelFileLooksValid(modelFile: File): Boolean {
+        if (!modelFile.exists() || modelFile.length() < 4) return false
+        val first8 = readFirst8(modelFile)
+        val isLitertlm = first8.take(4).toByteArray()
+            .contentEquals(byteArrayOf(0x4C, 0x49, 0x54, 0x45)) // "LITE"
+        val isZip = first8.take(2).toByteArray()
+            .contentEquals(byteArrayOf(0x50, 0x4B)) // "PK"
+        return isLitertlm || isZip
+    }
+
+    private fun readFirst8(modelFile: File): ByteArray {
+        val buf = ByteArray(8)
+        return try {
+            modelFile.inputStream().use { it.read(buf) }
+            buf
+        } catch (_: Exception) {
+            ByteArray(8)
         }
     }
 

--- a/app/src/main/java/net/interstellarai/unreminder/worker/ModelDownloadWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/worker/ModelDownloadWorker.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.CancellationException
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import javax.inject.Named
 
 @HiltWorker
@@ -28,11 +30,46 @@ class ModelDownloadWorker @AssistedInject constructor(
         const val KEY_PROGRESS = "progress"
         const val MODEL_FILENAME = "gemma3-1b-it-int4.task"
         private const val TAG = "ModelDownloadWorker"
+
+        /** Cap retry attempts so a genuinely broken URL doesn't loop forever. */
+        const val MAX_ATTEMPTS = 5
+
+        // Magic-byte prefixes for the two model container formats LiteRT-LM
+        // understands. Verified on-wire against the HF-hosted bundles:
+        //   - `.litertlm` files begin with the ASCII bytes "LITERTLM".
+        //   - `.task` files are zip containers; stored-entry zips begin with
+        //     `PK\x03\x04`, empty-zips with `PK\x05\x06`.
+        // Any other prefix (e.g. `<!DOCTYPE` from an HTML error body, or
+        // zeroed bytes from a truncated write) means the download is corrupt
+        // and `Engine.initialize()` would later throw
+        // `LiteRtLmJniException: Unable to open zip archive`.
+        private val MAGIC_LITERTLM = byteArrayOf(0x4C, 0x49, 0x54, 0x45, 0x52, 0x54, 0x4C, 0x4D)
+        private val MAGIC_ZIP_LOCAL = byteArrayOf(0x50, 0x4B, 0x03, 0x04)
+        private val MAGIC_ZIP_EMPTY = byteArrayOf(0x50, 0x4B, 0x05, 0x06)
+        private val KNOWN_MAGICS = listOf(MAGIC_LITERTLM, MAGIC_ZIP_LOCAL, MAGIC_ZIP_EMPTY)
     }
 
     override suspend fun doWork(): Result {
+        if (runAttemptCount >= MAX_ATTEMPTS) {
+            Log.e(TAG, "Giving up after $runAttemptCount attempts (cap=$MAX_ATTEMPTS)")
+            return Result.failure()
+        }
+
         val modelFile = File(applicationContext.filesDir, MODEL_FILENAME)
-        if (modelFile.exists()) return Result.success()
+        if (modelFile.exists()) {
+            // Guard against a previously-persisted corrupt download: a truncated
+            // body or an HTML error page saved under the final filename would
+            // otherwise cause `Engine.initialize()` to throw
+            // "Unable to open zip archive" on every app start forever, because
+            // the old early-return below never re-fetched.
+            if (fileLooksValid(modelFile)) {
+                return Result.success()
+            }
+            Log.w(TAG, "Existing model file failed integrity check — deleting and re-downloading")
+            if (!modelFile.delete()) {
+                Log.w(TAG, "Failed to delete corrupt model file: $modelFile")
+            }
+        }
 
         if (ModelConfig.isPlaceholderUrl(modelUrl)) {
             Log.w(
@@ -46,6 +83,7 @@ class ModelDownloadWorker @AssistedInject constructor(
         val tmpFile = File(applicationContext.filesDir, "$MODEL_FILENAME.tmp")
         return try {
             val request = Request.Builder().url(modelUrl).build()
+            var contentLength = -1L
             okHttpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
                     Log.w(TAG, "Download failed: HTTP ${response.code}")
@@ -55,7 +93,7 @@ class ModelDownloadWorker @AssistedInject constructor(
                     Log.e(TAG, "Download failed: null body on HTTP ${response.code}")
                     return Result.failure()
                 }
-                val contentLength = body.contentLength()
+                contentLength = body.contentLength()
                 var bytesRead = 0L
                 var lastReportedProgress = -1
                 body.byteStream().use { input ->
@@ -78,8 +116,43 @@ class ModelDownloadWorker @AssistedInject constructor(
                     }
                 }
             }
-            if (!tmpFile.renameTo(modelFile)) {
-                Log.w(TAG, "Rename failed: $tmpFile -> $modelFile")
+
+            // Verify declared length vs on-disk length. A mid-stream drop or
+            // a proxy that trickle-truncates the response will sail past the
+            // write loop without throwing but leaves a short file on disk
+            // that LiteRT-LM cannot open.
+            if (contentLength > 0 && tmpFile.length() != contentLength) {
+                Log.w(
+                    TAG,
+                    "Download size mismatch: got=${tmpFile.length()} expected=$contentLength"
+                )
+                tmpFile.delete()
+                return Result.retry()
+            }
+
+            // Verify first 8 bytes match a known model-container magic. Catches
+            // HTML error bodies served with a 200 status (CDN 503 → maintenance
+            // page, region-locked, etc.) and any other garbage that would later
+            // surface as a cryptic `Unable to open zip archive` on-device.
+            if (!fileLooksValid(tmpFile)) {
+                val hex = readFirst8(tmpFile).joinToString(" ") { "%02x".format(it) }
+                Log.w(TAG, "Download magic bytes unrecognised (got: $hex) — deleting and retrying")
+                tmpFile.delete()
+                return Result.retry()
+            }
+
+            // Atomic rename — on API 26+ `Files.move` with ATOMIC_MOVE guarantees
+            // we never observe a partially-populated final filename even if the
+            // process is killed mid-operation. minSdk = 31 for this app.
+            try {
+                Files.move(
+                    tmpFile.toPath(),
+                    modelFile.toPath(),
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
+            } catch (e: Exception) {
+                Log.w(TAG, "Atomic rename failed: $tmpFile -> $modelFile", e)
                 tmpFile.delete()
                 return Result.retry()
             }
@@ -91,6 +164,28 @@ class ModelDownloadWorker @AssistedInject constructor(
             Log.w(TAG, "Model download failed", e)
             tmpFile.delete()
             Result.retry()
+        }
+    }
+
+    /**
+     * True iff [file] starts with one of [KNOWN_MAGICS]. Non-existent or
+     * unreadable files are treated as invalid.
+     */
+    private fun fileLooksValid(file: File): Boolean {
+        if (!file.exists() || file.length() < MAGIC_LITERTLM.size) return false
+        val first8 = readFirst8(file)
+        return KNOWN_MAGICS.any { expected ->
+            first8.take(expected.size).toByteArray().contentEquals(expected)
+        }
+    }
+
+    private fun readFirst8(file: File): ByteArray {
+        val buf = ByteArray(MAGIC_LITERTLM.size)
+        return try {
+            file.inputStream().use { it.read(buf) }
+            buf
+        } catch (_: Exception) {
+            ByteArray(MAGIC_LITERTLM.size)
         }
     }
 }

--- a/app/src/test/java/net/interstellarai/unreminder/service/llm/PromptGeneratorTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/llm/PromptGeneratorTest.kt
@@ -96,6 +96,44 @@ class PromptGeneratorTest {
         assertNull(generator.downloadProgress.value)
     }
 
+    // --- corrupt model file pre-check ---
+    //
+    // Regression guard for the on-device `LiteRtLmJniException: Unable to open
+    // zip archive` bug. If a previous run left a truncated/HTML body under the
+    // model filename, the old code would feed it to `Engine.initialize()` and
+    // fail the same way on every app launch. The new pre-check must delete the
+    // file before attempting engine init so the re-download can overwrite it.
+
+    @Test
+    fun `initializeEngineFromFile deletes model file with bogus magic bytes`() = runTest {
+        // Write an HTML-error-page body under the model filename — matches the
+        // worst-case field scenario where a misconfigured CDN returned 200 OK
+        // with a maintenance page instead of the model bytes. In that state,
+        // the old code would hand the corrupt file straight to LiteRT-LM,
+        // catch the JNI exception, and leave the bad file on disk to fail the
+        // same way on every subsequent app launch.
+        val modelFile = File(tempDir, ModelDownloadWorker.MODEL_FILENAME)
+        modelFile.writeBytes("<!DOCTYPE html><html>oops</html>".toByteArray())
+        assertTrue("precondition: corrupt model file must exist", modelFile.exists())
+
+        // Bypass initialize() (which short-circuits on the placeholder
+        // MODEL_CDN_URL in test BuildConfig) and exercise the pre-init check
+        // directly. WorkManager is unavailable here, so the re-enqueue attempt
+        // will throw and the catch-branch sets aiStatus = Failed — that's OK,
+        // the contract under test is "corrupt file is removed".
+        generator.initializeEngineFromFile(modelFile)
+
+        assertTrue(
+            "corrupt model file must be deleted so a fresh download can land",
+            !modelFile.exists(),
+        )
+        val status = generator.aiStatus.value
+        assertTrue(
+            "aiStatus must not be Ready after corrupt-file cleanup (was $status)",
+            status !is AiStatus.Ready,
+        )
+    }
+
     // --- observeDownloadProgress: WorkManager flow wiring ---
     //
     // PromptGeneratorImpl takes an injectable workInfoFlowProvider so tests can

--- a/app/src/test/java/net/interstellarai/unreminder/worker/ModelDownloadWorkerTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/worker/ModelDownloadWorkerTest.kt
@@ -36,10 +36,17 @@ class ModelDownloadWorkerTest {
     private lateinit var filesDir: File
     private lateinit var worker: ModelDownloadWorker
 
+    // 8-byte LITERTLM magic prefix + arbitrary padding to form a believable
+    // model-file body in happy-path tests. The worker verifies size (via
+    // Content-Length match) and magic before renaming tmp → final.
+    private val litertlmMagic = byteArrayOf(0x4C, 0x49, 0x54, 0x45, 0x52, 0x54, 0x4C, 0x4D)
+    private val validModelBytes = litertlmMagic + "-fake-model-payload".toByteArray()
+
     @Before
     fun setup() {
         filesDir = createTempDir()
         every { mockContext.filesDir } returns filesDir
+        every { mockWorkerParams.runAttemptCount } returns 0
         worker = ModelDownloadWorker(mockContext, mockWorkerParams, mockOkHttpClient, testModelUrl)
     }
 
@@ -51,8 +58,10 @@ class ModelDownloadWorkerTest {
     // --- idempotency ---
 
     @Test
-    fun `doWork returns success immediately when model file already exists`() = runTest {
-        File(filesDir, ModelDownloadWorker.MODEL_FILENAME).createNewFile()
+    fun `doWork returns success immediately when valid model file already exists`() = runTest {
+        // Existing file with valid LITERTLM magic bytes passes the pre-download
+        // integrity check and short-circuits without hitting the network.
+        File(filesDir, ModelDownloadWorker.MODEL_FILENAME).writeBytes(validModelBytes)
 
         val result = worker.doWork()
 
@@ -67,13 +76,12 @@ class ModelDownloadWorkerTest {
         val mockCall: Call = mockk()
         val mockResponse: Response = mockk()
         val mockBody: ResponseBody = mockk()
-        val content = "fake-model-bytes".toByteArray()
         every { mockOkHttpClient.newCall(any<Request>()) } returns mockCall
         every { mockCall.execute() } returns mockResponse
         every { mockResponse.isSuccessful } returns true
         every { mockResponse.body } returns mockBody
-        every { mockBody.contentLength() } returns content.size.toLong()
-        every { mockBody.byteStream() } returns content.inputStream()
+        every { mockBody.contentLength() } returns validModelBytes.size.toLong()
+        every { mockBody.byteStream() } returns validModelBytes.inputStream()
         every { mockBody.close() } just Runs
         every { mockResponse.close() } just Runs
 
@@ -82,6 +90,120 @@ class ModelDownloadWorkerTest {
         assertEquals(Result.success(), result)
         assertTrue(File(filesDir, ModelDownloadWorker.MODEL_FILENAME).exists())
         assertFalse(File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp").exists())
+    }
+
+    // --- size mismatch -> retry + cleanup ---
+
+    @Test
+    fun `doWork returns retry and deletes tmp when body is shorter than Content-Length`() = runTest {
+        // Regression guard for the field bug: server promises 100 bytes, only
+        // delivers 50 — stream ends without throwing, but the on-disk file is
+        // truncated. Worker must detect this and NOT rename to the final name.
+        val content = litertlmMagic + ByteArray(42) // 50 bytes total
+        val declaredLength = 100L
+        val mockCall: Call = mockk()
+        val mockResponse: Response = mockk()
+        val mockBody: ResponseBody = mockk()
+        every { mockOkHttpClient.newCall(any<Request>()) } returns mockCall
+        every { mockCall.execute() } returns mockResponse
+        every { mockResponse.isSuccessful } returns true
+        every { mockResponse.body } returns mockBody
+        every { mockBody.contentLength() } returns declaredLength
+        every { mockBody.byteStream() } returns content.inputStream()
+        every { mockBody.close() } just Runs
+        every { mockResponse.close() } just Runs
+
+        val result = worker.doWork()
+
+        assertEquals(Result.retry(), result)
+        assertFalse(
+            "tmp file should be deleted on size mismatch",
+            File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp").exists(),
+        )
+        assertFalse(
+            "model file should NOT exist when the download was truncated",
+            File(filesDir, ModelDownloadWorker.MODEL_FILENAME).exists(),
+        )
+    }
+
+    // --- bad magic bytes (HTML error body served as 200) -> retry + cleanup ---
+
+    @Test
+    fun `doWork returns retry and deletes tmp when body has wrong magic bytes`() = runTest {
+        // Regression guard: a misconfigured CDN / Cloudflare-interstitial can
+        // return HTTP 200 with `<!DOCTYPE html>...` which would sail through
+        // the stream copy but LiteRT-LM cannot parse.
+        val htmlErrorBody = "<!DOCTYPE html><html>503 maintenance</html>".toByteArray()
+        val mockCall: Call = mockk()
+        val mockResponse: Response = mockk()
+        val mockBody: ResponseBody = mockk()
+        every { mockOkHttpClient.newCall(any<Request>()) } returns mockCall
+        every { mockCall.execute() } returns mockResponse
+        every { mockResponse.isSuccessful } returns true
+        every { mockResponse.body } returns mockBody
+        every { mockBody.contentLength() } returns htmlErrorBody.size.toLong()
+        every { mockBody.byteStream() } returns htmlErrorBody.inputStream()
+        every { mockBody.close() } just Runs
+        every { mockResponse.close() } just Runs
+
+        val result = worker.doWork()
+
+        assertEquals(Result.retry(), result)
+        assertFalse(
+            "tmp file should be deleted on magic-byte mismatch",
+            File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp").exists(),
+        )
+        assertFalse(
+            "model file should NOT exist when the download has wrong magic",
+            File(filesDir, ModelDownloadWorker.MODEL_FILENAME).exists(),
+        )
+    }
+
+    // --- pre-existing corrupt file -> re-downloads over it ---
+
+    @Test
+    fun `doWork deletes pre-existing corrupt model file and re-downloads`() = runTest {
+        // The old worker short-circuited on `modelFile.exists()` and never
+        // re-downloaded. A truncated or HTML body persisted under the final
+        // filename meant AI mode was permanently broken until reinstall.
+        val corruptExisting = "<!DOCTYPE html>oops".toByteArray()
+        File(filesDir, ModelDownloadWorker.MODEL_FILENAME).writeBytes(corruptExisting)
+
+        val mockCall: Call = mockk()
+        val mockResponse: Response = mockk()
+        val mockBody: ResponseBody = mockk()
+        every { mockOkHttpClient.newCall(any<Request>()) } returns mockCall
+        every { mockCall.execute() } returns mockResponse
+        every { mockResponse.isSuccessful } returns true
+        every { mockResponse.body } returns mockBody
+        every { mockBody.contentLength() } returns validModelBytes.size.toLong()
+        every { mockBody.byteStream() } returns validModelBytes.inputStream()
+        every { mockBody.close() } just Runs
+        every { mockResponse.close() } just Runs
+
+        val result = worker.doWork()
+
+        assertEquals(Result.success(), result)
+        val finalFile = File(filesDir, ModelDownloadWorker.MODEL_FILENAME)
+        assertTrue(finalFile.exists())
+        assertTrue(
+            "existing file should have been replaced with fresh download",
+            finalFile.readBytes().contentEquals(validModelBytes),
+        )
+    }
+
+    // --- attempt cap ---
+
+    @Test
+    fun `doWork returns failure when runAttemptCount has reached the cap`() = runTest {
+        every { mockWorkerParams.runAttemptCount } returns ModelDownloadWorker.MAX_ATTEMPTS
+        val cappedWorker =
+            ModelDownloadWorker(mockContext, mockWorkerParams, mockOkHttpClient, testModelUrl)
+
+        val result = cappedWorker.doWork()
+
+        assertEquals(Result.failure(), result)
+        verify { mockOkHttpClient wasNot Called }
     }
 
     // --- HTTP 5xx error -> retry ---


### PR DESCRIPTION
## Summary

Fix for the on-device `LiteRtLmJniException: Failed to create engine: UNKNOWN: Unable to open zip archive.` that has been making AI mode fail on the phone. The LiteRT-LM engine is happy — what it's being handed is a corrupt model file.

Two ways a corrupt file ends up on disk today:

1. The worker writes whatever the socket produces and renames tmp → final without checking `Content-Length` vs on-disk size or the container magic bytes. A truncated body (mid-stream proxy drop) or an HTML error body served as HTTP 200 by the CDN both sail through.
2. Once a bad file lands under the final filename, `ModelDownloadWorker.doWork()` short-circuits on `modelFile.exists()` forever and `PromptGeneratorImpl` keeps feeding the garbage to the JNI engine, which throws the same exception on every launch until the user uninstalls.

## What changed

**`ModelDownloadWorker.doWork()`** (`app/src/main/java/net/interstellarai/unreminder/worker/ModelDownloadWorker.kt`)
- After stream-copy, verify `tmpFile.length() == Content-Length` (when declared) → retry + delete tmp on mismatch.
- Verify the first 8 bytes are one of the known model-container magics: `LITERTLM` (`.litertlm` bundles), `PK\x03\x04`, or `PK\x05\x06` (`.task` zip bundles). Anything else → retry + delete tmp.
- Use `Files.move(…, ATOMIC_MOVE, REPLACE_EXISTING)` for the tmp → final rename (minSdk 31, so the API is available).
- Re-run the integrity check on any pre-existing `modelFile` and delete + re-download if it fails, instead of trusting mere existence.
- Cap retries at `runAttemptCount >= 5` so a genuinely broken URL does not loop forever.

**`PromptGeneratorImpl.initializeEngineFromFile`** (`app/src/main/java/net/interstellarai/unreminder/service/llm/PromptGeneratorImpl.kt`)
- Pre-flight magic-byte check before handing the file to the JNI engine. If it doesn't start with `LITE…` or `PK`, delete the file and re-enqueue the download. The UI banner from PR #57 will then drive downloading → success without the user uninstalling.

## Test plan

- [x] New `ModelDownloadWorkerTest` cases: truncated body (Content-Length=100, 50 bytes delivered) → `Result.retry()` + tmp deleted + final not created; HTML error body magic → `Result.retry()` + cleanup; pre-existing corrupt file → deleted and re-downloaded; `runAttemptCount >= MAX_ATTEMPTS` → `Result.failure()` without touching the network.
- [x] New `PromptGeneratorTest` case: corrupt file with bogus magic is deleted and `aiStatus` does not become `Ready`.
- [x] `./gradlew lint test` — 143 tests, 0 failures.
- [x] `./gradlew assembleDebug` — builds cleanly.
- [ ] On-device: install, observe downloading banner → AI mode becomes available without manual uninstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)