### PR TITLE
feat: model catalog + Settings selector + fallback-capable downloads

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/data/repository/ActiveModelRepository.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/repository/ActiveModelRepository.kt
@@ -1,0 +1,81 @@
+package net.interstellarai.unreminder.data.repository
+
+import android.util.Log
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import net.interstellarai.unreminder.service.llm.ModelCatalog
+import net.interstellarai.unreminder.service.llm.ModelDescriptor
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Persistent store for the currently-selected on-device LLM.
+ *
+ * A single string id is persisted under `active_model_id` in the shared
+ * settings DataStore. Resolving the id into a [ModelDescriptor] is done
+ * through [ModelCatalog.byId] so catalog additions/removals don't require a
+ * migration — unknown ids simply fall back to [ModelCatalog.default].
+ *
+ * Kept separate from [ModelDownloadProgressRepository] because the two have
+ * different lifecycles: the fraction clears on every download terminal state
+ * whereas the active model selection persists forever (or until the user
+ * changes it in Settings).
+ */
+@Singleton
+class ActiveModelRepository @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) {
+    private val activeIdKey = stringPreferencesKey(KEY_ACTIVE_ID)
+
+    /**
+     * Cold flow of the currently-selected descriptor. Emits [ModelCatalog.default]
+     * on a fresh install (no key present) or when the persisted id refers to
+     * a model no longer in the catalog (we removed it between app versions).
+     */
+    val active: Flow<ModelDescriptor> = dataStore.data
+        .catch { e ->
+            if (e is IOException) {
+                Log.w(TAG, "DataStore read error — defaulting to catalog default", e)
+                emit(emptyPreferences())
+            } else {
+                throw e
+            }
+        }
+        .map { prefs ->
+            val id = prefs[activeIdKey]
+            if (id == null) {
+                ModelCatalog.default
+            } else {
+                ModelCatalog.byId(id) ?: ModelCatalog.default
+            }
+        }
+
+    /**
+     * Blocking one-shot read for synchronous call sites — [PromptGeneratorImpl]
+     * uses this during `initialize()` so it knows which file to look for
+     * before it can safely observe the flow.
+     */
+    suspend fun peek(): ModelDescriptor = active.first()
+
+    /**
+     * Persist the user's selection. The caller is responsible for enqueuing
+     * the download — this repo only stores the choice so the next
+     * `initialize()` can resolve it.
+     */
+    suspend fun setActive(id: String) {
+        dataStore.edit { prefs -> prefs[activeIdKey] = id }
+    }
+
+    companion object {
+        private const val TAG = "ActiveModelRepository"
+        private const val KEY_ACTIVE_ID = "active_model_id"
+    }
+}

--- a/app/src/main/java/net/interstellarai/unreminder/di/ServiceModule.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/di/ServiceModule.kt
@@ -1,7 +1,7 @@
 package net.interstellarai.unreminder.di
 
 import android.content.Context
-import net.interstellarai.unreminder.BuildConfig
+import net.interstellarai.unreminder.data.repository.ActiveModelRepository
 import net.interstellarai.unreminder.data.repository.LocationRepository
 import net.interstellarai.unreminder.data.repository.ModelDownloadProgressRepository
 import net.interstellarai.unreminder.service.alarm.AlarmScheduler
@@ -16,7 +16,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
-import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -51,13 +50,17 @@ object ServiceModule {
     fun providePromptGenerator(
         @ApplicationContext context: Context,
         modelDownloadProgressRepository: ModelDownloadProgressRepository,
+        activeModelRepository: ActiveModelRepository,
     ): PromptGenerator =
         PromptGeneratorImpl(
             context = context,
             progressRepository = modelDownloadProgressRepository,
+            activeModelRepository = activeModelRepository,
         )
 
-    @Provides
-    @Named("modelCdnUrl")
-    fun provideModelCdnUrl(): String = BuildConfig.MODEL_CDN_URL
+    // Note: the old `@Named("modelCdnUrl")` binding for `BuildConfig.MODEL_CDN_URL`
+    // has been deleted. The model URL is now looked up via the catalog
+    // (`ModelCatalog.byId(...).url`) keyed on the user's active-model selection.
+    // BuildConfig.MODEL_CDN_URL remains compiled in but unread — left in place
+    // so the CI secret doesn't have to be rotated just for this refactor.
 }

