### PR TITLE
fix: move randomization from Kotlin to SQL to fix flaky test

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/data/db/VariationDao.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/VariationDao.kt
@@ -10,7 +10,7 @@ import java.time.Instant
 interface VariationDao {
 
     /** Returns up to [limit] unconsumed variations for [habitId]. */
-    @Query("SELECT * FROM variations WHERE habit_id = :habitId AND consumed_at IS NULL LIMIT :limit")
+    @Query("SELECT * FROM variations WHERE habit_id = :habitId AND consumed_at IS NULL ORDER BY RANDOM() LIMIT :limit")
     suspend fun getUnusedForHabit(habitId: Long, limit: Int): List<VariationEntity>
 
     /** Returns the number of rows updated (1 on success, 0 if already consumed or deleted). */

--- a/app/src/main/java/net/interstellarai/unreminder/data/repository/VariationRepository.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/repository/VariationRepository.kt
@@ -24,7 +24,7 @@ class VariationRepository @Inject constructor(
      * The returned entity is already marked consumed; do not call [VariationDao.markConsumed] again.
      */
     suspend fun pickRandomUnused(habitId: Long): VariationEntity? {
-        val unused = dao.getUnusedForHabit(habitId, POOL_SIZE).shuffled()
+        val unused = dao.getUnusedForHabit(habitId, POOL_SIZE)
         // Truncate to millis so the returned copy matches Room's epoch-millis storage
         val now = Instant.ofEpochMilli(Instant.now().toEpochMilli())
         for (candidate in unused) {

--- a/app/src/main/java/net/interstellarai/unreminder/data/repository/VariationRepository.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/repository/VariationRepository.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import net.interstellarai.unreminder.data.db.VariationDao
 import net.interstellarai.unreminder.data.db.VariationEntity
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -26,7 +27,7 @@ class VariationRepository @Inject constructor(
     suspend fun pickRandomUnused(habitId: Long): VariationEntity? {
         val unused = dao.getUnusedForHabit(habitId, POOL_SIZE)
         // Truncate to millis so the returned copy matches Room's epoch-millis storage
-        val now = Instant.ofEpochMilli(Instant.now().toEpochMilli())
+        val now = Instant.now().truncatedTo(ChronoUnit.MILLIS)
         for (candidate in unused) {
             val updated = dao.markConsumed(candidate.id, now)
             if (updated == 1) {


### PR DESCRIPTION
## Summary

Fixed CI build failure (flaky test) by moving randomization from Kotlin to SQL layer.

The `VariationRepositoryTest.pickRandomUnused` test was failing non-deterministically because:
- Repository called `.shuffled()` on the DAO result list, making mock iteration order unpredictable
- Test expected a specific mock order `[stale, good]` but `.shuffled()` would randomly reorder it
- When `good` was tried first, `markConsumed(99L)` was never called, causing `coVerify` to fail

## Changes

**File**: `app/src/main/java/net/interstellarai/unreminder/data/db/VariationDao.kt`
- Added `ORDER BY RANDOM()` to `getUnusedForHabit` query for stable, testable randomization

**File**: `app/src/main/java/net/interstellarai/unreminder/data/repository/VariationRepository.kt`
- Removed redundant `.shuffled()` call to enable deterministic test iteration

## Why this fix works

Moving randomization to the SQL layer (`ORDER BY RANDOM()`) means:
- **In tests**: Mock returns a fixed list in predictable order → repository iterates deterministically ✅
- **In production**: SQL shuffles rows randomly → repository gets randomized candidates ✅
- **Result**: Flaky test is now deterministic, CI passes consistently

## Validation

- Code reviewed and verified against investigation plan
- Changes match the scope identified in root cause analysis (2 one-line edits)
- Full test suite validation will run in CI

Fixes #78