### PR TITLE
fix: download model as foreground service with resume-from-partial + persistent progress

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,10 @@
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <!-- Model download worker promotes itself to a foreground service so Android
+         doesn't throttle/kill the 2.5 GB download when the app goes to the
+         background. DATA_SYNC is the required subtype on API 34+. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -19,6 +23,18 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.UnReminder">
+
+        <!-- WorkManager's SystemForegroundService hosts foreground workers like
+             ModelDownloadWorker. On API 34+, each FGS service element must
+             declare the *same* foregroundServiceType bits the worker requests
+             via ForegroundInfo — otherwise startForeground() throws
+             IllegalArgumentException. DATA_SYNC is the right subtype for a
+             one-shot model download. See:
+             https://developer.android.com/about/versions/14/changes/fgs-types-required -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
 
         <!-- LiteRT-LM GPU backend — optional native libs; app works on CPU if absent -->
         <uses-native-library android:name="libvndksupport.so" android:required="false"/>

--- a/app/src/main/java/net/interstellarai/unreminder/data/repository/ModelDownloadProgressRepository.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/repository/ModelDownloadProgressRepository.kt
@@ -1,0 +1,77 @@
+package net.interstellarai.unreminder.data.repository
+
+import android.util.Log
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.floatPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Persistent store for the last observed fraction of the on-device model
+ * download.
+ *
+ * Why this exists: `PromptGeneratorImpl` keeps `_downloadProgress` in a
+ * `StateFlow<Float?>` scoped to the application process. When Android kills
+ * the process while the app is backgrounded — which it *will* do during a
+ * 2.5 GB download — the StateFlow reverts to `null` on the next cold start
+ * and the UI momentarily reads "0%" even though WorkManager is about to
+ * resume the download with a `Range` header from the `.tmp` file's current
+ * length. Writing the fraction to DataStore on every 1% update lets
+ * `PromptGeneratorImpl.initialize()` seed `aiStatus = Downloading(fraction)`
+ * immediately, before WorkManager's `getWorkInfosForUniqueWorkFlow` catches
+ * up with the real state. Clears to `null` once the download terminates.
+ */
+@Singleton
+class ModelDownloadProgressRepository @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) {
+    private val fractionKey = floatPreferencesKey(KEY_FRACTION)
+
+    /**
+     * Cold flow of the last persisted fraction, or `null` when nothing is
+     * stored (clean install / completed download). Swallows IOException to
+     * stay safe on a corrupt prefs file — UI just sees "no progress yet".
+     */
+    val fraction: Flow<Float?> = dataStore.data
+        .catch { e ->
+            if (e is IOException) {
+                Log.w(TAG, "DataStore read error — treating as no persisted progress", e)
+                emit(emptyPreferences())
+            } else {
+                throw e
+            }
+        }
+        .map { prefs -> prefs[fractionKey] }
+
+    /** Blocking one-shot read for synchronous call sites (initialize()). */
+    suspend fun peek(): Float? = fraction.first()
+
+    /**
+     * Writes the current download fraction. Callers throttle to every 1% so
+     * DataStore isn't doing a flush on every byte — the worker already only
+     * computes a new Int percent once per percentage point.
+     */
+    suspend fun write(fraction: Float) {
+        dataStore.edit { prefs -> prefs[fractionKey] = fraction.coerceIn(0f, 1f) }
+    }
+
+    /** Clears the persisted value. Call on terminal states (success/failure). */
+    suspend fun clear() {
+        dataStore.edit { prefs -> prefs.remove(fractionKey) }
+    }
+
+    companion object {
+        private const val TAG = "ModelDownloadProgressRepository"
+        // Underscore-prefixed so it can't collide with the preferences key naming
+        // convention used by [OnboardingRepository] ("onboarding_done").
+        private const val KEY_FRACTION = "model_download_fraction"
+    }
+}

--- a/app/src/main/java/net/interstellarai/unreminder/di/ServiceModule.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/di/ServiceModule.kt
@@ -3,6 +3,7 @@ package net.interstellarai.unreminder.di
 import android.content.Context
 import net.interstellarai.unreminder.BuildConfig
 import net.interstellarai.unreminder.data.repository.LocationRepository
+import net.interstellarai.unreminder.data.repository.ModelDownloadProgressRepository
 import net.interstellarai.unreminder.service.alarm.AlarmScheduler
 import net.interstellarai.unreminder.service.geofence.GeofenceManager
 import net.interstellarai.unreminder.service.llm.PromptGenerator
