### PR TITLE
fix: address PR #106 review findings (CRITICAL/HIGH/MEDIUM)

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/data/db/Migration6To7.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/Migration6To7.kt
@@ -51,7 +51,13 @@ val MIGRATION_6_7 = object : Migration(6, 7) {
             WHERE `full_description` <> ''
         """.trimIndent())
 
-        // 5. Drop old habits table and rename new one
+        // 5. Map legacy completion statuses to unified COMPLETED
+        db.execSQL("""
+            UPDATE `triggers` SET `status` = 'COMPLETED'
+            WHERE `status` IN ('COMPLETED_FULL', 'COMPLETED_LOW_FLOOR')
+        """.trimIndent())
+
+        // 6. Drop old habits table and rename new one
         db.execSQL("DROP TABLE `habits`")
         db.execSQL("ALTER TABLE `habits_new` RENAME TO `habits`")
     }

--- a/app/src/main/java/net/interstellarai/unreminder/data/repository/HabitLevelDescriptionRepository.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/repository/HabitLevelDescriptionRepository.kt
@@ -1,5 +1,6 @@
 package net.interstellarai.unreminder.data.repository
 
+import androidx.room.Transaction
 import net.interstellarai.unreminder.data.db.HabitLevelDescriptionDao
 import net.interstellarai.unreminder.data.db.HabitLevelDescriptionEntity
 import javax.inject.Inject
@@ -15,6 +16,7 @@ class HabitLevelDescriptionRepository @Inject constructor(
     suspend fun getDescriptionForLevel(habitId: Long, level: Int): String? =
         dao.getForLevel(habitId, level)?.description
 
+    @Transaction
     suspend fun setDescriptions(habitId: Long, descriptions: List<String>) {
         dao.deleteByHabit(habitId)
         dao.insertAll(

--- a/app/src/test/java/net/interstellarai/unreminder/data/db/Migration6To7Test.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/db/Migration6To7Test.kt
@@ -32,6 +32,14 @@ class Migration6To7Test {
                         "PRIMARY KEY(`habit_id`, `window_id`)" +
                         ")"
                     )
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS `triggers` (" +
+                        "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "`window_id` INTEGER, `habit_id` INTEGER, " +
+                        "`scheduled_at` INTEGER NOT NULL, `fired_at` INTEGER, " +
+                        "`status` TEXT NOT NULL DEFAULT 'SCHEDULED', " +
+                        "`generated_prompt` TEXT, `source` TEXT)"
+                    )
                 }
                 override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {}
             }).build()
@@ -141,6 +149,40 @@ class Migration6To7Test {
 
         assertTrue(indices.contains("index_habit_level_descriptions_habit_id"))
 
+        db.close()
+    }
+
+    @Test
+    fun `migration updates legacy trigger statuses to COMPLETED`() {
+        val db = createV6Database()
+        db.execSQL(
+            "INSERT INTO habits (name, full_description, low_floor_description) VALUES ('h', 'full', 'low')"
+        )
+        db.execSQL(
+            "INSERT INTO triggers (habit_id, scheduled_at, status) VALUES (1, 1000, 'COMPLETED_FULL')"
+        )
+        db.execSQL(
+            "INSERT INTO triggers (habit_id, scheduled_at, status) VALUES (1, 2000, 'COMPLETED_LOW_FLOOR')"
+        )
+        db.execSQL(
+            "INSERT INTO triggers (habit_id, scheduled_at, status) VALUES (1, 3000, 'DISMISSED')"
+        )
+
+        MIGRATION_6_7.migrate(db)
+
+        val cursor = db.query("SELECT status FROM triggers ORDER BY scheduled_at ASC")
+        assertEquals(3, cursor.count)
+
+        cursor.moveToFirst()
+        assertEquals("COMPLETED", cursor.getString(cursor.getColumnIndex("status")))
+
+        cursor.moveToNext()
+        assertEquals("COMPLETED", cursor.getString(cursor.getColumnIndex("status")))
+
+        cursor.moveToNext()
+        assertEquals("DISMISSED", cursor.getString(cursor.getColumnIndex("status")))
+
+        cursor.close()
         db.close()
     }
 }


### PR DESCRIPTION
## Summary

Follow-up fixes for review findings from PR #106 (merged). These address a **critical data integrity bug**, a **high-severity query correctness issue**, and a **medium-severity atomicity concern**.

- **CRITICAL**: Migration6To7 now updates legacy `COMPLETED_FULL`/`COMPLETED_LOW_FLOOR` trigger statuses to `COMPLETED`, preventing `IllegalArgumentException` crash when Room's `TypeConverter` deserializes old rows via `valueOf()`
- **HIGH**: `countCompletionsSince` query (resolved by the same migration fix — old status strings now match the query's `status = 'COMPLETED'` filter)
- **MEDIUM**: `HabitLevelDescriptionRepository.setDescriptions` now uses `@Transaction` to ensure atomic delete+insert, preventing data loss if the app crashes between operations

## Test plan

- [x] Added `migration updates legacy trigger statuses to COMPLETED` test in `Migration6To7Test`
- [x] Added `triggers` table to v6 schema fixture so migration tests cover trigger status updates
- [ ] Verify existing migration tests still pass
- [ ] Verify `DedicationLevelManagerTest` still passes (depends on correct status counting)

## Files changed

| File | Change |
|------|--------|
| `Migration6To7.kt` | Added `UPDATE triggers` SQL statement |
| `HabitLevelDescriptionRepository.kt` | Added `@Transaction` annotation |
| `Migration6To7Test.kt` | Added triggers table to v6 fixture + new test case |

🤖 Generated with [Claude Code](https://claude.com/claude-code)