### PR TITLE
fix: address PR #100 review findings

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
@@ -19,10 +19,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -580,6 +580,7 @@ private fun QueuedNotificationsSection(
 ) {
     var expanded by remember { mutableStateOf(false) }
     val formatter = remember { DateTimeFormatter.ofPattern("MMM d · HH:mm") }
+    val dateOnlyFormatter = remember { DateTimeFormatter.ofPattern("MMM d") }
 
     Column(modifier = modifier.fillMaxWidth()) {
         // Header row — always visible, toggles expansion
@@ -624,7 +625,7 @@ private fun QueuedNotificationsSection(
                     if (lastRefilled != null) {
                         append(" · last refilled: ")
                         append(lastRefilled.atZone(ZoneId.systemDefault()).format(
-                            DateTimeFormatter.ofPattern("MMM d")
+                            dateOnlyFormatter
                         ))
                     }
                 },

--- a/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModelTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModelTest.kt
@@ -475,6 +475,27 @@ class HabitEditViewModelTest {
         job.cancel()
     }
 
+    // --- deleteVariation ---
+
+    @Test
+    fun `deleteVariation delegates to repository`() = runTest(testDispatcher) {
+        viewModel.deleteVariation(42L)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { mockVariationRepository.deleteById(42L) }
+    }
+
+    @Test
+    fun `deleteVariation swallows non-cancellation exceptions`() = runTest(testDispatcher) {
+        coEvery { mockVariationRepository.deleteById(any()) } throws RuntimeException("DB error")
+
+        viewModel.deleteVariation(42L)
+        advanceUntilIdle()
+
+        // No crash, no error state change — silently logged
+        assertNull(viewModel.uiState.value.errorMessage)
+    }
+
     @Test
     fun `aiStatus is Ready when cloud ON and worker configured`() = runTest(testDispatcher) {
         every { mockFeatureFlagsRepository.useCloudPool } returns flowOf(true)


### PR DESCRIPTION
## Summary

- Fix import ordering in `HabitEditScreen.kt`: restore alphabetical order for material3 imports
- Fix `DateTimeFormatter` reallocation: use `remember`-ed instance instead of inline `DateTimeFormatter.ofPattern()` on every recomposition
- Add 2 unit tests for `deleteVariation` in `HabitEditViewModelTest.kt`: delegation verification and error-swallowing behavior

## Context

Follow-up to PR #100 (already merged). These fixes address findings from the automated comprehensive review.

**Review findings addressed:**
| Severity | Issue | Status |
|----------|-------|--------|
| HIGH | `deleteVariation` untested | ✅ Tests added |
| LOW | Import ordering | ✅ Fixed |
| LOW | Inline DateTimeFormatter | ✅ Fixed |

**Remaining (not addressed — require user decision):**
| Severity | Issue | Recommendation |
|----------|-------|---------------|
| MEDIUM | DAO Flow queries untested | Create follow-up issue |
| MEDIUM | ViewModel StateFlows untested | Create follow-up issue |
| LOW | Repository delegation untested | Optional |

## Test plan

- [ ] CI passes (Build & test)
- [ ] Verify `deleteVariation delegates to repository` test passes
- [ ] Verify `deleteVariation swallows non-cancellation exceptions` test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)