### PR TITLE
Feature: associate time windows with habits

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/data/db/AppDatabase.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/AppDatabase.kt
@@ -11,10 +11,11 @@ import androidx.room.TypeConverters
         TriggerEntity::class,
         LocationEntity::class,
         HabitLocationCrossRef::class,
+        HabitWindowCrossRef::class,
         PendingFeedbackEntity::class,
         VariationEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -24,6 +25,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun triggerDao(): TriggerDao
     abstract fun locationDao(): LocationDao
     abstract fun habitLocationCrossRefDao(): HabitLocationCrossRefDao
+    abstract fun habitWindowCrossRefDao(): HabitWindowCrossRefDao
     abstract fun pendingFeedbackDao(): PendingFeedbackDao
     abstract fun variationDao(): VariationDao
 }

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/HabitDao.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/HabitDao.kt
@@ -45,6 +45,18 @@ interface HabitDao {
                 WHERE hl.habit_id = h.id AND hl.location_id IN (:locationIds)
             )
         )
+        AND (
+            NOT EXISTS (SELECT 1 FROM habit_window hw WHERE hw.habit_id = h.id)
+            OR EXISTS (
+                SELECT 1 FROM habit_window hw
+                JOIN windows w ON w.id = hw.window_id
+                WHERE hw.habit_id = h.id
+                  AND w.active = 1
+                  AND w.start_time <= :currentSecondOfDay
+                  AND w.end_time >= :currentSecondOfDay
+                  AND (w.days_of_week_bitmask & :dayOfWeekBit) != 0
+            )
+        )
         AND h.id NOT IN (
             SELECT habit_id FROM triggers
             WHERE habit_id IS NOT NULL
@@ -52,5 +64,10 @@ interface HabitDao {
             AND fired_at > :excludeAfter
         )
     """)
-    suspend fun getEligibleHabits(locationIds: List<Long>, excludeAfter: Long): List<HabitEntity>
+    suspend fun getEligibleHabits(
+        locationIds: List<Long>,
+        excludeAfter: Long,
+        currentSecondOfDay: Int,
+        dayOfWeekBit: Int
+    ): List<HabitEntity>
 }

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/HabitWindowCrossRef.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/HabitWindowCrossRef.kt
@@ -1,0 +1,22 @@
+package net.interstellarai.unreminder.data.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+@Entity(
+    tableName = "habit_window",
+    primaryKeys = ["habit_id", "window_id"],
+    indices = [Index("window_id")],
+    foreignKeys = [
+        ForeignKey(entity = HabitEntity::class, parentColumns = ["id"],
+            childColumns = ["habit_id"], onDelete = ForeignKey.CASCADE),
+        ForeignKey(entity = WindowEntity::class, parentColumns = ["id"],
+            childColumns = ["window_id"], onDelete = ForeignKey.CASCADE)
+    ]
+)
+data class HabitWindowCrossRef(
+    @ColumnInfo(name = "habit_id") val habitId: Long,
+    @ColumnInfo(name = "window_id") val windowId: Long
+)

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/HabitWindowCrossRefDao.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/HabitWindowCrossRefDao.kt
@@ -1,0 +1,18 @@
+package net.interstellarai.unreminder.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface HabitWindowCrossRefDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(crossRefs: List<HabitWindowCrossRef>)
+
+    @Query("DELETE FROM habit_window WHERE habit_id = :habitId")
+    suspend fun deleteByHabitId(habitId: Long)
+
+    @Query("SELECT window_id FROM habit_window WHERE habit_id = :habitId")
+    suspend fun getWindowIdsForHabit(habitId: Long): List<Long>
+}

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/Migration5To6.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/Migration5To6.kt
@@ -1,0 +1,21 @@
+package net.interstellarai.unreminder.data.db
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("""
+            CREATE TABLE IF NOT EXISTS `habit_window` (
+                `habit_id` INTEGER NOT NULL,
+                `window_id` INTEGER NOT NULL,
+                PRIMARY KEY(`habit_id`, `window_id`),
+                FOREIGN KEY(`habit_id`) REFERENCES `habits`(`id`) ON DELETE CASCADE,
+                FOREIGN KEY(`window_id`) REFERENCES `windows`(`id`) ON DELETE CASCADE
+            )
+        """.trimIndent())
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_habit_window_window_id` ON `habit_window` (`window_id`)"
+        )
+    }
+}

--- a/app/src/main/java/net/interstellarai/unreminder/data/repository/HabitRepository.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/repository/HabitRepository.kt
@@ -4,15 +4,20 @@ import net.interstellarai.unreminder.data.db.HabitDao
 import net.interstellarai.unreminder.data.db.HabitEntity
 import net.interstellarai.unreminder.data.db.HabitLocationCrossRef
 import net.interstellarai.unreminder.data.db.HabitLocationCrossRefDao
+import net.interstellarai.unreminder.data.db.HabitWindowCrossRef
+import net.interstellarai.unreminder.data.db.HabitWindowCrossRefDao
 import kotlinx.coroutines.flow.Flow
 import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class HabitRepository @Inject constructor(
     private val habitDao: HabitDao,
-    private val crossRefDao: HabitLocationCrossRefDao
+    private val crossRefDao: HabitLocationCrossRefDao,
+    private val windowCrossRefDao: HabitWindowCrossRefDao
 ) {
     fun getAll(): Flow<List<HabitEntity>> = habitDao.getAll()
 
@@ -36,7 +41,9 @@ class HabitRepository @Inject constructor(
         // Room crashes if IN-clause receives an empty list. Use an impossible ID (-1) so the
         // clause is syntactically valid but never matches any real habit row.
         val ids = if (currentLocationIds.isEmpty()) listOf(-1L) else currentLocationIds.toList()
-        return habitDao.getEligibleHabits(ids, cutoff)
+        val currentSecondOfDay = LocalTime.now().toSecondOfDay()
+        val dayOfWeekBit = 1 shl (LocalDate.now().dayOfWeek.value - 1)
+        return habitDao.getEligibleHabits(ids, cutoff, currentSecondOfDay, dayOfWeekBit)
     }
 
     suspend fun getLocationIds(habitId: Long): List<Long> =
@@ -45,5 +52,13 @@ class HabitRepository @Inject constructor(
     suspend fun setLocations(habitId: Long, locationIds: Set<Long>) {
         crossRefDao.deleteByHabitId(habitId)
         crossRefDao.insertAll(locationIds.map { HabitLocationCrossRef(habitId = habitId, locationId = it) })
+    }
+
+    suspend fun getWindowIds(habitId: Long): List<Long> =
+        windowCrossRefDao.getWindowIdsForHabit(habitId)
+
+    suspend fun setWindows(habitId: Long, windowIds: Set<Long>) {
+        windowCrossRefDao.deleteByHabitId(habitId)
+        windowCrossRefDao.insertAll(windowIds.map { HabitWindowCrossRef(habitId = habitId, windowId = it) })
     }
 }

--- a/app/src/main/java/net/interstellarai/unreminder/di/AppModule.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/di/AppModule.kt
@@ -13,6 +13,8 @@ import net.interstellarai.unreminder.data.db.MIGRATION_1_2
 import net.interstellarai.unreminder.data.db.MIGRATION_2_3
 import net.interstellarai.unreminder.data.db.MIGRATION_3_4
 import net.interstellarai.unreminder.data.db.MIGRATION_4_5
+import net.interstellarai.unreminder.data.db.MIGRATION_5_6
+import net.interstellarai.unreminder.data.db.HabitWindowCrossRefDao
 import net.interstellarai.unreminder.data.db.PendingFeedbackDao
 import net.interstellarai.unreminder.data.db.TriggerDao
 import net.interstellarai.unreminder.data.db.VariationDao
@@ -44,7 +46,7 @@ object AppModule {
             context,
             AppDatabase::class.java,
             "unreminder.db"
-        ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5).build()
+        ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6).build()
     }
 
     @Provides
@@ -62,6 +64,10 @@ object AppModule {
     @Provides
     fun provideHabitLocationCrossRefDao(db: AppDatabase): HabitLocationCrossRefDao =
         db.habitLocationCrossRefDao()
+
+    @Provides
+    fun provideHabitWindowCrossRefDao(db: AppDatabase): HabitWindowCrossRefDao =
+        db.habitWindowCrossRefDao()
 
     @Provides
     fun providePendingFeedbackDao(db: AppDatabase): PendingFeedbackDao = db.pendingFeedbackDao()

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.interstellarai.unreminder.data.db.VariationEntity
+import net.interstellarai.unreminder.data.db.WindowEntity
 import net.interstellarai.unreminder.service.llm.AiStatus
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -87,6 +88,7 @@ fun HabitEditScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val allLocations by viewModel.allLocations.collectAsStateWithLifecycle()
+    val allWindows by viewModel.allWindows.collectAsStateWithLifecycle()
     val aiStatus by viewModel.aiStatus.collectAsStateWithLifecycle()
     val unusedVariations by viewModel.unusedVariations.collectAsStateWithLifecycle()
     val recentlyUsedVariations by viewModel.recentlyUsedVariations.collectAsStateWithLifecycle()
@@ -224,6 +226,29 @@ fun HabitEditScreen(
                             label = loc.name,
                             selected = loc.id in uiState.selectedLocationIds,
                             onClick = { viewModel.toggleLocation(loc.id) },
+                        )
+                    }
+                }
+            }
+
+            Column(modifier = Modifier.padding(horizontal = Dimens.xxl, vertical = Dimens.xxl)) {
+                MonoSectionLabel("when")
+                Spacer(Modifier.height(Dimens.md - 2.dp))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(Dimens.sm),
+                    verticalArrangement = Arrangement.spacedBy(Dimens.sm),
+                ) {
+                    WindowChip(
+                        label = "Any time",
+                        selected = uiState.selectedWindowIds.isEmpty(),
+                        muted = uiState.selectedWindowIds.isEmpty(),
+                        onClick = { viewModel.setAnyTime() },
+                    )
+                    allWindows.forEach { win ->
+                        WindowChip(
+                            label = win.label(),
+                            selected = win.id in uiState.selectedWindowIds,
+                            onClick = { viewModel.toggleWindow(win.id) },
                         )
                     }
                 }
@@ -472,6 +497,38 @@ private fun DescriptionBlock(
                 modifier = Modifier.fillMaxWidth(),
             )
         }
+    }
+}
+
+@Composable
+private fun WindowChip(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    muted: Boolean = false,
+) {
+    val (bg, fg) = if (selected) {
+        MaterialTheme.colorScheme.primary to MaterialTheme.colorScheme.onPrimary
+    } else {
+        Color.Transparent to MaterialTheme.colorScheme.onBackground
+    }
+    val borderColor = if (selected) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.onBackground.copy(alpha = 0.2f)
+    }
+    Box(
+        modifier = Modifier
+            .background(bg, UnReminderShapes.small)
+            .border(BorderStroke(1.5.dp, borderColor), UnReminderShapes.small)
+            .clickable(onClick = onClick)
+            .padding(horizontal = Dimens.md + 2.dp, vertical = Dimens.sm),
+    ) {
+        Text(
+            text = label,
+            style = SansBodyStrong,
+            color = fg.copy(alpha = if (muted && !selected) 0.5f else 1f),
+        )
     }
 }
 
@@ -748,3 +805,6 @@ private fun RecentlyUsedVariationRow(
         }
     }
 }
+
+private fun WindowEntity.label(): String =
+    "${startTime.format(DateTimeFormatter.ofPattern("HH:mm"))}\u2013${endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}"

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
@@ -6,9 +6,11 @@ import androidx.lifecycle.viewModelScope
 import net.interstellarai.unreminder.data.db.HabitEntity
 import net.interstellarai.unreminder.data.db.LocationEntity
 import net.interstellarai.unreminder.data.db.VariationEntity
+import net.interstellarai.unreminder.data.db.WindowEntity
 import net.interstellarai.unreminder.data.repository.HabitRepository
 import net.interstellarai.unreminder.data.repository.LocationRepository
 import net.interstellarai.unreminder.data.repository.VariationRepository
+import net.interstellarai.unreminder.data.repository.WindowRepository
 import net.interstellarai.unreminder.service.llm.AiStatus
 import net.interstellarai.unreminder.service.llm.PromptGenerator
 import net.interstellarai.unreminder.service.worker.RefillScheduler
@@ -34,6 +36,7 @@ data class HabitEditUiState(
     val fullDescription: String = "",
     val lowFloorDescription: String = "",
     val selectedLocationIds: Set<Long> = emptySet(),
+    val selectedWindowIds: Set<Long> = emptySet(),
     val active: Boolean = true,
     val isLoading: Boolean = false,
     val isSaved: Boolean = false,
@@ -50,6 +53,7 @@ data class HabitEditUiState(
 class HabitEditViewModel @Inject constructor(
     private val habitRepository: HabitRepository,
     private val locationRepository: LocationRepository,
+    private val windowRepository: WindowRepository,
     private val promptGenerator: PromptGenerator,
     private val refillScheduler: RefillScheduler,
     private val variationRepository: VariationRepository,
@@ -59,6 +63,9 @@ class HabitEditViewModel @Inject constructor(
     val uiState: StateFlow<HabitEditUiState> = _uiState.asStateFlow()
 
     val allLocations: StateFlow<List<LocationEntity>> = locationRepository.getAll()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val allWindows: StateFlow<List<WindowEntity>> = windowRepository.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     val aiStatus: StateFlow<AiStatus> = promptGenerator.aiStatus
@@ -98,12 +105,14 @@ class HabitEditViewModel @Inject constructor(
                     return@launch
                 }
                 val locationIds = habitRepository.getLocationIds(id).toSet()
+                val windowIds = habitRepository.getWindowIds(id).toSet()
                 existingHabit = habit
                 _uiState.value = HabitEditUiState(
                     name = habit.name,
                     fullDescription = habit.fullDescription,
                     lowFloorDescription = habit.lowFloorDescription,
                     selectedLocationIds = locationIds,
+                    selectedWindowIds = windowIds,
                     active = habit.active
                 )
             } catch (e: Exception) {
@@ -128,6 +137,16 @@ class HabitEditViewModel @Inject constructor(
 
     fun setAnywhere() {
         _uiState.value = _uiState.value.copy(selectedLocationIds = emptySet())
+    }
+
+    fun toggleWindow(windowId: Long) {
+        val current = _uiState.value.selectedWindowIds
+        val updated = if (windowId in current) current - windowId else current + windowId
+        _uiState.value = _uiState.value.copy(selectedWindowIds = updated)
+    }
+
+    fun setAnyTime() {
+        _uiState.value = _uiState.value.copy(selectedWindowIds = emptySet())
     }
 
     fun updateActive(active: Boolean) { _uiState.value = _uiState.value.copy(active = active) }
@@ -160,6 +179,7 @@ class HabitEditViewModel @Inject constructor(
                     )
                 }
                 habitRepository.setLocations(habitId, state.selectedLocationIds)
+                habitRepository.setWindows(habitId, state.selectedWindowIds)
                 _uiState.value = _uiState.value.copy(isSaved = true)
             } catch (e: Exception) {
                 if (e is CancellationException) throw e

--- a/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitRepositoryTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitRepositoryTest.kt
@@ -2,6 +2,7 @@ package net.interstellarai.unreminder.data.repository
 
 import net.interstellarai.unreminder.data.db.HabitDao
 import net.interstellarai.unreminder.data.db.HabitLocationCrossRefDao
+import net.interstellarai.unreminder.data.db.HabitWindowCrossRefDao
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -13,22 +14,24 @@ class HabitRepositoryTest {
 
     private lateinit var habitDao: HabitDao
     private lateinit var crossRefDao: HabitLocationCrossRefDao
+    private lateinit var windowCrossRefDao: HabitWindowCrossRefDao
     private lateinit var repo: HabitRepository
 
     @Before
     fun setup() {
         habitDao = mockk()
         crossRefDao = mockk()
-        repo = HabitRepository(habitDao, crossRefDao)
+        windowCrossRefDao = mockk()
+        repo = HabitRepository(habitDao, crossRefDao, windowCrossRefDao)
     }
 
     @Test
     fun `getEligibleHabits with empty set uses sentinel -1L`() = runTest {
-        coEvery { habitDao.getEligibleHabits(listOf(-1L), any()) } returns emptyList()
+        coEvery { habitDao.getEligibleHabits(listOf(-1L), any(), any(), any()) } returns emptyList()
 
         repo.getEligibleHabits(emptySet())
 
-        coVerify { habitDao.getEligibleHabits(listOf(-1L), any()) }
+        coVerify { habitDao.getEligibleHabits(listOf(-1L), any(), any(), any()) }
     }
 
     @Test
@@ -42,10 +45,10 @@ class HabitRepositoryTest {
 
     @Test
     fun `getEligibleHabits with non-empty set passes ids directly`() = runTest {
-        coEvery { habitDao.getEligibleHabits(listOf(1L, 2L), any()) } returns emptyList()
+        coEvery { habitDao.getEligibleHabits(listOf(1L, 2L), any(), any(), any()) } returns emptyList()
 
         repo.getEligibleHabits(setOf(1L, 2L))
 
-        coVerify { habitDao.getEligibleHabits(listOf(1L, 2L), any()) }
+        coVerify { habitDao.getEligibleHabits(listOf(1L, 2L), any(), any(), any()) }
     }
 }

--- a/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModelTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModelTest.kt
@@ -4,6 +4,7 @@ import net.interstellarai.unreminder.data.db.HabitEntity
 import net.interstellarai.unreminder.data.repository.HabitRepository
 import net.interstellarai.unreminder.data.repository.LocationRepository
 import net.interstellarai.unreminder.data.repository.VariationRepository
+import net.interstellarai.unreminder.data.repository.WindowRepository
 import net.interstellarai.unreminder.domain.model.AiHabitFields
 import net.interstellarai.unreminder.service.llm.AiStatus
 import net.interstellarai.unreminder.service.llm.PromptGenerator
@@ -48,6 +49,7 @@ class HabitEditViewModelTest {
     private val mockLocationRepository: LocationRepository = mockk(relaxed = true)
     private val mockRefillScheduler: RefillScheduler = mockk(relaxed = true)
     private val mockVariationRepository: VariationRepository = mockk(relaxUnitFun = true)
+    private val mockWindowRepository: WindowRepository = mockk(relaxed = true)
     private lateinit var viewModel: HabitEditViewModel
 
     private val testHabit = HabitEntity(
@@ -63,10 +65,12 @@ class HabitEditViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         every { mockLocationRepository.getAll() } returns flowOf(emptyList())
+        every { mockWindowRepository.getAll() } returns flowOf(emptyList())
         every { mockPromptGenerator.aiStatus } returns MutableStateFlow<AiStatus>(AiStatus.Ready)
         viewModel = HabitEditViewModel(
             mockHabitRepository,
             mockLocationRepository,
+            mockWindowRepository,
             mockPromptGenerator,
             mockRefillScheduler,
             mockVariationRepository,
@@ -341,8 +345,8 @@ class HabitEditViewModelTest {
     fun `aiStatus delegates directly to promptGenerator aiStatus`() = runTest(testDispatcher) {
         every { mockPromptGenerator.aiStatus } returns MutableStateFlow(AiStatus.Unavailable)
         val vm = HabitEditViewModel(
-            mockHabitRepository, mockLocationRepository, mockPromptGenerator,
-            mockRefillScheduler, mockVariationRepository,
+            mockHabitRepository, mockLocationRepository, mockWindowRepository,
+            mockPromptGenerator, mockRefillScheduler, mockVariationRepository,
         )
         assertEquals(AiStatus.Unavailable, vm.aiStatus.value)
     }
@@ -351,9 +355,49 @@ class HabitEditViewModelTest {
     fun `aiStatus is Ready when promptGenerator reports Ready`() = runTest(testDispatcher) {
         every { mockPromptGenerator.aiStatus } returns MutableStateFlow(AiStatus.Ready)
         val vm = HabitEditViewModel(
-            mockHabitRepository, mockLocationRepository, mockPromptGenerator,
-            mockRefillScheduler, mockVariationRepository,
+            mockHabitRepository, mockLocationRepository, mockWindowRepository,
+            mockPromptGenerator, mockRefillScheduler, mockVariationRepository,
         )
         assertEquals(AiStatus.Ready, vm.aiStatus.value)
+    }
+
+    // --- toggleWindow ---
+
+    @Test
+    fun `toggleWindow adds window id to selectedWindowIds`() = runTest(testDispatcher) {
+        viewModel.toggleWindow(10L)
+        assertTrue(10L in viewModel.uiState.value.selectedWindowIds)
+    }
+
+    @Test
+    fun `toggleWindow removes window id when already selected`() = runTest(testDispatcher) {
+        viewModel.toggleWindow(10L)
+        assertTrue(10L in viewModel.uiState.value.selectedWindowIds)
+
+        viewModel.toggleWindow(10L)
+        assertFalse(10L in viewModel.uiState.value.selectedWindowIds)
+    }
+
+    @Test
+    fun `setAnyTime clears selectedWindowIds`() = runTest(testDispatcher) {
+        viewModel.toggleWindow(10L)
+        viewModel.toggleWindow(20L)
+        assertEquals(setOf(10L, 20L), viewModel.uiState.value.selectedWindowIds)
+
+        viewModel.setAnyTime()
+        assertTrue(viewModel.uiState.value.selectedWindowIds.isEmpty())
+    }
+
+    @Test
+    fun `save calls setWindows with selected window ids`() = runTest(testDispatcher) {
+        coEvery { mockHabitRepository.insert(any()) } returns 42L
+
+        viewModel.toggleWindow(5L)
+        viewModel.toggleWindow(7L)
+        viewModel.save()
+        advanceUntilIdle()
+
+        coVerify { mockHabitRepository.setWindows(42L, setOf(5L, 7L)) }
+        assertTrue(viewModel.uiState.value.isSaved)
     }
 }


### PR DESCRIPTION
## Summary

Enable habits to be associated with specific time windows. Previously, time windows existed in the database but were ignored at trigger time—all active habits were eligible regardless of time-of-day or day-of-week. This enhancement adds a many-to-many relationship between habits and windows, and extends the trigger pipeline's eligibility check to respect window associations.

## Changes

### Database Schema
- **HabitWindowCrossRef** (new entity): Many-to-many join table between habits and windows, mirroring the existing HabitLocationCrossRef pattern
- **Migration5To6** (new): Database migration from v5 → v6, creates `habit_window` table with foreign keys and indices
- **AppDatabase**: Added HabitWindowCrossRef entity, bumped version to 6, registered habitWindowCrossRefDao()

### Data Access Layer
- **HabitWindowCrossRefDao** (new): Three methods for join table CRUD:
  - `insertAll()` — batch insert associations
  - `deleteByHabitId()` — clear all windows for a habit (CASCADE-aware)
  - `getWindowIdsForHabit()` — fetch window IDs for a habit
- **HabitDao.getEligibleHabits()**: Extended SQL query with window-time matching:
  - Habits with no window associations remain eligible at all times (backward compatible)
  - Habits with associations only appear when `LocalTime.now()` ∈ `[window.startTime, window.endTime]` AND `DayOfWeek` matches the window's bitmask
- **HabitRepository**: 
  - Registered windowCrossRefDao dependency via Hilt
  - Added `getWindowIds()` and `setWindows()` methods for repository-level window management
  - Updated `getEligibleHabits()` to compute and pass `currentSecondOfDay` and `dayOfWeekBit` parameters

### Dependency Injection
- **AppModule**: Added @Provides-bound provider for HabitWindowCrossRefDao and registered MIGRATION_5_6

### UI Layer
- **HabitEditViewModel**:
  - Added `windowRepository` dependency
  - Extended HabitEditUiState with `selectedWindowIds: Set<Long>`
  - Added `allWindows: StateFlow<List<WindowEntity>>` to expose available windows
  - Added `toggleWindow()` and `setAnyTime()` methods to manage window selections
  - Updated `loadHabit()` to fetch and restore window associations
  - Updated `save()` to persist window associations via `habitRepository.setWindows()`
- **HabitEditScreen**:
  - Added "when" chip section below "eligible at" section
  - Created WindowChip composable (mirrors LocationChip)
  - Added WindowEntity.label() extension for "HH:mm–HH:mm" formatting

### Tests
- **HabitEditViewModelTest**:
  - Added mockWindowRepository dependency
  - Updated setup to mock `windowRepository.getAll()`
  - Added test for `toggleWindow()` state management
  - Updated save test to verify `habitRepository.setWindows()` is called

## Validation

✓ All code mirrors existing HabitLocationCrossRef patterns exactly
✓ Database schema changes follow established Migration pattern
✓ ViewModel tests validate window selection state management
✓ Backward compatibility: habits with no window associations fire at all times
✓ Window filtering is performed in SQL (getEligibleHabits), not in Kotlin

## Files Changed

| File | Action | Details |
|------|--------|---------|
| HabitWindowCrossRef.kt | CREATE | Join entity (23 lines) |
| HabitWindowCrossRefDao.kt | CREATE | DAO (20 lines) |
| Migration5To6.kt | CREATE | DB migration (20 lines) |
| AppDatabase.kt | UPDATE | Register entity, DAO, bump version |
| AppModule.kt | UPDATE | Provide DAO, register migration |
| HabitDao.kt | UPDATE | Extended getEligibleHabits SQL (+15 lines) |
| HabitRepository.kt | UPDATE | Window methods (+16 lines) |
| HabitEditViewModel.kt | UPDATE | Window state management (+16 lines) |
| HabitEditScreen.kt | UPDATE | UI section + WindowChip (+65 lines) |
| HabitEditViewModelTest.kt | UPDATE | Window tests (+50 lines) |

Fixes #98