@@ -47,8 +48,14 @@ object ServiceModule {
 
     @Provides
     @Singleton
-    fun providePromptGenerator(@ApplicationContext context: Context): PromptGenerator =
-        PromptGeneratorImpl(context)
+    fun providePromptGenerator(
+        @ApplicationContext context: Context,
+        modelDownloadProgressRepository: ModelDownloadProgressRepository,
+    ): PromptGenerator =
+        PromptGeneratorImpl(
+            context = context,
+            progressRepository = modelDownloadProgressRepository,
+        )
 
     @Provides
     @Named("modelCdnUrl")

--- a/app/src/main/java/net/interstellarai/unreminder/service/llm/PromptGeneratorImpl.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/llm/PromptGeneratorImpl.kt
@@ -10,6 +10,7 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import net.interstellarai.unreminder.BuildConfig
 import net.interstellarai.unreminder.data.db.HabitEntity
+import net.interstellarai.unreminder.data.repository.ModelDownloadProgressRepository
 import net.interstellarai.unreminder.domain.model.AiHabitFields
 import net.interstellarai.unreminder.worker.ModelDownloadWorker
 import com.google.ai.edge.litertlm.Content
@@ -48,6 +49,15 @@ class PromptGeneratorImpl(
      * can be driven and cancelled deterministically.
      */
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    /**
+     * Optional repo for reading the last persisted download fraction on cold
+     * start. Seeding from this value prevents the UI from briefly flashing
+     * "0%" when the app process is killed mid-download and recreated — the
+     * StateFlow inside this class would otherwise revert to `null`/`Idle`
+     * until WorkManager's [WorkInfo] flow catches up. Tests omit to keep
+     * the old constructor arity compatible.
+     */
+    private val progressRepository: ModelDownloadProgressRepository? = null,
 ) : PromptGenerator {
 
     companion object {
@@ -84,6 +94,19 @@ class PromptGeneratorImpl(
         }
         val modelFile = File(context.filesDir, ModelDownloadWorker.MODEL_FILENAME)
         if (!modelFile.exists()) {
+            // Seed the StateFlows from DataStore *before* enqueueing so the UI
+            // shows a non-zero fraction immediately on cold start if a previous
+            // worker had made progress. Without this the banner reads 0% for
+            // ~1-2s until the WorkInfo flow fires its first RUNNING emission.
+            try {
+                val persisted = progressRepository?.peek()
+                if (persisted != null && persisted in 0f..1f) {
+                    _downloadProgress.value = persisted
+                    _aiStatus.value = AiStatus.Downloading(persisted)
+                }
+            } catch (e: Throwable) {
+                Log.w(TAG, "Failed to read persisted download progress — continuing", e)
+            }
             try {
                 enqueueModelDownload()
                 observeDownloadProgress()

--- a/app/src/main/java/net/interstellarai/unreminder/service/notification/NotificationHelper.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/notification/NotificationHelper.kt
@@ -26,6 +26,12 @@ class NotificationHelper @Inject constructor(
         const val ACTION_DISMISSED = "DISMISSED"
         const val CHANNEL_ID_SYSTEM = "un_reminder_system"
         const val CHANNEL_NAME_SYSTEM = "Habit Status"
+        // Dedicated channel for the foreground-service notification posted by
+        // [ModelDownloadWorker] while the 2.5 GB AI model is streaming down.
+        // IMPORTANCE_LOW keeps it silent — the user hasn't asked for alerts,
+        // they just need the FGS to stay alive.
+        const val MODEL_DOWNLOAD_CHANNEL_ID = "model_download"
+        const val MODEL_DOWNLOAD_CHANNEL_NAME = "Model download"
         // Paused-habit notifications use habitId as offset.
         // Base chosen well above realistic trigger ID values to avoid collisions.
         const val NOTIFICATION_ID_PAUSED_BASE = 900_000L
@@ -51,6 +57,17 @@ class NotificationHelper @Inject constructor(
             enableVibration(false)
         }
         notificationManager.createNotificationChannel(systemChannel)
+
+        val modelDownloadChannel = NotificationChannel(
+            MODEL_DOWNLOAD_CHANNEL_ID,
+            MODEL_DOWNLOAD_CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = "Progress of the on-device AI model download"
+            setSound(null, null)
+            enableVibration(false)
+        }
+        notificationManager.createNotificationChannel(modelDownloadChannel)
     }
 
     fun postTriggerNotification(triggerId: Long, promptText: String, habitName: String) {

--- a/app/src/main/java/net/interstellarai/unreminder/worker/ModelDownloadWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/worker/ModelDownloadWorker.kt
@@ -1,18 +1,29 @@
 package net.interstellarai.unreminder.worker
 
+import android.Manifest
 import android.content.Context
+import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import net.interstellarai.unreminder.R
+import net.interstellarai.unreminder.data.repository.ModelDownloadProgressRepository
 import net.interstellarai.unreminder.service.llm.ModelConfig
+import net.interstellarai.unreminder.service.notification.NotificationHelper
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CancellationException
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
+import java.io.FileOutputStream
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import javax.inject.Named
@@ -22,7 +33,8 @@ class ModelDownloadWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val okHttpClient: OkHttpClient,
-    @Named("modelCdnUrl") private val modelUrl: String
+    @Named("modelCdnUrl") private val modelUrl: String,
+    private val progressRepository: ModelDownloadProgressRepository,
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
@@ -30,6 +42,11 @@ class ModelDownloadWorker @AssistedInject constructor(
         const val KEY_PROGRESS = "progress"
         const val MODEL_FILENAME = "gemma3-1b-it-int4.task"
         private const val TAG = "ModelDownloadWorker"
+
+        // Foreground-service notification id. Constant — the FGS is a singleton
+        // (WorkManager serialises the unique work "model_download") so reusing
+        // one id is fine and keeps the channel clean.
+        private const val NOTIF_ID = 42_001
 
         /** Cap retry attempts so a genuinely broken URL doesn't loop forever. */
         const val MAX_ATTEMPTS = 5
@@ -49,11 +66,27 @@ class ModelDownloadWorker @AssistedInject constructor(
         private val KNOWN_MAGICS = listOf(MAGIC_LITERTLM, MAGIC_ZIP_LOCAL, MAGIC_ZIP_EMPTY)
     }
 
+    /**
+     * Called once by WorkManager before [doWork] so the worker has a valid
+     * foreground-service notification while it downloads. Returning a
+     * [ForegroundInfo] lets Android treat our SystemJobService instance as a
+     * short-lived FGS, exempt from background-execution throttling — without
+     * this, a 2.5 GB download is killed the moment the app leaves the
+     * foreground.
+     */
+    override suspend fun getForegroundInfo(): ForegroundInfo =
+        createForegroundInfo(progress = -1)
+
     override suspend fun doWork(): Result {
         if (runAttemptCount >= MAX_ATTEMPTS) {
             Log.e(TAG, "Giving up after $runAttemptCount attempts (cap=$MAX_ATTEMPTS)")
             return Result.failure()
         }
+
+        // Promote to FGS up-front so the OS knows to keep us alive even if the
+        // user presses HOME before the first progress tick lands.
+        runCatching { setForeground(createForegroundInfo(progress = -1)) }
+            .onFailure { Log.w(TAG, "setForeground(initial) failed — FGS may be throttled", it) }
 
         val modelFile = File(applicationContext.filesDir, MODEL_FILENAME)
         if (modelFile.exists()) {
@@ -63,6 +96,7 @@ class ModelDownloadWorker @AssistedInject constructor(
             // "Unable to open zip archive" on every app start forever, because
             // the old early-return below never re-fetched.
             if (fileLooksValid(modelFile)) {
+                progressRepository.clear()
                 return Result.success()
             }
             Log.w(TAG, "Existing model file failed integrity check — deleting and re-downloading")
@@ -82,33 +116,93 @@ class ModelDownloadWorker @AssistedInject constructor(
 
         val tmpFile = File(applicationContext.filesDir, "$MODEL_FILENAME.tmp")
         return try {
-            val request = Request.Builder().url(modelUrl).build()
-            var contentLength = -1L
+            // Resume-from-partial: if a previous attempt wrote bytes to `.tmp`,
+            // request only the remainder via a Range header instead of restarting
+            // from byte 0. This is the single biggest win when the OS kills the
+            // worker midway — without it, WorkManager's retry mechanism wastes
+            // every previously-downloaded byte. See RFC 7233 §3.1.
+            val existingBytes = if (tmpFile.exists()) tmpFile.length() else 0L
+            val requestBuilder = Request.Builder().url(modelUrl)
+            if (existingBytes > 0) {
+                requestBuilder.addHeader("Range", "bytes=$existingBytes-")
+                Log.i(TAG, "Resuming download from byte $existingBytes")
+            }
+            val request = requestBuilder.build()
+
+            // `expectedTotalLength` is what the *entire* file should be, not
+            // just what this HTTP response carries. For a 206 Partial Content
+            // response the Content-Length is the remainder; we add the bytes
+            // already on disk to recover the whole-file size.
+            var expectedTotalLength = -1L
             okHttpClient.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) {
-                    Log.w(TAG, "Download failed: HTTP ${response.code}")
-                    return if (response.code in 500..599) Result.retry() else Result.failure()
+                // 200 = full download (server ignored Range or tmp was empty)
+                // 206 = Partial Content — our Range header was honoured
+                // Any other non-2xx = transient (5xx → retry) or hard (4xx → fail).
+                when {
+                    response.code == 200 -> {
+                        if (existingBytes > 0) {
+                            Log.w(TAG, "Server ignored Range header (HTTP 200) — restarting from 0")
+                            // Truncate tmp so the append-mode write below doesn't
+                            // concatenate the full body onto partial bytes.
+                            tmpFile.delete()
+                        }
+                    }
+                    response.code == 206 -> {
+                        if (existingBytes == 0L) {
+                            Log.w(TAG, "Got HTTP 206 without a Range header — treating as 200")
+                        }
+                    }
+                    response.code == 416 -> {
+                        // Range not satisfiable — our tmp is already >= total size.
+                        // Either the file is already complete or corrupt; delete
+                        // and retry from scratch.
+                        Log.w(TAG, "HTTP 416 Range Not Satisfiable — wiping tmp and retrying")
+                        tmpFile.delete()
+                        return Result.retry()
+                    }
+                    !response.isSuccessful -> {
+                        Log.w(TAG, "Download failed: HTTP ${response.code}")
+                        return if (response.code in 500..599) Result.retry() else Result.failure()
+                    }
                 }
                 val body = response.body ?: run {
                     Log.e(TAG, "Download failed: null body on HTTP ${response.code}")
                     return Result.failure()
                 }
-                contentLength = body.contentLength()
-                var bytesRead = 0L
+                val bodyLength = body.contentLength()
+                // For 206, bodyLength is the remaining bytes; for 200, it's the whole file.
+                val startOffset = if (response.code == 206) existingBytes else 0L
+                expectedTotalLength = if (bodyLength > 0) startOffset + bodyLength else -1L
+
+                var bytesWritten = startOffset
                 var lastReportedProgress = -1
                 body.byteStream().use { input ->
-                    tmpFile.outputStream().use { output ->
+                    // append mode when resuming, overwrite otherwise
+                    FileOutputStream(tmpFile, /*append=*/ startOffset > 0).use { output ->
                         val buffer = ByteArray(8 * 1024)
                         var bytes = input.read(buffer)
                         while (bytes >= 0) {
                             output.write(buffer, 0, bytes)
-                            bytesRead += bytes
-                            if (contentLength > 0) {
-                                val progress = (bytesRead * 100 / contentLength).toInt()
+                            bytesWritten += bytes
+                            if (expectedTotalLength > 0) {
+                                val progress =
+                                    (bytesWritten * 100 / expectedTotalLength).toInt().coerceIn(0, 100)
                                 if (progress != lastReportedProgress) {
                                     lastReportedProgress = progress
                                     @Suppress("CheckResult")
                                     setProgressAsync(workDataOf(KEY_PROGRESS to progress))
+                                    // Persist so cold starts can render the
+                                    // banner immediately, before WorkManager's
+                                    // flow catches up. See repository docs.
+                                    progressRepository.write(progress / 100f)
+                                    // Re-issue the foreground notification with
+                                    // fresh progress on every 1% tick. This
+                                    // doubles as a keep-alive that prevents the
+                                    // OS from deciding our FGS is stale.
+                                    runCatching { setForeground(createForegroundInfo(progress)) }
+                                        .onFailure {
+                                            Log.w(TAG, "setForeground(update) failed", it)
+                                        }
                                 }
                             }
                             bytes = input.read(buffer)
@@ -121,12 +215,17 @@ class ModelDownloadWorker @AssistedInject constructor(
             // a proxy that trickle-truncates the response will sail past the
             // write loop without throwing but leaves a short file on disk
             // that LiteRT-LM cannot open.
-            if (contentLength > 0 && tmpFile.length() != contentLength) {
+            if (expectedTotalLength > 0 && tmpFile.length() != expectedTotalLength) {
                 Log.w(
                     TAG,
-                    "Download size mismatch: got=${tmpFile.length()} expected=$contentLength"
+                    "Download size mismatch: got=${tmpFile.length()} expected=$expectedTotalLength",
                 )
-                tmpFile.delete()
+                // Keep the partial around so the next retry can resume from it
+                // if length is < expected. If length is > expected we delete
+                // because the file is unrecoverable.
+                if (tmpFile.length() > expectedTotalLength) {
+                    tmpFile.delete()
+                }
                 return Result.retry()
             }
 
@@ -156,15 +255,63 @@ class ModelDownloadWorker @AssistedInject constructor(
                 tmpFile.delete()
                 return Result.retry()
             }
+            progressRepository.clear()
             Result.success()
         } catch (e: CancellationException) {
-            tmpFile.delete()
+            // NB: don't delete tmpFile on cancellation — it holds the partial
+            // bytes we want to resume from on the next WorkManager retry.
             throw e
         } catch (e: Exception) {
             Log.w(TAG, "Model download failed", e)
-            tmpFile.delete()
+            // Same rationale: keep partial data so `Range:` resume works.
             Result.retry()
         }
+    }
+
+    /**
+     * Builds the FGS notification with the current [progress] percent.
+     * `progress` < 0 renders an indeterminate spinner ("Preparing…"); the
+     * 0..100 range renders a determinate progress bar. Keeps the notification
+     * silent (IMPORTANCE_LOW channel) and only-alert-once so we don't spam
+     * the shade on every 1% tick.
+     */
+    private fun createForegroundInfo(progress: Int): ForegroundInfo {
+        val indeterminate = progress !in 0..100
+        val notification = NotificationCompat.Builder(
+            applicationContext,
+            NotificationHelper.MODEL_DOWNLOAD_CHANNEL_ID,
+        )
+            .setContentTitle("Downloading AI model")
+            .setContentText(if (indeterminate) "Preparing…" else "$progress%")
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setProgress(100, progress.coerceIn(0, 100), indeterminate)
+            .build()
+
+        // API 34+ requires a declared FGS *type*. DATA_SYNC is the documented
+        // match for "this is a one-shot download we need to keep alive". On
+        // older API levels the type arg is a no-op.
+        val type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+        } else {
+            0
+        }
+
+        // POST_NOTIFICATIONS is a runtime permission on API 33+. If it's denied
+        // the FGS still runs — the notification is just invisible to the user.
+        // Log a breadcrumb so Sentry can surface denials when debugging.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val granted = ContextCompat.checkSelfPermission(
+                applicationContext,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+            if (!granted) {
+                Log.i(TAG, "POST_NOTIFICATIONS not granted — FGS runs, notification hidden")
+            }
+        }
+
+        return ForegroundInfo(NOTIF_ID, notification, type)
     }
 
     /**

--- a/app/src/test/java/net/interstellarai/unreminder/worker/ModelDownloadWorkerTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/worker/ModelDownloadWorkerTest.kt
@@ -4,13 +4,17 @@ import android.content.Context
 import androidx.work.ListenableWorker.Result
 import androidx.work.WorkerParameters
 import io.mockk.Called
+import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.Runs
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
+import net.interstellarai.unreminder.data.repository.ModelDownloadProgressRepository
 import net.interstellarai.unreminder.service.llm.ModelConfig
 import okhttp3.Call
 import okhttp3.OkHttpClient
@@ -32,6 +36,7 @@ class ModelDownloadWorkerTest {
     private val mockWorkerParams: WorkerParameters = mockk(relaxed = true)
     private val mockOkHttpClient: OkHttpClient = mockk()
     private val testModelUrl = "https://example.test/model.task"
+    private val mockProgressRepository: ModelDownloadProgressRepository = mockk(relaxed = true)
 
     private lateinit var filesDir: File
     private lateinit var worker: ModelDownloadWorker
@@ -47,7 +52,20 @@ class ModelDownloadWorkerTest {
         filesDir = createTempDir()
         every { mockContext.filesDir } returns filesDir
         every { mockWorkerParams.runAttemptCount } returns 0
-        worker = ModelDownloadWorker(mockContext, mockWorkerParams, mockOkHttpClient, testModelUrl)
+        // `mockk(relaxed = true)` returns default values for non-suspend calls
+        // but still throws for suspend functions — stub those explicitly so the
+        // worker's `progressRepository.write(...)` / `clear()` calls don't
+        // nondeterministically blow up the tests.
+        coJustRun { mockProgressRepository.write(any()) }
+        coJustRun { mockProgressRepository.clear() }
+        coEvery { mockProgressRepository.peek() } returns null
+        worker = ModelDownloadWorker(
+            mockContext,
+            mockWorkerParams,
+            mockOkHttpClient,
+            testModelUrl,
+            mockProgressRepository,
+        )
     }
 
     @After
@@ -79,6 +97,7 @@ class ModelDownloadWorkerTest {
         every { mockOkHttpClient.newCall(any<Request>()) } returns mockCall
         every { mockCall.execute() } returns mockResponse
         every { mockResponse.isSuccessful } returns true
+        every { mockResponse.code } returns 200
         every { mockResponse.body } returns mockBody
         every { mockBody.contentLength() } returns validModelBytes.size.toLong()
         every { mockBody.byteStream() } returns validModelBytes.inputStream()
@@ -95,10 +114,18 @@ class ModelDownloadWorkerTest {
     // --- size mismatch -> retry + cleanup ---
 
     @Test
-    fun `doWork returns retry and deletes tmp when body is shorter than Content-Length`() = runTest {
+    fun `doWork returns retry and keeps partial tmp when body is shorter than Content-Length`() = runTest {
         // Regression guard for the field bug: server promises 100 bytes, only
         // delivers 50 — stream ends without throwing, but the on-disk file is
         // truncated. Worker must detect this and NOT rename to the final name.
+        //
+        // New resume-from-partial semantics (fix for the backgrounded-download
+        // bug): when the received body is SHORTER than declared, we preserve
+        // the partial tmp file so the next WorkManager retry can send a
+        // `Range: bytes=N-` header and finish the download from where this
+        // attempt stopped. Only deletions that would lose recoverable bytes
+        // were removed; magic-byte mismatch still deletes (HTML error body is
+        // not a resumable download).
         val content = litertlmMagic + ByteArray(42) // 50 bytes total
         val declaredLength = 100L
         val mockCall: Call = mockk()
@@ -107,6 +134,7 @@ class ModelDownloadWorkerTest {
         every { mockOkHttpClient.newCall(any<Request>()) } returns mockCall
         every { mockCall.execute() } returns mockResponse
         every { mockResponse.isSuccessful } returns true
+        every { mockResponse.code } returns 200
         every { mockResponse.body } returns mockBody
         every { mockBody.contentLength() } returns declaredLength
         every { mockBody.byteStream() } returns content.inputStream()
@@ -116,9 +144,15 @@ class ModelDownloadWorkerTest {
         val result = worker.doWork()
 
         assertEquals(Result.retry(), result)
-        assertFalse(
-            "tmp file should be deleted on size mismatch",
-            File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp").exists(),
+        val tmp = File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp")
+        assertTrue(
+            "tmp file should be retained so resume-from-partial can continue",
+            tmp.exists(),
+        )
+        assertEquals(
+            "tmp should contain exactly the partial bytes received (50)",
+            50L,
+            tmp.length(),
         )
         assertFalse(
             "model file should NOT exist when the download was truncated",
@@ -140,6 +174,7 @@ class ModelDownloadWorkerTest {
         every { mockOkHttpClient.newCall(any<Request>()) } returns mockCall
         every { mockCall.execute() } returns mockResponse
         every { mockResponse.isSuccessful } returns true
+        every { mockResponse.code } returns 200
         every { mockResponse.body } returns mockBody
         every { mockBody.contentLength() } returns htmlErrorBody.size.toLong()
         every { mockBody.byteStream() } returns htmlErrorBody.inputStream()
@@ -175,6 +210,7 @@ class ModelDownloadWorkerTest {
         every { mockOkHttpClient.newCall(any<Request>()) } returns mockCall
         every { mockCall.execute() } returns mockResponse
         every { mockResponse.isSuccessful } returns true
+        every { mockResponse.code } returns 200
         every { mockResponse.body } returns mockBody
         every { mockBody.contentLength() } returns validModelBytes.size.toLong()
         every { mockBody.byteStream() } returns validModelBytes.inputStream()
@@ -197,8 +233,13 @@ class ModelDownloadWorkerTest {
     @Test
     fun `doWork returns failure when runAttemptCount has reached the cap`() = runTest {
         every { mockWorkerParams.runAttemptCount } returns ModelDownloadWorker.MAX_ATTEMPTS
-        val cappedWorker =
-            ModelDownloadWorker(mockContext, mockWorkerParams, mockOkHttpClient, testModelUrl)
+        val cappedWorker = ModelDownloadWorker(
+            mockContext,
+            mockWorkerParams,
+            mockOkHttpClient,
+            testModelUrl,
+            mockProgressRepository,
+        )
 
         val result = cappedWorker.doWork()
 
@@ -258,24 +299,35 @@ class ModelDownloadWorkerTest {
         assertEquals(Result.failure(), result)
     }
 
-    // --- network exception -> tmp cleanup + retry ---
+    // --- network exception -> retry, tmp preserved for resume ---
 
     @Test
-    fun `doWork cleans up tmp file and returns retry on network exception`() = runTest {
+    fun `doWork preserves tmp and returns retry on network exception`() = runTest {
+        // New resume-from-partial semantics: the tmp file is the raw bytes we
+        // already spent bandwidth on, so we keep it across retries. The next
+        // attempt will send `Range: bytes=<length>-` and continue. The
+        // previous "delete on any failure" behaviour was the root cause of
+        // the user-visible "went back to 0%" bug.
         val tmpFile = File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp")
+        // Simulate some prior progress so we can assert it survives.
+        tmpFile.writeBytes(litertlmMagic + ByteArray(100))
+        val priorLen = tmpFile.length()
         every { mockOkHttpClient.newCall(any<Request>()) } throws IOException("connection reset")
 
         val result = worker.doWork()
 
         assertEquals(Result.retry(), result)
-        assertFalse("tmp file should be deleted on exception", tmpFile.exists())
+        assertTrue("tmp file should survive a network exception", tmpFile.exists())
+        assertEquals("tmp file size should be unchanged", priorLen, tmpFile.length())
     }
 
-    // --- cancellation -> tmp cleanup ---
+    // --- cancellation -> rethrow, tmp preserved for resume ---
 
     @Test
-    fun `doWork cleans up tmp file and rethrows on cancellation`() = runTest {
+    fun `doWork preserves tmp and rethrows on cancellation`() = runTest {
         val tmpFile = File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp")
+        tmpFile.writeBytes(litertlmMagic + ByteArray(50))
+        val priorLen = tmpFile.length()
         every { mockOkHttpClient.newCall(any<Request>()) } throws CancellationException("cancelled")
 
         var threw = false
@@ -285,7 +337,8 @@ class ModelDownloadWorkerTest {
             threw = true
         }
         assertTrue("CancellationException should be rethrown", threw)
-        assertFalse("tmp file should be deleted on cancellation", tmpFile.exists())
+        assertTrue("tmp file should survive cancellation", tmpFile.exists())
+        assertEquals("tmp file size should be unchanged", priorLen, tmpFile.length())
     }
 
     // --- constants ---
@@ -308,7 +361,8 @@ class ModelDownloadWorkerTest {
             mockContext,
             mockWorkerParams,
             mockOkHttpClient,
-            ModelConfig.PLACEHOLDER_URL
+            ModelConfig.PLACEHOLDER_URL,
+            mockProgressRepository,
         )
 
         val result = placeholderWorker.doWork()
@@ -317,13 +371,116 @@ class ModelDownloadWorkerTest {
         verify { mockOkHttpClient wasNot Called }
     }
 
+    // --- resume-from-partial semantics ---
+
+    @Test
+    fun `doWork sends Range header and appends when tmp file already has bytes`() = runTest {
+        // Pre-seed tmp with 100 bytes of "previous attempt" payload. The new
+        // worker should see the tmp, send `Range: bytes=100-`, append the
+        // remaining bytes returned as 206 Partial Content, then finalise.
+        val tmpFile = File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp")
+        val firstHalf = litertlmMagic + ByteArray(92) { it.toByte() } // 100 bytes
+        tmpFile.writeBytes(firstHalf)
+
+        val remainder = ByteArray(50) { (it + 100).toByte() } // bytes 100..149
+        val totalExpected = 150L
+        val mockCall: Call = mockk()
+        val mockResponse: Response = mockk()
+        val mockBody: ResponseBody = mockk()
+        val capturedRequest = slot<Request>()
+        every { mockOkHttpClient.newCall(capture(capturedRequest)) } returns mockCall
+        every { mockCall.execute() } returns mockResponse
+        every { mockResponse.code } returns 206
+        every { mockResponse.isSuccessful } returns true
+        every { mockResponse.body } returns mockBody
+        // Partial-Content body length = only the remainder, not the whole file.
+        every { mockBody.contentLength() } returns remainder.size.toLong()
+        every { mockBody.byteStream() } returns remainder.inputStream()
+        every { mockBody.close() } just Runs
+        every { mockResponse.close() } just Runs
+
+        val result = worker.doWork()
+
+        assertEquals(Result.success(), result)
+        assertEquals(
+            "Range header should resume from the tmp file's current size",
+            "bytes=100-",
+            capturedRequest.captured.header("Range"),
+        )
+        val finalFile = File(filesDir, ModelDownloadWorker.MODEL_FILENAME)
+        assertTrue("final file should exist", finalFile.exists())
+        assertEquals(
+            "final file should be the pre-existing partial + remainder",
+            totalExpected,
+            finalFile.length(),
+        )
+        // Content = firstHalf + remainder, verifying we appended rather than
+        // truncating the resumed tmp.
+        assertTrue(
+            "final bytes must be the concatenation of partial + remainder",
+            finalFile.readBytes().contentEquals(firstHalf + remainder),
+        )
+    }
+
+    @Test
+    fun `doWork wipes tmp and returns retry on HTTP 416 Range Not Satisfiable`() = runTest {
+        // Partial tmp is larger than the server's current total, or tmp is
+        // corrupt somehow — 416 means "your Range is outside the resource".
+        // The safe recovery is to drop the tmp and retry from zero.
+        val tmpFile = File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp")
+        tmpFile.writeBytes(ByteArray(200))
+
+        val mockCall: Call = mockk()
+        val mockResponse: Response = mockk()
+        every { mockOkHttpClient.newCall(any<Request>()) } returns mockCall
+        every { mockCall.execute() } returns mockResponse
+        every { mockResponse.isSuccessful } returns false
+        every { mockResponse.code } returns 416
+        every { mockResponse.close() } just Runs
+
+        val result = worker.doWork()
+
+        assertEquals(Result.retry(), result)
+        assertFalse("tmp must be wiped on HTTP 416", tmpFile.exists())
+    }
+
+    @Test
+    fun `doWork restarts from byte 0 when server ignores Range header and returns 200`() = runTest {
+        // Some CDNs silently ignore Range and return the whole file as 200.
+        // If we naively appended that to the existing tmp we'd double the
+        // file size and the integrity check would fire. Worker must detect
+        // the 200 and truncate the tmp before writing.
+        val tmpFile = File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp")
+        tmpFile.writeBytes(ByteArray(100) { 0xAA.toByte() })
+
+        val mockCall: Call = mockk()
+        val mockResponse: Response = mockk()
+        val mockBody: ResponseBody = mockk()
+        every { mockOkHttpClient.newCall(any<Request>()) } returns mockCall
+        every { mockCall.execute() } returns mockResponse
+        every { mockResponse.isSuccessful } returns true
+        every { mockResponse.code } returns 200
+        every { mockResponse.body } returns mockBody
+        every { mockBody.contentLength() } returns validModelBytes.size.toLong()
+        every { mockBody.byteStream() } returns validModelBytes.inputStream()
+        every { mockBody.close() } just Runs
+        every { mockResponse.close() } just Runs
+
+        val result = worker.doWork()
+
+        assertEquals(Result.success(), result)
+        val finalFile = File(filesDir, ModelDownloadWorker.MODEL_FILENAME)
+        assertTrue(finalFile.readBytes().contentEquals(validModelBytes))
+    }
+
     @Test
     fun `doWork returns failure and skips network when URL is blank`() = runTest {
         val blankWorker = ModelDownloadWorker(
             mockContext,
             mockWorkerParams,
             mockOkHttpClient,
-            ""
+            "",
+            mockProgressRepository,
         )
 
         val result = blankWorker.doWork()


### PR DESCRIPTION
## Symptom

User report: *"The download only works if the app is on — I changed apps and came back and went to 0%."*

## Root cause

`ModelDownloadWorker` was a plain `CoroutineWorker`. Android throttles / kills long-running background workers once the app leaves the foreground, and a 2.5 GB download easily exceeds any background grace window. When WorkManager retried, the `.tmp` file was opened with the default `outputStream()` (overwrite mode), so every retry restarted from byte 0. Additionally, `PromptGeneratorImpl._downloadProgress` was a pure in-memory `StateFlow`; a process kill + restart reverted it to `null`/`Idle`, flashing the banner at 0% even when WorkManager was about to resume.

## Summary

- Promote the worker to a foreground service via `setForeground(...)`, using a dedicated `IMPORTANCE_LOW` `model_download` notification channel. Declare `FOREGROUND_SERVICE_DATA_SYNC` in the manifest (required on API 34+) and merge `foregroundServiceType=\"dataSync\"` onto `SystemForegroundService` — without the merge `startForeground()` throws `IllegalArgumentException`.
- Resume-from-partial: if `.tmp` has bytes, send `Range: bytes=<len>-`, open the output stream in append mode, and handle HTTP **206** (partial), **200** (server ignored Range → truncate), and **416** (wipe + retry). Keep the partial `.tmp` across network errors / cancellation so the next retry resumes instead of restarting.
- Persist the current fraction to DataStore on every 1% tick (`ModelDownloadProgressRepository`). `PromptGeneratorImpl.initialize()` seeds `aiStatus = Downloading(fraction)` from it before the `WorkInfo` flow catches up, so cold starts after a kill render the real progress immediately.

Composes with the PR #59 integrity check — magic-byte mismatch still deletes the tmp (HTML error bodies are not resumable); only recoverable cases retain the partial.

## Test plan

- [x] Baseline reproduction on `emulator-5554` with the main APK (`34f6c31`): `Starting work for ModelDownloadWorker` → progress ticks → `app died` after WorkManager eventually got interrupted on the user's real device (emulator is too lenient to reproduce the kill directly in 2 min, but the same conditions apply for doze / app-standby over longer windows).
- [x] Fixed APK built with `MODEL_CDN_URL=https://dl.google.com/.../commandlinetools-linux-12266719_latest.zip` (165 MB test payload with `Accept-Ranges: bytes`):
  - `I/ActivityManager: Background started FGS: Allowed ... net.interstellarai.unreminder/androidx.work.impl.foreground.SystemForegroundService`
  - `I/WM-SystemFgDispatcher: Started foreground service`
  - `I/WM-WorkerWrapper: Worker result SUCCESS for net.interstellarai.unreminder.worker.ModelDownloadWorker`
- [x] `./gradlew testDebugUnitTest` passes — new tests exercise the Range header (`bytes=100-`), HTTP 416 wipe-and-retry, server-ignored-Range restart, tmp-preservation on network exception, and tmp-preservation on cancellation.
- [x] `./gradlew lintDebug` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)