--- a/app/src/main/java/net/interstellarai/unreminder/service/llm/ModelCatalog.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/llm/ModelCatalog.kt
@@ -1,0 +1,156 @@
+package net.interstellarai.unreminder.service.llm
+
+/**
+ * Static description of an on-device LLM the user can pick in Settings.
+ *
+ * Each descriptor fully parameterises the download + integrity-check path in
+ * [net.interstellarai.unreminder.worker.ModelDownloadWorker] and the engine-
+ * init path in [PromptGeneratorImpl]: swapping to a different model is purely
+ * a matter of writing a new [ModelDescriptor.id] to the active-model DataStore
+ * and re-enqueuing the worker.
+ *
+ * Why a data class + a tiny registry instead of a more elaborate plugin
+ * mechanism: there are two models today and adding a third is a ~6-line PR
+ * against [ModelCatalog.all]. Nothing about this design blocks a future
+ * runtime-loaded catalog (e.g. fetched from R2) — callers already resolve via
+ * [ModelCatalog.byId] so we can replace the registry without touching them.
+ */
+data class ModelDescriptor(
+    /**
+     * Stable key persisted in DataStore. Must never change after a model has
+     * shipped, or users who selected it will silently fall back to the
+     * default on next app start.
+     */
+    val id: String,
+    /** UI label. */
+    val displayName: String,
+    /** Short explanation shown under the display name. */
+    val description: String,
+    /**
+     * HTTPS download URL. Must either serve the full model body or 416 on an
+     * unsatisfiable `Range:` request — the worker uses RFC 7233 semantics for
+     * resume-from-partial.
+     */
+    val url: String,
+    /**
+     * On-disk filename under `filesDir`. MUST be distinct per model so the
+     * user can keep multiple downloaded simultaneously (or so we can fall
+     * back between them without re-downloading). Never reuse filenames
+     * between models — the integrity-check magic differs and a stale file
+     * would get rejected and re-downloaded on every app start.
+     */
+    val fileName: String,
+    /**
+     * Expected total download size in bytes. Shown in the UI as a human-
+     * readable figure; not used for validation (the worker trusts
+     * Content-Length from the CDN instead).
+     */
+    val sizeBytes: Long,
+    /**
+     * Expected magic-byte prefix at offset 0 of the downloaded file. The
+     * worker checks this after the stream completes and re-fetches if it
+     * doesn't match (catches HTML error bodies, truncated downloads, etc.).
+     */
+    val magicPrefix: ByteArray,
+    /**
+     * Soft filter hint for the UI. Not enforced — low-RAM devices can still
+     * select a large model, they'll just hit OOM on engine init and see
+     * [AiStatus.Failed].
+     */
+    val minDeviceMemoryGb: Int,
+    /**
+     * Optional caveats surfaced to the user ("experimental", "gated on HF",
+     * "known-broken on Pixel 8"). Null when the model is boring.
+     */
+    val notes: String? = null,
+) {
+    /**
+     * `ByteArray` needs custom equals/hashCode so unit tests and set-like
+     * operations on catalog entries behave sensibly. Auto-generated
+     * data-class equals uses reference equality for array members.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ModelDescriptor) return false
+        return id == other.id &&
+            displayName == other.displayName &&
+            description == other.description &&
+            url == other.url &&
+            fileName == other.fileName &&
+            sizeBytes == other.sizeBytes &&
+            magicPrefix.contentEquals(other.magicPrefix) &&
+            minDeviceMemoryGb == other.minDeviceMemoryGb &&
+            notes == other.notes
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + displayName.hashCode()
+        result = 31 * result + description.hashCode()
+        result = 31 * result + url.hashCode()
+        result = 31 * result + fileName.hashCode()
+        result = 31 * result + sizeBytes.hashCode()
+        result = 31 * result + magicPrefix.contentHashCode()
+        result = 31 * result + minDeviceMemoryGb
+        result = 31 * result + (notes?.hashCode() ?: 0)
+        return result
+    }
+}
+
+/**
+ * Registry of every model the app is willing to load. Add new entries here
+ * and they automatically show up in the Settings selector; no other wiring
+ * needed. Keep the list short — each entry is a promise to the user that the
+ * download + load path actually works.
+ */
+object ModelCatalog {
+    /**
+     * Latest Google Gemma 4 E2B model in LiteRT-LM container format.
+     * Flagship default for capable devices.
+     */
+    val gemma4E2BLitertlm = ModelDescriptor(
+        id = "gemma-4-e2b-it-litertlm",
+        displayName = "Gemma 4 E2B (LiteRT-LM)",
+        description = "Latest Google Gemma 4 model, 2B parameters, multimodal. 2.58 GB download.",
+        url = "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm",
+        fileName = "gemma-4-e2b-it.litertlm",
+        sizeBytes = 2_583_085_056L,
+        magicPrefix = byteArrayOf(0x4C, 0x49, 0x54, 0x45, 0x52, 0x54, 0x4C, 0x4D),
+        minDeviceMemoryGb = 8,
+        notes = "Experimental. Some devices can't load .litertlm files yet.",
+    )
+
+    /**
+     * Smaller, proven-working Gemma 3 1B in MediaPipe `.task` format. Fallback
+     * for low-RAM devices or when Gemma 4 fails to load.
+     *
+     * NB: The HuggingFace copy of this file is currently GATED, so the URL
+     * below is a deliberate placeholder that the worker will short-circuit on.
+     * Users wanting this model must self-host (or we do) and ship a real URL
+     * in a follow-up PR.
+     */
+    val gemma3_1B_Task = ModelDescriptor(
+        id = "gemma-3-1b-it-task",
+        displayName = "Gemma 3 1B (Task)",
+        description = "Smaller, known-good Gemma 3 model. 700 MB download, text-only.",
+        url = "https://placeholder.invalid/gemma3-1b-it-int4.task",
+        fileName = "gemma3-1b-it-int4.task",
+        sizeBytes = 689_000_000L,
+        magicPrefix = byteArrayOf(0x50, 0x4B, 0x03, 0x04),
+        minDeviceMemoryGb = 4,
+        notes = "Fallback option. File is gated on HuggingFace — you must self-host or provide your own URL.",
+    )
+
+    /** All models currently in the catalog, in display order. */
+    val all: List<ModelDescriptor> = listOf(gemma4E2BLitertlm, gemma3_1B_Task)
+
+    /**
+     * Resolve a descriptor by its stable [ModelDescriptor.id]. Returns null
+     * when the id refers to a model we've since removed — callers treat this
+     * as "fall back to [default]".
+     */
+    fun byId(id: String): ModelDescriptor? = all.firstOrNull { it.id == id }
+
+    /** Default on a fresh install. */
+    val default: ModelDescriptor = gemma4E2BLitertlm
+}

--- a/app/src/main/java/net/interstellarai/unreminder/service/llm/ModelConfig.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/llm/ModelConfig.kt
@@ -3,20 +3,29 @@ package net.interstellarai.unreminder.service.llm
 /**
  * Model-download configuration helpers.
  *
- * The on-device LLM model is downloaded on first launch from a CDN URL baked into
- * the APK at build time via `BuildConfig.MODEL_CDN_URL`. When CI is missing the
- * `MODEL_CDN_URL` secret, the build falls back to a placeholder host that will
- * never resolve — this helper lets callers detect that misconfiguration and fail
- * loudly instead of silently attempting a download that can never succeed.
+ * Historically the on-device LLM URL lived exclusively in
+ * `BuildConfig.MODEL_CDN_URL` (a CI-wired secret). That single URL has been
+ * superseded by the per-descriptor [ModelCatalog] mechanism, but a handful
+ * of catalog entries still ship with `https://placeholder.invalid/...`
+ * sentinel URLs — either because we haven't self-hosted a gated model yet,
+ * or because CI hasn't been given the real URL. Callers use
+ * [isPlaceholderUrl] to detect that state and surface `AiStatus.Unavailable`
+ * instead of attempting a download that can never succeed.
  */
 object ModelConfig {
     /** Matches the fallback in `app/build.gradle.kts` when `MODEL_CDN_URL` is unset. */
     const val PLACEHOLDER_URL = "https://placeholder.invalid/model.task"
 
+    /** Host used for all sentinel URLs we treat as "not really downloadable". */
+    private const val PLACEHOLDER_HOST_PREFIX = "https://placeholder.invalid/"
+
     /**
-     * @return true when [url] is blank or equals the build-time placeholder, indicating
-     * that no real model URL was wired through CI and AI features cannot work.
+     * @return true when [url] is blank, equals the legacy build-time
+     * placeholder, or points at the generic `placeholder.invalid` host
+     * we reserve for unresolved catalog entries.
      */
     fun isPlaceholderUrl(url: String?): Boolean =
-        url.isNullOrBlank() || url == PLACEHOLDER_URL
+        url.isNullOrBlank() ||
+            url == PLACEHOLDER_URL ||
+            url.startsWith(PLACEHOLDER_HOST_PREFIX)
 }

--- a/app/src/main/java/net/interstellarai/unreminder/service/llm/PromptGeneratorImpl.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/llm/PromptGeneratorImpl.kt
@@ -8,8 +8,9 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
-import net.interstellarai.unreminder.BuildConfig
+import androidx.work.workDataOf
 import net.interstellarai.unreminder.data.db.HabitEntity
+import net.interstellarai.unreminder.data.repository.ActiveModelRepository
 import net.interstellarai.unreminder.data.repository.ModelDownloadProgressRepository
 import net.interstellarai.unreminder.domain.model.AiHabitFields
 import net.interstellarai.unreminder.worker.ModelDownloadWorker
@@ -60,6 +61,12 @@ class PromptGeneratorImpl(
      */
     private val progressRepository: ModelDownloadProgressRepository? = null,
     /**
+     * Source of truth for which model the user has selected. When absent
+     * (e.g. unit tests that haven't wired this up) we fall back to
+     * [ModelCatalog.default].
+     */
+    private val activeModelRepository: ActiveModelRepository? = null,
+    /**
      * Factory for constructing the underlying LiteRT-LM engine given a model
      * path and a backend hint ("gpu" or "cpu"). Tests override this to
      * simulate GPU-init failure + CPU fallback without needing a real model
@@ -101,25 +108,39 @@ class PromptGeneratorImpl(
 
     private var progressCollectorJob: Job? = null
 
+    /**
+     * Currently-selected descriptor. Cached at each `initialize()` entry so
+     * observeDownloadProgress()'s SUCCEEDED branch can locate the correct
+     * on-disk file without an extra DataStore read on the hot path.
+     */
+    private var activeDescriptor: ModelDescriptor = ModelCatalog.default
+
     override suspend fun initialize() {
-        if (ModelConfig.isPlaceholderUrl(BuildConfig.MODEL_CDN_URL)) {
-            // Build misconfiguration: the MODEL_CDN_URL env var was not supplied at build time,
-            // so the APK was built with the "https://placeholder.invalid/model.task" default.
-            // Any download attempt would fail with UnknownHostException and AI features would
-            // silently do nothing. Log, flag to Sentry, and skip enqueueing the download.
+        // Read the user's current selection. Fresh installs and any test
+        // config that omits the repo both fall back to the catalog default.
+        val desc = runCatching { activeModelRepository?.peek() }
+            .getOrNull()
+            ?: ModelCatalog.default
+        activeDescriptor = desc
+
+        if (ModelConfig.isPlaceholderUrl(desc.url)) {
+            // Catalog entry ships with a sentinel URL (e.g. Gemma 3 is gated
+            // on HF and nobody has plugged in a self-host yet). Surface as
+            // Unavailable so the UI can render a descriptive message instead
+            // of a perpetual "Downloading 0%".
             Log.w(
                 TAG,
-                "MODEL_CDN_URL is a placeholder (${BuildConfig.MODEL_CDN_URL}) — " +
-                    "AI features disabled. Set the MODEL_CDN_URL secret in CI to fix."
+                "Active model '${desc.id}' has a placeholder URL — AI features disabled. " +
+                    "Pick a different model in Settings or self-host this one.",
             )
             Sentry.captureMessage(
-                "MODEL_CDN_URL is a placeholder — AI features disabled",
-                SentryLevel.WARNING
+                "Active model '${desc.id}' has placeholder URL — AI features disabled",
+                SentryLevel.WARNING,
             ) { scope -> scope.setTag("component", "litert-lm-init") }
             _aiStatus.value = AiStatus.Unavailable
             return
         }
-        val modelFile = File(context.filesDir, ModelDownloadWorker.MODEL_FILENAME)
+        val modelFile = File(context.filesDir, desc.fileName)
         if (!modelFile.exists()) {
             // Seed the StateFlows from DataStore *before* enqueueing so the UI
             // shows a non-zero fraction immediately on cold start if a previous
@@ -135,7 +156,7 @@ class PromptGeneratorImpl(
                 Log.w(TAG, "Failed to read persisted download progress — continuing", e)
             }
             try {
-                enqueueModelDownload()
+                enqueueModelDownload(desc)
                 observeDownloadProgress()
             } catch (e: Throwable) {
                 Log.w(TAG, "WorkManager unavailable in this environment; model download skipped", e)
@@ -165,7 +186,7 @@ class PromptGeneratorImpl(
             )
             modelFile.delete()
             try {
-                enqueueModelDownload()
+                enqueueModelDownload(activeDescriptor)
                 observeDownloadProgress()
                 _aiStatus.value = AiStatus.Downloading(0f)
                 _downloadProgress.value = 0f
@@ -245,24 +266,26 @@ class PromptGeneratorImpl(
         }
     }
 
-    private fun enqueueModelDownload() {
+    private fun enqueueModelDownload(desc: ModelDescriptor) {
         val request = OneTimeWorkRequestBuilder<ModelDownloadWorker>()
             .setConstraints(
                 Constraints.Builder()
                     .setRequiredNetworkType(NetworkType.CONNECTED)
                     .build()
             )
+            .setInputData(workDataOf(ModelDownloadWorker.KEY_MODEL_ID to desc.id))
             .build()
         WorkManager.getInstance(context)
             .enqueueUniqueWork(ModelDownloadWorker.WORK_NAME, ExistingWorkPolicy.KEEP, request)
     }
 
     override fun retryModelDownload() {
-        if (ModelConfig.isPlaceholderUrl(BuildConfig.MODEL_CDN_URL)) {
-            Log.w(TAG, "retryModelDownload: placeholder URL — ignoring")
+        val desc = activeDescriptor
+        if (ModelConfig.isPlaceholderUrl(desc.url)) {
+            Log.w(TAG, "retryModelDownload: placeholder URL for '${desc.id}' — ignoring")
             return
         }
-        val modelFile = File(context.filesDir, ModelDownloadWorker.MODEL_FILENAME)
+        val modelFile = File(context.filesDir, desc.fileName)
         if (modelFile.exists()) {
             // File already on disk — re-attempt engine init instead of re-downloading.
             initializeEngineFromFile(modelFile)
@@ -276,6 +299,7 @@ class PromptGeneratorImpl(
                         .setRequiredNetworkType(NetworkType.CONNECTED)
                         .build()
                 )
+                .setInputData(workDataOf(ModelDownloadWorker.KEY_MODEL_ID to desc.id))
                 .build()
             WorkManager.getInstance(context).enqueueUniqueWork(
                 ModelDownloadWorker.WORK_NAME,
@@ -336,7 +360,7 @@ class PromptGeneratorImpl(
                             // against double-init.
                             val modelFile = File(
                                 context.filesDir,
-                                ModelDownloadWorker.MODEL_FILENAME,
+                                activeDescriptor.fileName,
                             )
                             if (modelFile.exists()) {
                                 initializeEngineFromFile(modelFile)

--- a/app/src/main/java/net/interstellarai/unreminder/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/settings/SettingsScreen.kt
@@ -16,21 +16,31 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import net.interstellarai.unreminder.service.llm.AiStatus
+import net.interstellarai.unreminder.service.llm.ModelCatalog
+import net.interstellarai.unreminder.service.llm.ModelDescriptor
 import net.interstellarai.unreminder.ui.theme.Dimens
 import net.interstellarai.unreminder.ui.theme.DisplayHuge
 import net.interstellarai.unreminder.ui.theme.DisplaySmall
@@ -42,6 +52,7 @@ import net.interstellarai.unreminder.ui.theme.NavPill
 import net.interstellarai.unreminder.ui.theme.SansBody
 import net.interstellarai.unreminder.ui.theme.SansBodyStrong
 import net.interstellarai.unreminder.ui.theme.UnReminderShapes
+import net.interstellarai.unreminder.ui.theme.UnReminderTheme
 
 // ─────────────────────────────────────────────────────────────────────────
 // Settings — no explicit screen in the handoff, but styled to match the rest
@@ -58,6 +69,8 @@ fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val activeModel by viewModel.activeModel.collectAsStateWithLifecycle()
+    val aiStatus by viewModel.aiStatus.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         viewModel.refreshPermissions()
@@ -70,6 +83,10 @@ fun SettingsScreen(
     val locationPermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions(),
     ) { viewModel.refreshPermissions() }
+
+    // Pending selection: drives the confirmation dialog. Holds (previous,
+    // newly-chosen) so the dialog can name both models explicitly.
+    var pendingSelection by remember { mutableStateOf<Pair<ModelDescriptor, ModelDescriptor>?>(null) }
 
     Scaffold(containerColor = MaterialTheme.colorScheme.background) { padding ->
         Column(
@@ -91,6 +108,20 @@ fun SettingsScreen(
                     color = MaterialTheme.colorScheme.onBackground,
                 )
             }
+
+            ModelCatalogSection(
+                catalog = viewModel.catalog,
+                active = activeModel,
+                status = aiStatus,
+                onSelect = { chosen ->
+                    if (chosen.id != activeModel.id) {
+                        pendingSelection = activeModel to chosen
+                    }
+                },
+                modifier = Modifier.padding(horizontal = Dimens.xxl),
+            )
+
+            Spacer(Modifier.height(Dimens.xxl))
 
             SettingsSection(
                 label = "permissions",
@@ -169,6 +200,224 @@ fun SettingsScreen(
             NavPill()
         }
     }
+
+    val pending = pendingSelection
+    if (pending != null) {
+        val (previous, chosen) = pending
+        AlertDialog(
+            onDismissRequest = { pendingSelection = null },
+            title = {
+                Text(
+                    "Switch to ${chosen.displayName}?",
+                    style = DisplaySmall,
+                )
+            },
+            text = {
+                Column {
+                    Text(
+                        "The download (${formatSize(chosen.sizeBytes)}) will start on Wi-Fi. " +
+                            "AI generation will be unavailable until it finishes.",
+                        style = SansBody,
+                    )
+                    if (chosen.notes != null) {
+                        Spacer(Modifier.height(Dimens.sm))
+                        Text(
+                            chosen.notes,
+                            style = MonoLabelTiny,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                        )
+                    }
+                    Spacer(Modifier.height(Dimens.md))
+                    Text(
+                        "You can free up space by deleting the previous model " +
+                            "(${previous.displayName}).",
+                        style = SansBody,
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.selectModel(chosen.id)
+                    viewModel.deleteOtherModelFiles(keep = chosen)
+                    pendingSelection = null
+                }) {
+                    Text("Switch & delete previous")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    viewModel.selectModel(chosen.id)
+                    pendingSelection = null
+                }) {
+                    Text("Switch & keep previous")
+                }
+            },
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// AI model catalog UI
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun ModelCatalogSection(
+    catalog: List<ModelDescriptor>,
+    active: ModelDescriptor,
+    status: AiStatus,
+    onSelect: (ModelDescriptor) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(modifier = modifier) {
+        MonoSectionLabel("ai model")
+        Spacer(Modifier.height(Dimens.md - 2.dp))
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant, UnReminderShapes.small),
+        ) {
+            // Active model row — always visible, tap to expand.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { expanded = !expanded }
+                    .padding(horizontal = Dimens.lg, vertical = Dimens.md + 2.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        active.displayName,
+                        style = DisplaySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        statusLabel(status),
+                        style = MonoLabelTiny,
+                        color = statusColor(status),
+                    )
+                }
+                Text(
+                    if (expanded) "hide \u2191" else "change \u2193",
+                    style = MonoLabel.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+            if (status is AiStatus.Downloading) {
+                // Inline progress bar so the user sees download activity
+                // without leaving the Settings screen.
+                LinearProgressIndicator(
+                    progress = { status.fraction.coerceIn(0f, 1f) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = Dimens.lg)
+                        .padding(bottom = Dimens.md),
+                    color = MaterialTheme.colorScheme.primary,
+                    trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.18f),
+                )
+            }
+
+            if (expanded) {
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.background,
+                    thickness = Dimens.hairline,
+                )
+                catalog.forEachIndexed { index, desc ->
+                    if (index > 0) {
+                        HorizontalDivider(
+                            color = MaterialTheme.colorScheme.background,
+                            thickness = Dimens.hairline,
+                        )
+                    }
+                    CatalogEntryRow(
+                        descriptor = desc,
+                        isActive = desc.id == active.id,
+                        onClick = { onSelect(desc) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CatalogEntryRow(
+    descriptor: ModelDescriptor,
+    isActive: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = !isActive, onClick = onClick)
+            .padding(horizontal = Dimens.lg, vertical = Dimens.md + 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.Top,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                descriptor.displayName,
+                style = DisplaySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                descriptor.description,
+                style = SansBody,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.85f),
+            )
+            Spacer(Modifier.height(Dimens.xs))
+            Text(
+                "${formatSize(descriptor.sizeBytes)} \u00B7 needs ${descriptor.minDeviceMemoryGb}+ GB RAM",
+                style = MonoLabelTiny,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+            )
+            if (descriptor.notes != null) {
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    descriptor.notes,
+                    style = MonoLabelTiny,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                )
+            }
+        }
+        Spacer(Modifier.height(Dimens.xs))
+        Text(
+            if (isActive) "\u2713 active" else "select \u2192",
+            style = MonoLabel.copy(fontWeight = FontWeight.SemiBold),
+            color = if (isActive) MaterialTheme.colorScheme.primary
+            else MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
+        )
+    }
+}
+
+@Composable
+private fun statusLabel(status: AiStatus): String = when (status) {
+    is AiStatus.Ready -> "ready"
+    is AiStatus.Downloading -> "downloading ${(status.fraction * 100).toInt()}%"
+    is AiStatus.Failed -> "failed \u2014 tap to change model"
+    is AiStatus.Unavailable -> "unavailable \u2014 url is placeholder"
+    is AiStatus.Idle -> "not downloaded"
+}
+
+@Composable
+private fun statusColor(status: AiStatus): Color = when (status) {
+    is AiStatus.Ready -> MaterialTheme.colorScheme.primary
+    is AiStatus.Downloading -> MaterialTheme.colorScheme.primary
+    is AiStatus.Failed, is AiStatus.Unavailable ->
+        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+    is AiStatus.Idle -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+}
+
+/** "2.58 GB", "689 MB". Keeps the UI stable across locales without pulling in NumberFormat. */
+private fun formatSize(bytes: Long): String {
+    val gb = bytes.toDouble() / 1_000_000_000.0
+    if (gb >= 1.0) return "%.2f GB".format(gb)
+    val mb = bytes.toDouble() / 1_000_000.0
+    return "%.0f MB".format(mb)
 }
 
 @Composable
@@ -278,5 +527,26 @@ private fun OutlineAction(
             style = SansBody,
             color = MaterialTheme.colorScheme.onBackground,
         )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Preview — mirrors the production UI path but uses stub state so the
+// catalog section renders without Hilt wiring. Useful for design review
+// and for the PR body screenshot.
+// ─────────────────────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, backgroundColor = 0xFFE8EBD9)
+@Composable
+private fun ModelCatalogSectionPreview() {
+    UnReminderTheme {
+        Column(Modifier.padding(Dimens.xxl)) {
+            ModelCatalogSection(
+                catalog = ModelCatalog.all,
+                active = ModelCatalog.default,
+                status = AiStatus.Downloading(0.42f),
+                onSelect = {},
+            )
+        }
     }
 }

--- a/app/src/main/java/net/interstellarai/unreminder/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/settings/SettingsViewModel.kt
@@ -7,19 +7,32 @@ import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
+import androidx.work.workDataOf
 import net.interstellarai.unreminder.data.db.TriggerEntity
+import net.interstellarai.unreminder.data.repository.ActiveModelRepository
 import net.interstellarai.unreminder.data.repository.TriggerRepository
 import net.interstellarai.unreminder.domain.model.TriggerStatus
+import net.interstellarai.unreminder.service.llm.AiStatus
+import net.interstellarai.unreminder.service.llm.ModelCatalog
+import net.interstellarai.unreminder.service.llm.ModelDescriptor
+import net.interstellarai.unreminder.service.llm.PromptGenerator
 import net.interstellarai.unreminder.service.trigger.TriggerPipeline
 import net.interstellarai.unreminder.worker.DailySchedulerWorker
+import net.interstellarai.unreminder.worker.ModelDownloadWorker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import java.io.File
 import java.time.Instant
 import javax.inject.Inject
 
@@ -28,18 +41,33 @@ data class SettingsUiState(
     val hasFineLocationPermission: Boolean = false,
     val hasBackgroundLocationPermission: Boolean = false,
     val hasExactAlarmPermission: Boolean = false,
-    val testTriggered: Boolean = false
+    val testTriggered: Boolean = false,
 )
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val triggerPipeline: TriggerPipeline,
-    private val triggerRepository: TriggerRepository
+    private val triggerRepository: TriggerRepository,
+    private val activeModelRepository: ActiveModelRepository,
+    private val promptGenerator: PromptGenerator,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    /** Full catalog — rendered as a list in the Settings "AI model" section. */
+    val catalog: List<ModelDescriptor> = ModelCatalog.all
+
+    /** Currently-active descriptor, reflected live from DataStore. */
+    val activeModel: StateFlow<ModelDescriptor> = activeModelRepository.active
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ModelCatalog.default)
+
+    /** Coarse AI readiness — drives the status label next to the active model row. */
+    val aiStatus: StateFlow<AiStatus> = promptGenerator.aiStatus
+
+    /** 0..1 download fraction, or null when no download is active. */
+    val downloadProgress: StateFlow<Float?> = promptGenerator.downloadProgress
 
     fun refreshPermissions() {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
@@ -55,6 +83,54 @@ class SettingsViewModel @Inject constructor(
             ) == PackageManager.PERMISSION_GRANTED,
             hasExactAlarmPermission = alarmManager.canScheduleExactAlarms()
         )
+    }
+
+    /**
+     * Write the user's new selection + re-enqueue the download worker for
+     * the freshly selected model. The previous model's file is NOT deleted
+     * here; [deleteModelFile] is the separate action for that so users can
+     * confirm in the dialog.
+     */
+    fun selectModel(id: String) {
+        viewModelScope.launch {
+            activeModelRepository.setActive(id)
+            val desc = ModelCatalog.byId(id) ?: return@launch
+            // REPLACE so a currently-running download for a different model
+            // gets cancelled — otherwise the unique-work guard would silently
+            // drop the new enqueue. WorkManager cancels the old worker; its
+            // partial `.tmp` file stays on disk under the old filename (we
+            // can clean it up via deleteModelFile()).
+            val request = OneTimeWorkRequestBuilder<ModelDownloadWorker>()
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .setInputData(workDataOf(ModelDownloadWorker.KEY_MODEL_ID to desc.id))
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                ModelDownloadWorker.WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                request,
+            )
+        }
+    }
+
+    /**
+     * Delete on-disk files for any catalog model that isn't [keep]. Safe to
+     * call any time — missing files are just a no-op. Used by the "Delete now"
+     * branch of the confirmation dialog so users can free up ~2 GB when
+     * switching between models.
+     */
+    fun deleteOtherModelFiles(keep: ModelDescriptor) {
+        viewModelScope.launch {
+            ModelCatalog.all
+                .filter { it.id != keep.id }
+                .forEach { other ->
+                    File(context.filesDir, other.fileName).takeIf { it.exists() }?.delete()
+                    File(context.filesDir, "${other.fileName}.tmp").takeIf { it.exists() }?.delete()
+                }
+        }
     }
 
     fun testTriggerNow() = executeTrigger(onComplete = {

--- a/app/src/main/java/net/interstellarai/unreminder/worker/ModelDownloadWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/worker/ModelDownloadWorker.kt
@@ -15,7 +15,9 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import net.interstellarai.unreminder.R
 import net.interstellarai.unreminder.data.repository.ModelDownloadProgressRepository
+import net.interstellarai.unreminder.service.llm.ModelCatalog
 import net.interstellarai.unreminder.service.llm.ModelConfig
+import net.interstellarai.unreminder.service.llm.ModelDescriptor
 import net.interstellarai.unreminder.service.notification.NotificationHelper
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -26,21 +28,27 @@ import java.io.File
 import java.io.FileOutputStream
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
-import javax.inject.Named
 
 @HiltWorker
 class ModelDownloadWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val okHttpClient: OkHttpClient,
-    @Named("modelCdnUrl") private val modelUrl: String,
     private val progressRepository: ModelDownloadProgressRepository,
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
         const val WORK_NAME = "model_download"
         const val KEY_PROGRESS = "progress"
+        const val KEY_MODEL_ID = "modelId"
+
+        /**
+         * Legacy constant retained for backwards compatibility with tests and
+         * any cached WorkManager state from pre-catalog installs. New code
+         * must derive the filename from a [ModelDescriptor] instead.
+         */
         const val MODEL_FILENAME = "gemma3-1b-it-int4.task"
+
         private const val TAG = "ModelDownloadWorker"
 
         // Foreground-service notification id. Constant — the FGS is a singleton
@@ -51,20 +59,20 @@ class ModelDownloadWorker @AssistedInject constructor(
         /** Cap retry attempts so a genuinely broken URL doesn't loop forever. */
         const val MAX_ATTEMPTS = 5
 
-        // Magic-byte prefixes for the two model container formats LiteRT-LM
-        // understands. Verified on-wire against the HF-hosted bundles:
-        //   - `.litertlm` files begin with the ASCII bytes "LITERTLM".
-        //   - `.task` files are zip containers; stored-entry zips begin with
-        //     `PK\x03\x04`, empty-zips with `PK\x05\x06`.
-        // Any other prefix (e.g. `<!DOCTYPE` from an HTML error body, or
-        // zeroed bytes from a truncated write) means the download is corrupt
-        // and `Engine.initialize()` would later throw
-        // `LiteRtLmJniException: Unable to open zip archive`.
+        // Magic-byte prefixes accepted when a descriptor doesn't ship its own.
+        // Kept as a safety net; all catalog entries currently set magicPrefix
+        // explicitly, so these are only hit by the legacy non-catalog path.
         private val MAGIC_LITERTLM = byteArrayOf(0x4C, 0x49, 0x54, 0x45, 0x52, 0x54, 0x4C, 0x4D)
         private val MAGIC_ZIP_LOCAL = byteArrayOf(0x50, 0x4B, 0x03, 0x04)
         private val MAGIC_ZIP_EMPTY = byteArrayOf(0x50, 0x4B, 0x05, 0x06)
         private val KNOWN_MAGICS = listOf(MAGIC_LITERTLM, MAGIC_ZIP_LOCAL, MAGIC_ZIP_EMPTY)
     }
+
+    /**
+     * Resolved at [doWork] entry from the worker's inputData. Null only when
+     * the caller forgot to pass [KEY_MODEL_ID] — treated as a Result.failure().
+     */
+    private var descriptor: ModelDescriptor? = null
 
     /**
      * Called once by WorkManager before [doWork] so the worker has a valid
@@ -83,19 +91,33 @@ class ModelDownloadWorker @AssistedInject constructor(
             return Result.failure()
         }
 
+        // Resolve which model to download from the inputData. Default to the
+        // catalog default so historical callers that didn't pass a modelId
+        // still work (e.g. a WorkManager request persisted before this
+        // rolled out).
+        val modelId = inputData.getString(KEY_MODEL_ID) ?: ModelCatalog.default.id
+        val desc = ModelCatalog.byId(modelId)
+        if (desc == null) {
+            Log.e(TAG, "Unknown modelId='$modelId' — catalog has no matching entry")
+            return Result.failure()
+        }
+        descriptor = desc
+        val modelUrl = desc.url
+        val filename = desc.fileName
+
         // Promote to FGS up-front so the OS knows to keep us alive even if the
         // user presses HOME before the first progress tick lands.
         runCatching { setForeground(createForegroundInfo(progress = -1)) }
             .onFailure { Log.w(TAG, "setForeground(initial) failed — FGS may be throttled", it) }
 
-        val modelFile = File(applicationContext.filesDir, MODEL_FILENAME)
+        val modelFile = File(applicationContext.filesDir, filename)
         if (modelFile.exists()) {
             // Guard against a previously-persisted corrupt download: a truncated
             // body or an HTML error page saved under the final filename would
             // otherwise cause `Engine.initialize()` to throw
             // "Unable to open zip archive" on every app start forever, because
             // the old early-return below never re-fetched.
-            if (fileLooksValid(modelFile)) {
+            if (fileLooksValid(modelFile, desc)) {
                 progressRepository.clear()
                 return Result.success()
             }
@@ -108,13 +130,13 @@ class ModelDownloadWorker @AssistedInject constructor(
         if (ModelConfig.isPlaceholderUrl(modelUrl)) {
             Log.w(
                 TAG,
-                "MODEL_CDN_URL is a placeholder ($modelUrl) — skipping download. " +
-                    "Set the MODEL_CDN_URL secret in CI."
+                "Model '${desc.id}' has a placeholder URL ($modelUrl) — skipping download. " +
+                    "Self-host the file and point the catalog entry at it.",
             )
             return Result.failure()
         }
 
-        val tmpFile = File(applicationContext.filesDir, "$MODEL_FILENAME.tmp")
+        val tmpFile = File(applicationContext.filesDir, "$filename.tmp")
         return try {
             // Resume-from-partial: if a previous attempt wrote bytes to `.tmp`,
             // request only the remainder via a Range header instead of restarting
@@ -229,12 +251,13 @@ class ModelDownloadWorker @AssistedInject constructor(
                 return Result.retry()
             }
 
-            // Verify first 8 bytes match a known model-container magic. Catches
-            // HTML error bodies served with a 200 status (CDN 503 → maintenance
-            // page, region-locked, etc.) and any other garbage that would later
-            // surface as a cryptic `Unable to open zip archive` on-device.
-            if (!fileLooksValid(tmpFile)) {
-                val hex = readFirst8(tmpFile).joinToString(" ") { "%02x".format(it) }
+            // Verify first bytes match the descriptor's declared magic prefix.
+            // Catches HTML error bodies served with a 200 status (CDN 503 →
+            // maintenance page, region-locked, etc.) and any other garbage
+            // that would later surface as a cryptic `Unable to open zip
+            // archive` on-device.
+            if (!fileLooksValid(tmpFile, desc)) {
+                val hex = readFirst(tmpFile, 8).joinToString(" ") { "%02x".format(it) }
                 Log.w(TAG, "Download magic bytes unrecognised (got: $hex) — deleting and retrying")
                 tmpFile.delete()
                 return Result.retry()
@@ -277,11 +300,12 @@ class ModelDownloadWorker @AssistedInject constructor(
      */
     private fun createForegroundInfo(progress: Int): ForegroundInfo {
         val indeterminate = progress !in 0..100
+        val label = descriptor?.displayName ?: "AI model"
         val notification = NotificationCompat.Builder(
             applicationContext,
             NotificationHelper.MODEL_DOWNLOAD_CHANNEL_ID,
         )
-            .setContentTitle("Downloading AI model")
+            .setContentTitle("Downloading $label")
             .setContentText(if (indeterminate) "Preparing…" else "$progress%")
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setOngoing(true)
@@ -315,24 +339,31 @@ class ModelDownloadWorker @AssistedInject constructor(
     }
 
     /**
-     * True iff [file] starts with one of [KNOWN_MAGICS]. Non-existent or
-     * unreadable files are treated as invalid.
+     * True iff [file] starts with the magic declared by [desc]. Falls back to
+     * any of the known generic magics when [desc] is absent (legacy path).
+     * Non-existent or unreadable files are treated as invalid.
      */
-    private fun fileLooksValid(file: File): Boolean {
+    private fun fileLooksValid(file: File, desc: ModelDescriptor?): Boolean {
+        val expected = desc?.magicPrefix
+        if (expected != null) {
+            if (!file.exists() || file.length() < expected.size) return false
+            val first = readFirst(file, expected.size)
+            return first.contentEquals(expected)
+        }
         if (!file.exists() || file.length() < MAGIC_LITERTLM.size) return false
-        val first8 = readFirst8(file)
-        return KNOWN_MAGICS.any { expected ->
-            first8.take(expected.size).toByteArray().contentEquals(expected)
+        val first8 = readFirst(file, MAGIC_LITERTLM.size)
+        return KNOWN_MAGICS.any { magic ->
+            first8.take(magic.size).toByteArray().contentEquals(magic)
         }
     }
 
-    private fun readFirst8(file: File): ByteArray {
-        val buf = ByteArray(MAGIC_LITERTLM.size)
+    private fun readFirst(file: File, size: Int): ByteArray {
+        val buf = ByteArray(size)
         return try {
             file.inputStream().use { it.read(buf) }
             buf
         } catch (_: Exception) {
-            ByteArray(MAGIC_LITERTLM.size)
+            ByteArray(size)
         }
     }
 }

--- a/app/src/test/java/net/interstellarai/unreminder/data/repository/ActiveModelRepositoryTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/repository/ActiveModelRepositoryTest.kt
@@ -1,0 +1,125 @@
+package net.interstellarai.unreminder.data.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import androidx.datastore.preferences.core.stringPreferencesKey
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import net.interstellarai.unreminder.service.llm.ModelCatalog
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ActiveModelRepositoryTest {
+
+    private fun buildRepo(prefs: Preferences): ActiveModelRepository {
+        val dataStore: DataStore<Preferences> = mockk {
+            every { data } returns flowOf(prefs)
+        }
+        return ActiveModelRepository(dataStore)
+    }
+
+    @Test
+    fun `active defaults to ModelCatalog_default when no key is stored`() = runTest {
+        // Fresh-install contract: with no persisted id, users get the catalog
+        // default without any extra wiring in PromptGeneratorImpl.
+        val repo = buildRepo(mutablePreferencesOf())
+
+        val result = repo.active.first()
+
+        assertEquals(ModelCatalog.default, result)
+    }
+
+    @Test
+    fun `active returns stored descriptor when key resolves in the catalog`() = runTest {
+        val prefs = mutablePreferencesOf(
+            stringPreferencesKey("active_model_id") to ModelCatalog.gemma3_1B_Task.id,
+        )
+        val repo = buildRepo(prefs)
+
+        val result = repo.active.first()
+
+        assertEquals(ModelCatalog.gemma3_1B_Task, result)
+    }
+
+    @Test
+    fun `active falls back to default when persisted id is no longer in the catalog`() = runTest {
+        // Catalog shrinkage scenario: we removed a model between app versions.
+        // Users who picked that model must quietly revert to the current
+        // default instead of seeing a crash or an "unknown" state.
+        val prefs = mutablePreferencesOf(
+            stringPreferencesKey("active_model_id") to "retired-model-id",
+        )
+        val repo = buildRepo(prefs)
+
+        val result = repo.active.first()
+
+        assertEquals(ModelCatalog.default, result)
+    }
+
+    @Test
+    fun `peek returns the same value the flow emits`() = runTest {
+        val prefs = mutablePreferencesOf(
+            stringPreferencesKey("active_model_id") to ModelCatalog.gemma4E2BLitertlm.id,
+        )
+        val repo = buildRepo(prefs)
+
+        assertEquals(repo.active.first(), repo.peek())
+    }
+
+    @Test
+    fun `setActive writes the id into DataStore`() = runTest {
+        // Round-trip via the in-memory FakeDataStore: persistence contract is
+        // "after setActive(X), the underlying prefs map has the active_model_id
+        // key bound to X". The real DataStore is an async file-writer we can't
+        // exercise in a pure unit test.
+        val realStore = FakeDataStore()
+        val repo = ActiveModelRepository(realStore)
+
+        repo.setActive(ModelCatalog.gemma3_1B_Task.id)
+
+        assertEquals(
+            ModelCatalog.gemma3_1B_Task.id,
+            realStore.snapshot()[stringPreferencesKey("active_model_id")],
+        )
+    }
+
+    @Test
+    fun `round-trip setActive then active returns the new descriptor`() = runTest {
+        val realStore = FakeDataStore()
+        val repo = ActiveModelRepository(realStore)
+
+        repo.setActive(ModelCatalog.gemma3_1B_Task.id)
+        val result = repo.active.first()
+
+        assertEquals(ModelCatalog.gemma3_1B_Task, result)
+    }
+}
+
+/**
+ * Minimal in-memory DataStore<Preferences> for round-trip tests. Only supports
+ * the two operations [ActiveModelRepository] needs: a `data` flow and
+ * `updateData` (which `edit` delegates to). Kept private to this test file.
+ */
+private class FakeDataStore : DataStore<Preferences> {
+    private var current: Preferences = mutablePreferencesOf()
+    private val channel = kotlinx.coroutines.channels.Channel<Preferences>(
+        kotlinx.coroutines.channels.Channel.CONFLATED,
+    ).also { it.trySend(current) }
+
+    override val data: kotlinx.coroutines.flow.Flow<Preferences> = kotlinx.coroutines.flow.flow {
+        emit(current)
+    }
+
+    override suspend fun updateData(
+        transform: suspend (t: Preferences) -> Preferences,
+    ): Preferences {
+        current = transform(current)
+        return current
+    }
+
+    fun snapshot(): Preferences = current
+}

--- a/app/src/test/java/net/interstellarai/unreminder/service/llm/ModelCatalogTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/llm/ModelCatalogTest.kt
@@ -1,0 +1,144 @@
+package net.interstellarai.unreminder.service.llm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ModelCatalogTest {
+
+    @Test
+    fun `byId resolves every entry in all`() {
+        // Contract: every catalog entry is retrievable by its declared id,
+        // and the returned descriptor is identity-equal to the entry in
+        // `all` (no cloning).
+        ModelCatalog.all.forEach { entry ->
+            val resolved = ModelCatalog.byId(entry.id)
+            assertNotNull("byId returned null for '${entry.id}'", resolved)
+            assertSame("byId must return the canonical instance", entry, resolved)
+        }
+    }
+
+    @Test
+    fun `byId returns null for an unknown id`() {
+        assertNull(ModelCatalog.byId("definitely-not-in-the-catalog"))
+    }
+
+    @Test
+    fun `default is a member of all`() {
+        // Prevents the footgun where the default field is forgotten when the
+        // catalog list gets reshuffled, leaving `byId(default.id)` returning
+        // null on fresh installs.
+        assertTrue(
+            "ModelCatalog.default must appear in ModelCatalog.all",
+            ModelCatalog.all.any { it.id == ModelCatalog.default.id },
+        )
+    }
+
+    @Test
+    fun `catalog contains gemma-4 and gemma-3 fallback`() {
+        // The whole point of this PR: give users an escape hatch when Gemma 4
+        // fails to load. If either entry gets dropped this test catches it
+        // before release.
+        assertNotNull(ModelCatalog.byId("gemma-4-e2b-it-litertlm"))
+        assertNotNull(ModelCatalog.byId("gemma-3-1b-it-task"))
+    }
+
+    @Test
+    fun `every descriptor has plausible sizeBytes`() {
+        // Sanity floor/ceiling — on-device LLMs we ship are all between 100 MB
+        // and 10 GB. Catches a typo like "2580L" (2.5 KB) that would make the
+        // UI show "0.00 GB" and a user think the download was instant.
+        ModelCatalog.all.forEach { desc ->
+            assertTrue(
+                "${desc.id}: sizeBytes=${desc.sizeBytes} is implausibly small",
+                desc.sizeBytes >= 100_000_000L,
+            )
+            assertTrue(
+                "${desc.id}: sizeBytes=${desc.sizeBytes} is implausibly large",
+                desc.sizeBytes <= 10_000_000_000L,
+            )
+        }
+    }
+
+    @Test
+    fun `every descriptor has a non-empty magicPrefix`() {
+        // The worker uses magicPrefix for its post-download integrity check.
+        // A zero-length prefix would accept any download including HTML error
+        // bodies, which is the exact failure mode this PR's other tests guard
+        // against.
+        ModelCatalog.all.forEach { desc ->
+            assertTrue(
+                "${desc.id}: magicPrefix must not be empty",
+                desc.magicPrefix.isNotEmpty(),
+            )
+            assertTrue(
+                "${desc.id}: magicPrefix should be short enough to be a file header",
+                desc.magicPrefix.size in 2..16,
+            )
+        }
+    }
+
+    @Test
+    fun `each descriptor has a distinct fileName`() {
+        // Two descriptors sharing a filename would clobber each other on disk
+        // and silently corrupt the integrity check.
+        val filenames = ModelCatalog.all.map { it.fileName }
+        assertEquals(
+            "all catalog entries must have unique fileName values",
+            filenames.size,
+            filenames.toSet().size,
+        )
+    }
+
+    @Test
+    fun `each descriptor has a distinct id`() {
+        val ids = ModelCatalog.all.map { it.id }
+        assertEquals(
+            "all catalog entries must have unique id values",
+            ids.size,
+            ids.toSet().size,
+        )
+    }
+
+    @Test
+    fun `ModelDescriptor equals uses content equality for magicPrefix`() {
+        // Default data-class equals on a ByteArray field is reference equality,
+        // which makes set-membership and test assertions behave surprisingly.
+        // The overridden equals keeps tests stable when callers reconstruct a
+        // descriptor with a fresh byteArrayOf() call.
+        val a = ModelCatalog.gemma4E2BLitertlm
+        val b = a.copy(
+            magicPrefix = byteArrayOf(*a.magicPrefix),
+        )
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+
+        val c = a.copy(magicPrefix = byteArrayOf(0x00))
+        assertFalse("descriptors with different magicPrefix must not be equal", a == c)
+    }
+
+    @Test
+    fun `gemma-3 fallback entry is flagged as having a placeholder URL`() {
+        // Regression guard: if someone swaps the URL to a real CDN we should
+        // notice because downstream code (PromptGeneratorImpl.initialize())
+        // branches on ModelConfig.isPlaceholderUrl. This assertion is the
+        // canonical "are we still waiting for the self-host?" signal.
+        assertTrue(
+            "Gemma 3 descriptor is expected to keep its placeholder URL until " +
+                "we self-host the gated HF file",
+            ModelConfig.isPlaceholderUrl(ModelCatalog.gemma3_1B_Task.url),
+        )
+    }
+
+    @Test
+    fun `gemma-4 default entry has a real URL`() {
+        assertFalse(
+            "Gemma 4 default must ship with a real download URL, not the placeholder",
+            ModelConfig.isPlaceholderUrl(ModelCatalog.gemma4E2BLitertlm.url),
+        )
+    }
+}

--- a/app/src/test/java/net/interstellarai/unreminder/service/llm/ModelConfigTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/llm/ModelConfigTest.kt
@@ -33,4 +33,17 @@ class ModelConfigTest {
     fun `isPlaceholderUrl returns false for a real URL`() {
         assertFalse(ModelConfig.isPlaceholderUrl("https://cdn.example.com/gemma3-1b-it-int4.task"))
     }
+
+    @Test
+    fun `isPlaceholderUrl catches any URL on the placeholder_invalid host`() {
+        // Introduced with the model-catalog PR: multiple catalog entries may
+        // ship with different filenames under the same sentinel host. The old
+        // exact-match check missed those; the host-prefix check covers them.
+        assertTrue(
+            ModelConfig.isPlaceholderUrl("https://placeholder.invalid/gemma3-1b-it-int4.task"),
+        )
+        assertTrue(
+            ModelConfig.isPlaceholderUrl("https://placeholder.invalid/some-future-model.litertlm"),
+        )
+    }
 }

--- a/app/src/test/java/net/interstellarai/unreminder/service/llm/PromptGeneratorTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/llm/PromptGeneratorTest.kt
@@ -4,12 +4,15 @@ import android.content.Context
 import androidx.work.Data
 import androidx.work.WorkInfo
 import net.interstellarai.unreminder.data.db.HabitEntity
+import net.interstellarai.unreminder.data.repository.ActiveModelRepository
 import net.interstellarai.unreminder.worker.ModelDownloadWorker
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -112,7 +115,7 @@ class PromptGeneratorTest {
         // the old code would hand the corrupt file straight to LiteRT-LM,
         // catch the JNI exception, and leave the bad file on disk to fail the
         // same way on every subsequent app launch.
-        val modelFile = File(tempDir, ModelDownloadWorker.MODEL_FILENAME)
+        val modelFile = File(tempDir, ModelCatalog.default.fileName)
         modelFile.writeBytes("<!DOCTYPE html><html>oops</html>".toByteArray())
         assertTrue("precondition: corrupt model file must exist", modelFile.exists())
 
@@ -247,7 +250,7 @@ class PromptGeneratorTest {
     fun `initializeEngineFromFile tries GPU first then CPU then surfaces Failed when both throw`() {
         // Write a file with the LITE magic so the pre-flight modelFileLooksValid
         // check passes and we actually reach the engine construction path.
-        val modelFile = File(tempDir, ModelDownloadWorker.MODEL_FILENAME)
+        val modelFile = File(tempDir, ModelCatalog.default.fileName)
         modelFile.writeBytes(byteArrayOf(0x4C, 0x49, 0x54, 0x45) + ByteArray(16))
         assertTrue(modelFile.exists())
 
@@ -278,7 +281,7 @@ class PromptGeneratorTest {
     fun `initializeEngineFromFile still tries GPU first even when CPU would succeed`() {
         // Contract check: we don't silently prefer CPU. If GPU init throws, we
         // fall through to CPU and recover; if GPU succeeds we never touch CPU.
-        val modelFile = File(tempDir, ModelDownloadWorker.MODEL_FILENAME)
+        val modelFile = File(tempDir, ModelCatalog.default.fileName)
         modelFile.writeBytes(byteArrayOf(0x4C, 0x49, 0x54, 0x45) + ByteArray(16))
 
         val backendAttempts = mutableListOf<String>()
@@ -298,6 +301,63 @@ class PromptGeneratorTest {
 
         assertEquals("first attempt must be GPU", "gpu", backendAttempts.firstOrNull())
         assertEquals("CPU must be the fallback", listOf("gpu", "cpu"), backendAttempts)
+    }
+
+    // --- selected-model placeholder URL path ---
+    //
+    // When the user picks a catalog entry whose `url` is still a placeholder
+    // (e.g. Gemma 3 — gated on HuggingFace, no self-host yet), `initialize()`
+    // must surface AiStatus.Unavailable instead of silently attempting a
+    // download that can never succeed. This is the spec-called-out case in
+    // the PR: the fallback exists in the catalog but isn't downloadable
+    // until an ops follow-up.
+
+    @Test
+    fun `initialize sets AiStatus Unavailable when selected model has a placeholder URL`() = runTest {
+        val repo: ActiveModelRepository = mockk()
+        every { repo.active } returns flowOf(ModelCatalog.gemma3_1B_Task)
+        coEvery { repo.peek() } returns ModelCatalog.gemma3_1B_Task
+
+        val gen = PromptGeneratorImpl(
+            context = context,
+            activeModelRepository = repo,
+        )
+
+        gen.initialize()
+
+        assertEquals(
+            "Selecting a model with placeholder URL must yield Unavailable",
+            AiStatus.Unavailable,
+            gen.aiStatus.value,
+        )
+        assertNull(
+            "downloadProgress must stay null when AI is Unavailable",
+            gen.downloadProgress.value,
+        )
+    }
+
+    @Test
+    fun `initialize with no selection defaults to catalog default`() = runTest {
+        // Repo that returns null for peek() — hits the getOrNull() path.
+        val repo: ActiveModelRepository = mockk()
+        every { repo.active } returns flowOf(ModelCatalog.default)
+        coEvery { repo.peek() } returns ModelCatalog.default
+
+        val gen = PromptGeneratorImpl(
+            context = context,
+            activeModelRepository = repo,
+        )
+
+        // The default has a real URL, so we'd try to enqueue — WorkManager is
+        // unavailable in the unit-test env, which the impl catches and logs.
+        // The observable contract here is only "doesn't crash, doesn't set
+        // Unavailable".
+        gen.initialize()
+
+        assertTrue(
+            "Default model should not produce AiStatus.Unavailable",
+            gen.aiStatus.value !is AiStatus.Unavailable,
+        )
     }
 
 private fun buildWorkInfo(

--- a/app/src/test/java/net/interstellarai/unreminder/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/ui/settings/SettingsViewModelTest.kt
@@ -3,8 +3,12 @@ package net.interstellarai.unreminder.ui.settings
 import android.app.AlarmManager
 import android.content.Context
 import net.interstellarai.unreminder.data.db.TriggerEntity
+import net.interstellarai.unreminder.data.repository.ActiveModelRepository
 import net.interstellarai.unreminder.data.repository.TriggerRepository
 import net.interstellarai.unreminder.domain.model.TriggerStatus
+import net.interstellarai.unreminder.service.llm.AiStatus
+import net.interstellarai.unreminder.service.llm.ModelCatalog
+import net.interstellarai.unreminder.service.llm.PromptGenerator
 import net.interstellarai.unreminder.service.trigger.TriggerPipeline
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -12,6 +16,8 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -25,6 +31,8 @@ class SettingsViewModelTest {
 
     private lateinit var triggerRepository: TriggerRepository
     private lateinit var triggerPipeline: TriggerPipeline
+    private lateinit var activeModelRepository: ActiveModelRepository
+    private lateinit var promptGenerator: PromptGenerator
     private lateinit var context: Context
     private lateinit var viewModel: SettingsViewModel
 
@@ -35,13 +43,22 @@ class SettingsViewModelTest {
         Dispatchers.setMain(testDispatcher)
         triggerRepository = mockk(relaxUnitFun = true)
         triggerPipeline = mockk(relaxUnitFun = true)
+        activeModelRepository = mockk(relaxed = true) {
+            every { active } returns flowOf(ModelCatalog.default)
+        }
+        promptGenerator = mockk(relaxed = true) {
+            every { aiStatus } returns MutableStateFlow<AiStatus>(AiStatus.Idle)
+            every { downloadProgress } returns MutableStateFlow<Float?>(null)
+        }
         context = mockk(relaxed = true)
         every { context.getSystemService(Context.ALARM_SERVICE) } returns mockk<AlarmManager>(relaxed = true)
 
         viewModel = SettingsViewModel(
             context = context,
             triggerPipeline = triggerPipeline,
-            triggerRepository = triggerRepository
+            triggerRepository = triggerRepository,
+            activeModelRepository = activeModelRepository,
+            promptGenerator = promptGenerator,
         )
     }
 

--- a/app/src/test/java/net/interstellarai/unreminder/worker/ModelDownloadWorkerTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/worker/ModelDownloadWorkerTest.kt
@@ -1,6 +1,7 @@
 package net.interstellarai.unreminder.worker
 
 import android.content.Context
+import androidx.work.Data
 import androidx.work.ListenableWorker.Result
 import androidx.work.WorkerParameters
 import io.mockk.Called
@@ -15,7 +16,7 @@ import io.mockk.verify
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import net.interstellarai.unreminder.data.repository.ModelDownloadProgressRepository
-import net.interstellarai.unreminder.service.llm.ModelConfig
+import net.interstellarai.unreminder.service.llm.ModelCatalog
 import okhttp3.Call
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -35,11 +36,19 @@ class ModelDownloadWorkerTest {
     private val mockContext: Context = mockk(relaxed = true)
     private val mockWorkerParams: WorkerParameters = mockk(relaxed = true)
     private val mockOkHttpClient: OkHttpClient = mockk()
-    private val testModelUrl = "https://example.test/model.task"
     private val mockProgressRepository: ModelDownloadProgressRepository = mockk(relaxed = true)
 
     private lateinit var filesDir: File
     private lateinit var worker: ModelDownloadWorker
+
+    /**
+     * The worker now resolves URL + filename + magic from [ModelCatalog] using
+     * the `modelId` work-data key. Use Gemma 4 as the default test target
+     * because it has a non-placeholder URL (the worker short-circuits
+     * placeholder URLs to Result.failure() early).
+     */
+    private val defaultModel = ModelCatalog.gemma4E2BLitertlm
+    private val defaultFilename = defaultModel.fileName
 
     // 8-byte LITERTLM magic prefix + arbitrary padding to form a believable
     // model-file body in happy-path tests. The worker verifies size (via
@@ -47,11 +56,16 @@ class ModelDownloadWorkerTest {
     private val litertlmMagic = byteArrayOf(0x4C, 0x49, 0x54, 0x45, 0x52, 0x54, 0x4C, 0x4D)
     private val validModelBytes = litertlmMagic + "-fake-model-payload".toByteArray()
 
+    /** Build inputData containing [KEY_MODEL_ID] → [id]. */
+    private fun inputDataFor(id: String): Data =
+        Data.Builder().putString(ModelDownloadWorker.KEY_MODEL_ID, id).build()
+
     @Before
     fun setup() {
         filesDir = createTempDir()
         every { mockContext.filesDir } returns filesDir
         every { mockWorkerParams.runAttemptCount } returns 0
+        every { mockWorkerParams.inputData } returns inputDataFor(defaultModel.id)
         // `mockk(relaxed = true)` returns default values for non-suspend calls
         // but still throws for suspend functions — stub those explicitly so the
         // worker's `progressRepository.write(...)` / `clear()` calls don't
@@ -63,7 +77,6 @@ class ModelDownloadWorkerTest {
             mockContext,
             mockWorkerParams,
             mockOkHttpClient,
-            testModelUrl,
             mockProgressRepository,
         )
     }
@@ -79,7 +92,7 @@ class ModelDownloadWorkerTest {
     fun `doWork returns success immediately when valid model file already exists`() = runTest {
         // Existing file with valid LITERTLM magic bytes passes the pre-download
         // integrity check and short-circuits without hitting the network.
-        File(filesDir, ModelDownloadWorker.MODEL_FILENAME).writeBytes(validModelBytes)
+        File(filesDir, defaultFilename).writeBytes(validModelBytes)
 
         val result = worker.doWork()
 
@@ -107,8 +120,8 @@ class ModelDownloadWorkerTest {
         val result = worker.doWork()
 
         assertEquals(Result.success(), result)
-        assertTrue(File(filesDir, ModelDownloadWorker.MODEL_FILENAME).exists())
-        assertFalse(File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp").exists())
+        assertTrue(File(filesDir, defaultFilename).exists())
+        assertFalse(File(filesDir, "$defaultFilename.tmp").exists())
     }
 
     // --- size mismatch -> retry + cleanup ---
@@ -144,7 +157,7 @@ class ModelDownloadWorkerTest {
         val result = worker.doWork()
 
         assertEquals(Result.retry(), result)
-        val tmp = File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp")
+        val tmp = File(filesDir, "$defaultFilename.tmp")
         assertTrue(
             "tmp file should be retained so resume-from-partial can continue",
             tmp.exists(),
@@ -156,7 +169,7 @@ class ModelDownloadWorkerTest {
         )
         assertFalse(
             "model file should NOT exist when the download was truncated",
-            File(filesDir, ModelDownloadWorker.MODEL_FILENAME).exists(),
+            File(filesDir, defaultFilename).exists(),
         )
     }
 
@@ -186,11 +199,11 @@ class ModelDownloadWorkerTest {
         assertEquals(Result.retry(), result)
         assertFalse(
             "tmp file should be deleted on magic-byte mismatch",
-            File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp").exists(),
+            File(filesDir, "$defaultFilename.tmp").exists(),
         )
         assertFalse(
             "model file should NOT exist when the download has wrong magic",
-            File(filesDir, ModelDownloadWorker.MODEL_FILENAME).exists(),
+            File(filesDir, defaultFilename).exists(),
         )
     }
 
@@ -202,7 +215,7 @@ class ModelDownloadWorkerTest {
         // re-downloaded. A truncated or HTML body persisted under the final
         // filename meant AI mode was permanently broken until reinstall.
         val corruptExisting = "<!DOCTYPE html>oops".toByteArray()
-        File(filesDir, ModelDownloadWorker.MODEL_FILENAME).writeBytes(corruptExisting)
+        File(filesDir, defaultFilename).writeBytes(corruptExisting)
 
         val mockCall: Call = mockk()
         val mockResponse: Response = mockk()
@@ -220,7 +233,7 @@ class ModelDownloadWorkerTest {
         val result = worker.doWork()
 
         assertEquals(Result.success(), result)
-        val finalFile = File(filesDir, ModelDownloadWorker.MODEL_FILENAME)
+        val finalFile = File(filesDir, defaultFilename)
         assertTrue(finalFile.exists())
         assertTrue(
             "existing file should have been replaced with fresh download",
@@ -237,7 +250,6 @@ class ModelDownloadWorkerTest {
             mockContext,
             mockWorkerParams,
             mockOkHttpClient,
-            testModelUrl,
             mockProgressRepository,
         )
 
@@ -308,7 +320,7 @@ class ModelDownloadWorkerTest {
         // attempt will send `Range: bytes=<length>-` and continue. The
         // previous "delete on any failure" behaviour was the root cause of
         // the user-visible "went back to 0%" bug.
-        val tmpFile = File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp")
+        val tmpFile = File(filesDir, "$defaultFilename.tmp")
         // Simulate some prior progress so we can assert it survives.
         tmpFile.writeBytes(litertlmMagic + ByteArray(100))
         val priorLen = tmpFile.length()
@@ -325,7 +337,7 @@ class ModelDownloadWorkerTest {
 
     @Test
     fun `doWork preserves tmp and rethrows on cancellation`() = runTest {
-        val tmpFile = File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp")
+        val tmpFile = File(filesDir, "$defaultFilename.tmp")
         tmpFile.writeBytes(litertlmMagic + ByteArray(50))
         val priorLen = tmpFile.length()
         every { mockOkHttpClient.newCall(any<Request>()) } throws CancellationException("cancelled")
@@ -353,15 +365,23 @@ class ModelDownloadWorkerTest {
         assertEquals("gemma3-1b-it-int4.task", ModelDownloadWorker.MODEL_FILENAME)
     }
 
+    @Test
+    fun `KEY_MODEL_ID constant is defined`() {
+        assertEquals("modelId", ModelDownloadWorker.KEY_MODEL_ID)
+    }
+
     // --- placeholder URL guard ---
 
     @Test
-    fun `doWork returns failure and skips network when URL is the placeholder`() = runTest {
+    fun `doWork returns failure and skips network when catalog entry has placeholder URL`() = runTest {
+        // Gemma 3 descriptor in the catalog ships with a placeholder URL
+        // (HF-gated), so selecting it triggers the short-circuit path before
+        // any HTTP call lands.
+        every { mockWorkerParams.inputData } returns inputDataFor(ModelCatalog.gemma3_1B_Task.id)
         val placeholderWorker = ModelDownloadWorker(
             mockContext,
             mockWorkerParams,
             mockOkHttpClient,
-            ModelConfig.PLACEHOLDER_URL,
             mockProgressRepository,
         )
 
@@ -371,6 +391,61 @@ class ModelDownloadWorkerTest {
         verify { mockOkHttpClient wasNot Called }
     }
 
+    // --- unknown model id -> failure ---
+
+    @Test
+    fun `doWork returns failure when modelId is not in the catalog`() = runTest {
+        every { mockWorkerParams.inputData } returns inputDataFor("nonexistent-model-id")
+        val strayWorker = ModelDownloadWorker(
+            mockContext,
+            mockWorkerParams,
+            mockOkHttpClient,
+            mockProgressRepository,
+        )
+
+        val result = strayWorker.doWork()
+
+        assertEquals(Result.failure(), result)
+        verify { mockOkHttpClient wasNot Called }
+    }
+
+    // --- model id drives URL + filename ---
+
+    @Test
+    fun `doWork given a modelId uses that descriptor's URL and filename`() = runTest {
+        // Contract: swapping the modelId in inputData swaps the download
+        // target (URL written into the Request) and the on-disk filename
+        // without the caller needing to tell the worker directly.
+        every { mockWorkerParams.inputData } returns inputDataFor(defaultModel.id)
+
+        val capturedRequest = slot<Request>()
+        val mockCall: Call = mockk()
+        val mockResponse: Response = mockk()
+        val mockBody: ResponseBody = mockk()
+        every { mockOkHttpClient.newCall(capture(capturedRequest)) } returns mockCall
+        every { mockCall.execute() } returns mockResponse
+        every { mockResponse.isSuccessful } returns true
+        every { mockResponse.code } returns 200
+        every { mockResponse.body } returns mockBody
+        every { mockBody.contentLength() } returns validModelBytes.size.toLong()
+        every { mockBody.byteStream() } returns validModelBytes.inputStream()
+        every { mockBody.close() } just Runs
+        every { mockResponse.close() } just Runs
+
+        val result = worker.doWork()
+
+        assertEquals(Result.success(), result)
+        assertEquals(
+            "URL must come from the descriptor, not a constant",
+            defaultModel.url,
+            capturedRequest.captured.url.toString(),
+        )
+        assertTrue(
+            "final file must use the descriptor's fileName",
+            File(filesDir, defaultModel.fileName).exists(),
+        )
+    }
+
     // --- resume-from-partial semantics ---
 
     @Test
@@ -378,7 +453,7 @@ class ModelDownloadWorkerTest {
         // Pre-seed tmp with 100 bytes of "previous attempt" payload. The new
         // worker should see the tmp, send `Range: bytes=100-`, append the
         // remaining bytes returned as 206 Partial Content, then finalise.
-        val tmpFile = File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp")
+        val tmpFile = File(filesDir, "$defaultFilename.tmp")
         val firstHalf = litertlmMagic + ByteArray(92) { it.toByte() } // 100 bytes
         tmpFile.writeBytes(firstHalf)
 
@@ -407,7 +482,7 @@ class ModelDownloadWorkerTest {
             "bytes=100-",
             capturedRequest.captured.header("Range"),
         )
-        val finalFile = File(filesDir, ModelDownloadWorker.MODEL_FILENAME)
+        val finalFile = File(filesDir, defaultFilename)
         assertTrue("final file should exist", finalFile.exists())
         assertEquals(
             "final file should be the pre-existing partial + remainder",
@@ -427,7 +502,7 @@ class ModelDownloadWorkerTest {
         // Partial tmp is larger than the server's current total, or tmp is
         // corrupt somehow — 416 means "your Range is outside the resource".
         // The safe recovery is to drop the tmp and retry from zero.
-        val tmpFile = File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp")
+        val tmpFile = File(filesDir, "$defaultFilename.tmp")
         tmpFile.writeBytes(ByteArray(200))
 
         val mockCall: Call = mockk()
@@ -450,7 +525,7 @@ class ModelDownloadWorkerTest {
         // If we naively appended that to the existing tmp we'd double the
         // file size and the integrity check would fire. Worker must detect
         // the 200 and truncate the tmp before writing.
-        val tmpFile = File(filesDir, "${ModelDownloadWorker.MODEL_FILENAME}.tmp")
+        val tmpFile = File(filesDir, "$defaultFilename.tmp")
         tmpFile.writeBytes(ByteArray(100) { 0xAA.toByte() })
 
         val mockCall: Call = mockk()
@@ -469,23 +544,7 @@ class ModelDownloadWorkerTest {
         val result = worker.doWork()
 
         assertEquals(Result.success(), result)
-        val finalFile = File(filesDir, ModelDownloadWorker.MODEL_FILENAME)
+        val finalFile = File(filesDir, defaultFilename)
         assertTrue(finalFile.readBytes().contentEquals(validModelBytes))
-    }
-
-    @Test
-    fun `doWork returns failure and skips network when URL is blank`() = runTest {
-        val blankWorker = ModelDownloadWorker(
-            mockContext,
-            mockWorkerParams,
-            mockOkHttpClient,
-            "",
-            mockProgressRepository,
-        )
-
-        val result = blankWorker.doWork()
-
-        assertEquals(Result.failure(), result)
-        verify { mockOkHttpClient wasNot Called }
     }
 }


### PR DESCRIPTION
## Summary

Adds a `ModelCatalog` of on-device LLMs with a Settings selector so the user can switch between Gemma 4 (default) and Gemma 3 (fallback) without a reinstall. The download worker is now parameterised by a `modelId` work-data key rather than reading a single `BuildConfig.MODEL_CDN_URL`, so swapping models is a DataStore write + `WorkManager` re-enqueue.

- **Catalog** lives in `service/llm/ModelCatalog.kt`. Two entries today; adding more is ~6 lines against `ModelCatalog.all`.
- **Settings UI** gains an "ai model" section with expandable catalog rows, inline progress bar, and a switch-confirmation dialog offering "Switch & delete previous" vs "Switch & keep previous".
- **Fallback** to Gemma 3 exists in the catalog but its URL is a deliberate `placeholder.invalid/...` sentinel — the HF-hosted `.task` file is gated. Users who pick it see `AiStatus.Unavailable` with a note in the UI. A follow-up will self-host the file and swap in the real URL.
- **No automatic fallback** on failure — selection is user-initiated only, as requested.
- **GPU → CPU backend fallback** in `PromptGeneratorImpl` is untouched.

## Catalog entries

```kotlin
val gemma4E2BLitertlm = ModelDescriptor(
    id = "gemma-4-e2b-it-litertlm",
    displayName = "Gemma 4 E2B (LiteRT-LM)",
    description = "Latest Google Gemma 4 model, 2B parameters, multimodal. 2.58 GB download.",
    url = "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm",
    fileName = "gemma-4-e2b-it.litertlm",
    sizeBytes = 2_583_085_056L,
    magicPrefix = byteArrayOf(0x4C, 0x49, 0x54, 0x45, 0x52, 0x54, 0x4C, 0x4D),
    minDeviceMemoryGb = 8,
    notes = "Experimental. Some devices can't load .litertlm files yet.",
)

val gemma3_1B_Task = ModelDescriptor(
    id = "gemma-3-1b-it-task",
    displayName = "Gemma 3 1B (Task)",
    description = "Smaller, known-good Gemma 3 model. 700 MB download, text-only.",
    url = "https://placeholder.invalid/gemma3-1b-it-int4.task",
    fileName = "gemma3-1b-it-int4.task",
    sizeBytes = 689_000_000L,
    magicPrefix = byteArrayOf(0x50, 0x4B, 0x03, 0x04),
    minDeviceMemoryGb = 4,
    notes = "Fallback option. File is gated on HuggingFace — you must self-host or provide your own URL.",
)
```

## Settings UI (@Preview-able composable)

```kotlin
@Composable
private fun ModelCatalogSection(
    catalog: List<ModelDescriptor>,
    active: ModelDescriptor,
    status: AiStatus,
    onSelect: (ModelDescriptor) -> Unit,
    modifier: Modifier = Modifier,
) {
    var expanded by remember { mutableStateOf(false) }

    Column(modifier = modifier) {
        MonoSectionLabel("ai model")
        Spacer(Modifier.height(Dimens.md - 2.dp))
        Column(
            modifier = Modifier
                .fillMaxWidth()
                .background(MaterialTheme.colorScheme.surfaceVariant, UnReminderShapes.small),
        ) {
            // Active model row — always visible, tap to expand.
            Row(
                modifier = Modifier
                    .fillMaxWidth()
                    .clickable { expanded = !expanded }
                    .padding(horizontal = Dimens.lg, vertical = Dimens.md + 2.dp),
                horizontalArrangement = Arrangement.SpaceBetween,
                verticalAlignment = Alignment.CenterVertically,
            ) {
                Column(modifier = Modifier.weight(1f)) {
                    Text(active.displayName, style = DisplaySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant)
                    Spacer(Modifier.height(2.dp))
                    Text(statusLabel(status), style = MonoLabelTiny, color = statusColor(status))
                }
                Text(if (expanded) "hide ↑" else "change ↓",
                     style = MonoLabel.copy(fontWeight = FontWeight.SemiBold),
                     color = MaterialTheme.colorScheme.primary)
            }
            if (status is AiStatus.Downloading) {
                LinearProgressIndicator(
                    progress = { status.fraction.coerceIn(0f, 1f) },
                    modifier = Modifier.fillMaxWidth()
                        .padding(horizontal = Dimens.lg).padding(bottom = Dimens.md),
                    color = MaterialTheme.colorScheme.primary,
                )
            }
            if (expanded) {
                catalog.forEach { desc ->
                    CatalogEntryRow(
                        descriptor = desc,
                        isActive = desc.id == active.id,
                        onClick = { onSelect(desc) },
                    )
                }
            }
        }
    }
}

@Preview(showBackground = true, backgroundColor = 0xFFE8EBD9)
@Composable
private fun ModelCatalogSectionPreview() {
    UnReminderTheme {
        Column(Modifier.padding(Dimens.xxl)) {
            ModelCatalogSection(
                catalog = ModelCatalog.all,
                active = ModelCatalog.default,
                status = AiStatus.Downloading(0.42f),
                onSelect = {},
            )
        }
    }
}
```

Each catalog row renders name, description, size + min-RAM hint, and any `notes`. Tap an inactive row to pop the confirmation dialog.

## Test plan

- [x] `./gradlew test` — 169 tests pass (was 158; +11 new assertions across ModelCatalog, ActiveModelRepository, ModelDownloadWorker, PromptGenerator, ModelConfig)
- [x] `./gradlew lint` — clean
- [x] `./gradlew assembleDebug` — builds
- [ ] Sideload the debug APK, open Settings, confirm the "ai model" section renders with the active row + expandable list
- [ ] Tap Gemma 3 → confirmation dialog → "Switch & keep previous" → observe `AiStatus.Unavailable` + placeholder-URL notes
- [ ] Tap Gemma 4 again → confirmation dialog → "Switch & delete previous" → download resumes

## Notes for reviewers

- `BuildConfig.MODEL_CDN_URL` is still emitted by `build.gradle.kts` (CI keeps setting the secret); the new code just doesn't read it. Safe to leave the secret in GitHub.
- `ModelConfig.isPlaceholderUrl` was widened from an exact-string match to a host-prefix match so multiple catalog entries can share the `placeholder.invalid` sentinel safely.
- `WorkManager` uniqueness-by-name is preserved (`WORK_NAME = "model_download"`). Selection switches use `ExistingWorkPolicy.REPLACE` so the old download gets cancelled instead of being ignored. The old model's `.tmp` file survives (for possible future resumption) unless the user picks "delete previous" in the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)