### PR TITLE
test: add regression tests for PR #87 review findings

### DIFF
--- a/app/src/test/java/net/interstellarai/unreminder/service/trigger/TriggerPipelineTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/trigger/TriggerPipelineTest.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import kotlin.coroutines.cancellation.CancellationException
 import org.junit.Before
 import org.junit.Test
 import java.time.Instant
@@ -255,6 +257,23 @@ class TriggerPipelineTest {
 
         coVerify { triggerRepository.updateFired(42L, 1L, "meditation") }
         coVerify { refillScheduler.enqueueForHabit(1L) }
+    }
+
+    @Test
+    fun `flag ON pickRandomUnused throws CancellationException - propagates`() = runTest {
+        coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
+        coEvery { habitRepository.getEligibleHabits(any(), any()) } returns listOf(testHabit)
+        every { featureFlagsRepository.useCloudPool } returns flowOf(true)
+        coEvery { variationRepository.pickRandomUnused(1L) } throws CancellationException("cancelled")
+
+        try {
+            pipeline.execute(42L)
+            fail("Expected CancellationException to propagate")
+        } catch (e: CancellationException) {
+            // expected
+        }
+
+        coVerify(exactly = 0) { triggerRepository.updateFired(any(), any(), any()) }
     }
 
     @Test

--- a/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModelTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModelTest.kt
@@ -444,6 +444,38 @@ class HabitEditViewModelTest {
     }
 
     @Test
+    fun `aiStatus is Unavailable when cloud ON and url blank but secret non-blank`() = runTest(testDispatcher) {
+        every { mockFeatureFlagsRepository.useCloudPool } returns flowOf(true)
+        every { mockWorkerSettingsRepository.effectiveWorkerUrl } returns flowOf("")
+        every { mockWorkerSettingsRepository.effectiveWorkerSecret } returns flowOf("secret")
+        val vm = HabitEditViewModel(
+            mockHabitRepository, mockLocationRepository, mockPromptGenerator,
+            mockRequestyProxyClient, mockWorkerSettingsRepository, mockRefillScheduler,
+            mockVariationRepository, mockFeatureFlagsRepository,
+        )
+        val job = launch { vm.aiStatus.collect {} }
+        advanceUntilIdle()
+        assertEquals(AiStatus.Unavailable, vm.aiStatus.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `aiStatus is Unavailable when cloud ON and secret blank but url non-blank`() = runTest(testDispatcher) {
+        every { mockFeatureFlagsRepository.useCloudPool } returns flowOf(true)
+        every { mockWorkerSettingsRepository.effectiveWorkerUrl } returns flowOf("https://worker.example.com")
+        every { mockWorkerSettingsRepository.effectiveWorkerSecret } returns flowOf("")
+        val vm = HabitEditViewModel(
+            mockHabitRepository, mockLocationRepository, mockPromptGenerator,
+            mockRequestyProxyClient, mockWorkerSettingsRepository, mockRefillScheduler,
+            mockVariationRepository, mockFeatureFlagsRepository,
+        )
+        val job = launch { vm.aiStatus.collect {} }
+        advanceUntilIdle()
+        assertEquals(AiStatus.Unavailable, vm.aiStatus.value)
+        job.cancel()
+    }
+
+    @Test
     fun `aiStatus is Ready when cloud ON and worker configured`() = runTest(testDispatcher) {
         every { mockFeatureFlagsRepository.useCloudPool } returns flowOf(true)
         every { mockWorkerSettingsRepository.effectiveWorkerUrl } returns flowOf("https://worker.example.com")

--- a/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitListViewModelTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitListViewModelTest.kt
@@ -61,6 +61,30 @@ class HabitListViewModelTest {
     }
 
     @Test
+    fun `aiStatus is Unavailable when cloud ON and url blank but secret non-blank`() = runTest(testDispatcher) {
+        every { mockFeatureFlags.useCloudPool } returns flowOf(true)
+        every { mockWorkerSettings.effectiveWorkerUrl } returns flowOf("")
+        every { mockWorkerSettings.effectiveWorkerSecret } returns flowOf("secret")
+        val vm = buildViewModel()
+        val job = launch { vm.aiStatus.collect {} }
+        advanceUntilIdle()
+        assertEquals(AiStatus.Unavailable, vm.aiStatus.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `aiStatus is Unavailable when cloud ON and secret blank but url non-blank`() = runTest(testDispatcher) {
+        every { mockFeatureFlags.useCloudPool } returns flowOf(true)
+        every { mockWorkerSettings.effectiveWorkerUrl } returns flowOf("https://worker.example.com")
+        every { mockWorkerSettings.effectiveWorkerSecret } returns flowOf("")
+        val vm = buildViewModel()
+        val job = launch { vm.aiStatus.collect {} }
+        advanceUntilIdle()
+        assertEquals(AiStatus.Unavailable, vm.aiStatus.value)
+        job.cancel()
+    }
+
+    @Test
     fun `aiStatus is Ready when cloud ON and url non-blank`() = runTest(testDispatcher) {
         every { mockFeatureFlags.useCloudPool } returns flowOf(true)
         every { mockWorkerSettings.effectiveWorkerUrl } returns flowOf("https://worker.example.com")


### PR DESCRIPTION
## Summary

- Add asymmetric tests for `||` vs `&&` in `aiStatus` derivation (url-blank/secret-set and url-set/secret-blank) to both `HabitEditViewModelTest` and `HabitListViewModelTest` — these guard the core `&&` → `||` logic fix from PR #87
- Add `CancellationException` propagation test to `TriggerPipelineTest` — verifies structured concurrency guards added in PR #87 are not accidentally removed

## Context

PR #87 fixed three review findings from PR #86. The [automated review](https://github.com/alexsiri7/un-reminder/pull/87#issuecomment-4283231375) identified that existing tests passed with either `&&` or `||` (because they set both url and secret to blank simultaneously), meaning a regression would be invisible to CI. This PR closes that gap.

## Test plan

- [x] All new tests pass locally (`./gradlew testDebugUnitTest`)
- [x] Asymmetric tests would fail if `||` reverted to `&&`
- [x] CancellationException test would fail if re-throw guard removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)