### PR TITLE
fix: address remaining PR #86 review findings

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/trigger/TriggerPipeline.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/trigger/TriggerPipeline.kt
@@ -112,6 +112,7 @@ class TriggerPipeline @Inject constructor(
         val variation = try {
             variationRepository.pickRandomUnused(habit.id)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Log.w(TAG, "variationRepository.pickRandomUnused failed — falling back to habit.name", e)
             null
         }
@@ -122,6 +123,7 @@ class TriggerPipeline @Inject constructor(
                     refillScheduler.enqueueForHabit(habit.id)
                 }
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Log.w(TAG, "needsRefill/enqueue failed — non-fatal, continuing", e)
             }
             return variation.text
@@ -135,6 +137,7 @@ class TriggerPipeline @Inject constructor(
         try {
             refillScheduler.enqueueForHabit(habit.id)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Log.w(TAG, "refill enqueue failed for habit=${habit.id} — non-fatal", e)
         }
         return habit.name

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
@@ -74,8 +74,8 @@ class HabitEditViewModel @Inject constructor(
         promptGenerator.aiStatus,
     ) { useCloud, url, secret, onDeviceStatus ->
         if (!useCloud) onDeviceStatus
-        else if (url.isBlank() && secret.isBlank()) AiStatus.Unavailable
-        // TODO Phase 5: add pool-empty signal here once VariationRepository exposes
+        else if (url.isBlank() || secret.isBlank()) AiStatus.Unavailable
+        // TODO: add pool-empty signal here once VariationRepository exposes
         // a reactive count flow. AiStatus.Empty UI branches are forward-compatible
         // scaffolding — they will never be reached until this is wired.
         else AiStatus.Ready

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitListViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitListViewModel.kt
@@ -38,8 +38,8 @@ class HabitListViewModel @Inject constructor(
         promptGenerator.aiStatus,
     ) { useCloud, url, secret, onDeviceStatus ->
         if (!useCloud) onDeviceStatus
-        else if (url.isBlank() && secret.isBlank()) AiStatus.Unavailable
-        // TODO Phase 5: add pool-empty signal here once VariationRepository exposes
+        else if (url.isBlank() || secret.isBlank()) AiStatus.Unavailable
+        // TODO: add pool-empty signal here once VariationRepository exposes
         // a reactive count flow. AiStatus.Empty UI branches are forward-compatible
         // scaffolding — they will never be reached until this is wired.
         else AiStatus.Ready

--- a/app/src/test/java/net/interstellarai/unreminder/service/trigger/TriggerPipelineTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/trigger/TriggerPipelineTest.kt
@@ -245,6 +245,19 @@ class TriggerPipelineTest {
     }
 
     @Test
+    fun `flag ON pickRandomUnused throws - falls back to habit name and enqueues refill`() = runTest {
+        coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
+        coEvery { habitRepository.getEligibleHabits(any(), any()) } returns listOf(testHabit)
+        every { featureFlagsRepository.useCloudPool } returns flowOf(true)
+        coEvery { variationRepository.pickRandomUnused(1L) } throws RuntimeException("db error")
+
+        pipeline.execute(42L)
+
+        coVerify { triggerRepository.updateFired(42L, 1L, "meditation") }
+        coVerify { refillScheduler.enqueueForHabit(1L) }
+    }
+
+    @Test
     fun `flag OFF - uses promptGenerator and does not touch variationRepository`() = runTest {
         coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
         coEvery { habitRepository.getEligibleHabits(any(), any()) } returns listOf(testHabit)


### PR DESCRIPTION
## Summary

Addresses review findings from the comprehensive review of PR #86 (Phase 4: switch notification path to pool) that were not covered by the prior fix commit.

- **HIGH**: Add `CancellationException` re-throw to 3 inner `catch (e: Exception)` blocks in `TriggerPipeline.resolvePrompt()` — the outer catch had the guard but the inner blocks swallowed cancellation, violating structured concurrency
- **MEDIUM**: Change `&&` to `||` in aiStatus `Unavailable` check in both `HabitEditViewModel` and `HabitListViewModel` — aligns UI with `RefillWorker`'s independent blank checks so partial config shows "Unavailable" instead of false "Ready"
- **MEDIUM**: Remove "Phase 5" prefix from TODO comments — Phase 5 in the project scope is "delete on-device LLM code", not the pool-empty signal wiring
- **MEDIUM**: Add test for `pickRandomUnused` exception fallback path in `TriggerPipelineTest`

## Test plan

- [ ] Existing TriggerPipelineTest tests still pass (cloud path, on-device path, pool-empty)
- [ ] New test `flag ON pickRandomUnused throws - falls back to habit name and enqueues refill` passes
- [ ] HabitEditViewModelTest and HabitListViewModelTest `aiStatus is Unavailable when cloud flag ON and worker url blank` tests still pass (both URL and secret are blank in those tests, so `||` vs `&&` doesn't change the result)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)