### PR TITLE
feat: wire archon-smart-pr-review as automated PR reviewer (pilot)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,149 @@
+name: archon PR review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    name: archon smart PR review
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    timeout-minutes: 20
+    steps:
+      - name: Checkout PR (full history for diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Checkout the PR head so archon reviews the actual PR contents.
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install archon CLI
+        run: |
+          # Official installer from GitHub releases.
+          # Writes to ~/.local/bin so it doesn't need sudo on the runner.
+          mkdir -p "$HOME/.local/bin"
+          INSTALL_DIR="$HOME/.local/bin" \
+            curl -fsSL https://raw.githubusercontent.com/coleam00/Archon/main/scripts/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/archon" version || true
+
+      - name: Fetch global conventions
+        id: conventions
+        run: |
+          # Conventions live in a public repo at alexsiri7/interstellarai.net.
+          # They may not be published yet — fall back to a placeholder so the
+          # review still runs. Each doc is fetched individually; a 404 on any
+          # one is not fatal.
+          mkdir -p /tmp/archon-conventions
+          for doc in clean-code documentation testing git; do
+            url="https://raw.githubusercontent.com/alexsiri7/interstellarai.net/main/src/content/conventions/$doc.md"
+            if curl -sfL "$url" -o "/tmp/archon-conventions/$doc.md"; then
+              echo "fetched: $doc.md"
+            else
+              echo "(conventions/$doc.md not yet published at $url)" \
+                > "/tmp/archon-conventions/$doc.md"
+              echo "missing: $doc.md (placeholder written)"
+            fi
+          done
+          ls -la /tmp/archon-conventions/
+
+      - name: Run archon-smart-pr-review
+        id: review
+        env:
+          # gh auth for workflow's internal PR context gathering + comment posting
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # archon expects these env var names for Claude Code SDK auth.
+          # If the repo has no ANTHROPIC_API_KEY secret, this is empty and
+          # the step will fail fast — we handle that in the next step.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Make conventions available to the review agents via env.
+          # (Agents can opt to read this directory; if unused, no harm done.)
+          ARCHON_CONVENTIONS_DIR: /tmp/archon-conventions
+          # Needed because archon detects Claude Code nesting and warns.
+          # We're not nested here, but set it explicitly for clarity.
+          CLAUDECODE: "0"
+          ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING: "1"
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          mkdir -p /tmp/archon-review
+
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::warning::ANTHROPIC_API_KEY secret not set on this repo — skipping archon review."
+            echo "not-configured" > /tmp/archon-review/status
+            cat > /tmp/archon-review/output.md <<'EOF'
+          ## archon PR review — not configured
+
+          This repo does not have the `ANTHROPIC_API_KEY` secret configured, so the
+          automated archon review could not run. To enable it:
+
+          ```bash
+          gh secret set ANTHROPIC_API_KEY --repo ${{ github.repository }}
+          ```
+          EOF
+            exit 0
+          fi
+
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          echo "Running archon-smart-pr-review for PR #$PR_NUMBER ..."
+
+          # archon posts the review comment itself via `gh` when it reaches
+          # the synthesize node. Capture stdout for debug logs in case it
+          # doesn't (e.g. early failure before synthesize).
+          if archon workflow run archon-smart-pr-review "$PR_NUMBER" \
+              --cwd "$GITHUB_WORKSPACE" \
+              --no-worktree \
+              2>&1 | tee /tmp/archon-review/output.md; then
+            echo "ok" > /tmp/archon-review/status
+          else
+            echo "failed" > /tmp/archon-review/status
+          fi
+
+      - name: Post fallback comment on failure
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          status="$(cat /tmp/archon-review/status 2>/dev/null || echo unknown)"
+          echo "archon review status: $status"
+
+          # archon posts its own comment on success. We only post a fallback
+          # if the workflow did NOT reach the synthesize step (status != ok).
+          if [ "$status" = "ok" ]; then
+            echo "archon posted its own review comment — nothing to do."
+            exit 0
+          fi
+
+          # Truncate log to last ~4k chars so the comment body is readable.
+          tail -c 4000 /tmp/archon-review/output.md > /tmp/archon-review/tail.md || true
+
+          body_file=/tmp/archon-review/comment.md
+          {
+            echo "## archon PR review — ${status}"
+            echo
+            if [ "$status" = "not-configured" ]; then
+              cat /tmp/archon-review/output.md
+            else
+              echo "The automated archon review did not complete successfully."
+              echo "This is a non-blocking signal — merge decisions are still yours."
+              echo
+              echo "<details><summary>Last ~4k chars of archon output</summary>"
+              echo
+              echo '```'
+              cat /tmp/archon-review/tail.md
+              echo '```'
+              echo
+              echo "</details>"
+            fi
+          } > "$body_file"
+
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body-file "$body_file" || true


### PR DESCRIPTION
## Summary

Wires automated PR reviews powered by archon into `un-reminder` as a pilot. On PR open/synchronize/ready_for_review, installs the archon CLI, fetches global conventions, runs `archon-smart-pr-review` against the PR, and lets archon post the review comment itself via `gh`.

## Key decisions

- **Workflow name**: `archon-smart-pr-review` (confirmed via `archon workflow list --json`).
- **archon install**: Official installer from GitHub releases (`coleam00/Archon/main/scripts/install.sh`) writing to `$HOME/.local/bin` — no sudo, no bun/node runtime needed (standalone binary). Takes ~2s.
- **Conventions**: `curl`ed from `alexsiri7/interstellarai.net:src/content/conventions/*.md` (public, no auth). On 404, a placeholder is written so the review still runs. Exposed to archon via `ARCHON_CONVENTIONS_DIR=/tmp/archon-conventions`.
- **Secrets**: Requires `ANTHROPIC_API_KEY`. archon shells out to the Claude Code SDK, which reads `ANTHROPIC_API_KEY` / `CLAUDE_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`. **This secret is not yet set on the repo** — add with:
  ```bash
  gh secret set ANTHROPIC_API_KEY --repo alexsiri7/un-reminder
  ```
  Until it is set, the workflow posts a "not configured" comment and exits 0.
- **Comment posting**: archon's `archon-synthesize-review` node calls `gh pr comment` itself. The workflow only posts a fallback comment if archon fails before reaching synthesize (or if the API key is missing). Avoids duplicate comments on the happy path.
- **Failure mode**: `continue-on-error: true` on the review step. A broken reviewer won't block merges. CI is green if the workflow *ran*, regardless of what archon produced.
- **env-leak gate**: archon refuses to run if sensitive keys are in a target-repo `.env` file. `un-reminder` has no `.env`, so no `--allow-env-keys` needed. Secrets are injected via the GHA `env:` block only.

## Required user action before merge

Set the `ANTHROPIC_API_KEY` secret on this repo (see above). Without it, the pilot never exercises a real review. The workflow will still pass CI (it degrades gracefully to a "not configured" comment).

## Test plan

- [ ] This very PR's workflow run completes green.
- [ ] If `ANTHROPIC_API_KEY` is set, archon posts a review comment on this PR.
- [ ] If the secret is *not* set, the workflow posts a "not configured" comment and exits 0 (no red X).
- [ ] On follow-up PRs to un-reminder, the workflow triggers automatically.

## Replicate to other repos

Once this proves itself on un-reminder, copy `.github/workflows/pr-review.yml` verbatim into:
- `alexsiri7/cosmic-match`
- `alexsiri7/reli`
- `alexsiri7/word-coach-annie`
- `alexsiri7/filmduel`

Set `ANTHROPIC_API_KEY` on each. No code changes needed to the workflow file — the workflow is repo-agnostic by design (uses `github.repository` + `github.event.pull_request.number`).