### PR TITLE
Fix: add imePadding to prevent keyboard overlap in feedback form

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,7 +67,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.UnReminder">
+            android:theme="@style/Theme.UnReminder"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/net/interstellarai/unreminder/ui/feedback/FeedbackScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/feedback/FeedbackScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -116,6 +117,7 @@ fun FeedbackScreen(
         Column(
             modifier = Modifier
                 .padding(padding)
+                .imePadding()
                 .padding(16.dp)
                 .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(12.dp)


### PR DESCRIPTION
## Summary

Fixes #90 by adding the missing `imePadding()` modifier to the scrollable Column in the feedback form. When the soft keyboard appears during composition, it now properly pushes content above it instead of overlapping the screenshot.

## Root Cause

When `MainActivity` calls `enableEdgeToEdge()`, the IME (soft keyboard) draws over the window rather than resizing it. The `FeedbackScreen` Column lacked the `imePadding()` modifier to consume IME window insets, causing the screenshot and form elements to be hidden behind the keyboard.

## Changes

### `app/src/main/java/net/interstellarai/unreminder/ui/feedback/FeedbackScreen.kt`
- Added `imePadding` import from `androidx.compose.foundation.layout`
- Added `.imePadding()` modifier to the scrollable Column (after `.padding(padding)`)

### `app/src/main/AndroidManifest.xml`
- Added `android:windowSoftInputMode="adjustResize"` to MainActivity for predictable IME behavior

## Validation

✅ Type checking: No errors (4 pre-existing deprecation warnings in unrelated file)  
✅ Lint: No errors  
✅ Tests: 261 passed, 0 failed  
✅ Build: assembleDebug compiled successfully

All validation checks passed. The implementation follows the standard Compose `imePadding()` pattern and is non-intrusive to existing code.

## References

- Addresses regression noted in #90
- Related to previous fix #48 which capped screenshot height

Fixes #90