### PR TITLE
feat: launcher icon — orbit mark in sage/olive palette

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,10 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    Un-Reminder launcher icon — orbit mark adapted from the interstellarai.net
+    nav-brand SVG (two intersecting orbits + center dot + satellite) into the
+    app's sage / olive palette.
+
+    Source SVG viewBox 64x64 → this VectorDrawable viewport 108x108 (Android
+    adaptive-icon standard). Scale factor ≈ 1.5×, content centered on (54,54).
+
+    Geometry (pre-rotation ellipses):
+      outer orbit: cx=54 cy=54 rx=39 ry=15  rotate(-24°)  stroke #4D6B3A (olive)
+      inner orbit: cx=54 cy=54 rx=30 ry=12  rotate(+24°)  stroke #4D6B3A @ 0.45
+      center dot : cx=54 cy=54 r=9          fill  #D97757 (coral — brand accent)
+      satellite  : cx=84 cy=39 r=3.3        fill  #1F2A1A (deep olive-black)
+
+    Ellipse paths are expressed as 4 cubic beziers (kappa ≈ 0.5523) with each
+    control/end point pre-rotated around (54,54); VectorDrawable does not
+    support <ellipse> nor transform="rotate(...)" on paths.
+
+    The second orbit is rendered as a *solid* translucent stroke rather than
+    dashed because VectorDrawable has no stroke-dasharray support and dashes
+    collapse visually at launcher-icon display sizes anyway.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
     android:height="108dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
+
+    <!-- Outer orbit (solid olive) -->
     <path
-        android:fillColor="#3DDC84"
-        android:pathData="M54,54m-36,0a36,36 0,1 1,72 0a36,36 0,1 1,-72 0" />
+        android:pathData="M89.628,38.137 C86.259,30.569 67.576,31.536 47.899,40.297 C28.222,49.058 15.002,62.295 18.372,69.863 C21.741,77.431 40.424,76.464 60.101,67.703 C79.778,58.942 92.998,45.705 89.628,38.137 Z"
+        android:strokeColor="#FF4D6B3A"
+        android:strokeWidth="4.2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000" />
+
+    <!-- Inner orbit (olive at reduced opacity, substituting for the dashed stroke) -->
+    <path
+        android:pathData="M81.406,66.202 C84.102,60.148 74.017,49.776 58.881,43.037 C43.745,36.298 29.289,35.743 26.594,41.798 C23.898,47.852 33.983,58.224 49.119,64.963 C64.255,71.702 78.711,72.257 81.406,66.202 Z"
+        android:strokeColor="#FF4D6B3A"
+        android:strokeAlpha="0.45"
+        android:strokeWidth="2.0"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000" />
+
+    <!-- Center dot (coral — preserved brand accent) -->
+    <path
+        android:pathData="M45,54 a9,9 0 1,0 18,0 a9,9 0 1,0 -18,0 Z"
+        android:fillColor="#FFD97757" />
+
+    <!-- Satellite (deep olive-black for contrast on cream) -->
+    <path
+        android:pathData="M80.7,39 a3.3,3.3 0 1,0 6.6,0 a3.3,3.3 0 1,0 -6.6,0 Z"
+        android:fillColor="#FF1F2A1A" />
+
 </vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background"/>
+    <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#FFFFFF</color>
+    <color name="ic_launcher_background">#E8EBD9</color>
 </resources>


### PR DESCRIPTION
## Summary

Replaces the placeholder green-blob launcher icon with the
[interstellarai.net](https://interstellarai.net) nav-brand orbit mark,
adapted to Un-Reminder's sage / olive theme.

## Colour mapping

| SVG source role | Colour | Palette token |
|---|---|---|
| Background | `#E8EBD9` cream | `SageBg` |
| Outer orbit stroke | `#4D6B3A` olive | `SageAccent` |
| Inner orbit stroke | `#4D6B3A` @ 0.45 alpha | `SageAccent` (translucent) |
| Center dot | `#D97757` coral | preserved brand accent |
| Satellite | `#1F2A1A` near-black | `SageInk` |

The coral center dot is intentionally kept — it's the one warm note
against the sage cream and preserves the visual link to the
interstellarai.net mark.

## Dashed orbit: kept as translucent solid, not dashed

`VectorDrawable` does not support `stroke-dasharray`. The two options
were:

1. Drop the inner orbit entirely.
2. Emulate dashes with many `trimPathStart/End` path copies.
3. Render the inner orbit as a solid stroke with reduced alpha.

I went with (3): a `0.45`-alpha solid stroke. It preserves the "two
intersecting orbits" read while staying a clean single `<path>`, and at
launcher-icon display sizes (≈ 48–72 dp) dashes collapse into a line
anyway — so a translucent solid is indistinguishable from a faithful
dashed emulation.

## 108-dp viewport math

Source viewBox `64 × 64` → adaptive-icon viewport `108 × 108`, scaled
by ≈ 1.5× and centred on `(54, 54)` to sit comfortably inside the
66-dp safe zone:

| Shape | Source (64²) | Scaled (108²) | Rotation |
|---|---|---|---|
| Outer orbit | `cx=32 cy=32 rx=26 ry=10` | `cx=54 cy=54 rx=39 ry=15` | -24° |
| Inner orbit | `cx=32 cy=32 rx=20 ry=8` | `cx=54 cy=54 rx=30 ry=12` | +24° |
| Center dot | `cx=32 cy=32 r=6` | `cx=54 cy=54 r=9` | — |
| Satellite | `cx=52 cy=22 r=2.2` | `cx=84 cy=39 r=3.3` | — |

Ellipses are expressed as 4 cubic beziers (kappa ≈ 0.5523) with each
control / end point pre-rotated around `(54, 54)`, since
`VectorDrawable` supports neither `<ellipse>` nor
`transform="rotate(...)"` on `<path>`.

## Files changed

- `app/src/main/res/drawable/ic_launcher_foreground.xml` — rewritten.
- `app/src/main/res/values/colors.xml` — `ic_launcher_background`
  updated from `#FFFFFF` to `#E8EBD9`. (Kept the existing resource
  rather than adding a duplicate `ic_launcher_background.xml` to avoid
  `duplicate-resource` errors at merge time.)
- `app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml` — added
  (was missing; same adaptive-icon content as `ic_launcher.xml`).

No changes to package name, app label, manifest, themes, or any
non-icon code.

## Test plan

- [x] `./gradlew lint test --stacktrace` passes locally (Java 17).
- [x] `./gradlew assembleDebug --stacktrace` passes locally.
- [ ] CI green on this PR.
- [ ] Post-merge: Release APK artifact published.
- [ ] Manual on-device check that the launcher icon renders as expected
      under the various OEM mask shapes (circle, squircle, teardrop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)