### PR TITLE
worker: fix KV id + bump maxTokens for reasoning models

### DIFF
--- a/worker/src/lib/requesty.ts
+++ b/worker/src/lib/requesty.ts
@@ -17,7 +17,7 @@ export async function callRequesty(
   apiKey: string,
   model: string,
   prompt: string,
-  maxTokens = 200,
+  maxTokens = 2048,
   temperature = 0.7,
 ): Promise<RequestyResult> {
   const resp = await fetch(REQUESTY_URL, {
@@ -60,7 +60,7 @@ export async function callRequestyWithSchemaRetry<T>(
   prompt: string,
   stricterPrompt: string,
   validate: (parsed: unknown) => T | null,
-  maxTokens = 200,
+  maxTokens = 2048,
   temperature = 0.7,
 ): Promise<{ data: T; outputTokens: number; inputTokens: number } | null> {
   let totalOutputTokens = 0

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -9,11 +9,11 @@ compatibility_date = "2026-04-18"
 [vars]
 UR_DAILY_CAP_CENTS  = "50"
 UR_MONTHLY_CAP_CENTS = "500"
-UR_MODEL = "gemini-3-flash-preview"
+UR_MODEL = "google/gemini-3-flash-preview"
 
 [[kv_namespaces]]
 binding = "UR_SPEND"
-id      = "REPLACE_WITH_REAL_ID"          # run: wrangler kv namespace create UR_SPEND
+id      = "ba35d7eb3c4b4e46b18707a20ce89d1e"
 
 [[ratelimits]]
 name         = "REQUEST_LIMITER"


### PR DESCRIPTION
## Summary
Two tiny post-scaffold fixes caught when first actually deploying the worker:

1. `wrangler.toml`: KV namespace id was still the `REPLACE_WITH_REAL_ID` placeholder from the Phase 0 scaffold (#67). Replaced with the actual id from `wrangler kv namespace create UR_SPEND`.
2. `lib/requesty.ts`: `callRequesty` default `maxTokens` was 200. Our configured `UR_MODEL` = \`google/gemini-3-flash-preview\` is a reasoning model that consumes ~80 output tokens on internal thinking before emitting content — enough to truncate the JSON reply. Bumped to 2048 (well within Gemini 3 Flash's budget).

Verified both by calling /v1/habit-fields against the live deployment at https://un-reminder-worker.alexsiri7.workers.dev — returns valid structured content.

## Test plan
- [x] \`wrangler deploy\` clean.
- [x] \`curl /v1/health\` → 200 with spend counters.
- [x] \`curl /v1/habit-fields\` with valid secret → 200 JSON with fullDescription + lowFloorDescription.
- [x] \`curl /v1/habit-fields\` with no secret → 401.