### PR TITLE
fix: use db.withTransaction for atomic setDescriptions

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/data/repository/HabitLevelDescriptionRepository.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/repository/HabitLevelDescriptionRepository.kt
@@ -1,6 +1,7 @@
 package net.interstellarai.unreminder.data.repository
 
-import androidx.room.Transaction
+import androidx.room.withTransaction
+import net.interstellarai.unreminder.data.db.AppDatabase
 import net.interstellarai.unreminder.data.db.HabitLevelDescriptionDao
 import net.interstellarai.unreminder.data.db.HabitLevelDescriptionEntity
 import javax.inject.Inject
@@ -8,7 +9,8 @@ import javax.inject.Singleton
 
 @Singleton
 class HabitLevelDescriptionRepository @Inject constructor(
-    private val dao: HabitLevelDescriptionDao
+    private val dao: HabitLevelDescriptionDao,
+    private val db: AppDatabase
 ) {
     suspend fun getDescriptionsForHabit(habitId: Long): List<HabitLevelDescriptionEntity> =
         dao.getForHabit(habitId)
@@ -16,14 +18,15 @@ class HabitLevelDescriptionRepository @Inject constructor(
     suspend fun getDescriptionForLevel(habitId: Long, level: Int): String? =
         dao.getForLevel(habitId, level)?.description
 
-    @Transaction
     suspend fun setDescriptions(habitId: Long, descriptions: List<String>) {
-        dao.deleteByHabit(habitId)
-        dao.insertAll(
-            descriptions.mapIndexedNotNull { i, desc ->
-                if (desc.isBlank()) null
-                else HabitLevelDescriptionEntity(habitId = habitId, level = i, description = desc)
-            }
-        )
+        db.withTransaction {
+            dao.deleteByHabit(habitId)
+            dao.insertAll(
+                descriptions.mapIndexedNotNull { i, desc ->
+                    if (desc.isBlank()) null
+                    else HabitLevelDescriptionEntity(habitId = habitId, level = i, description = desc)
+                }
+            )
+        }
     }
 }

--- a/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitLevelDescriptionRepositoryTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitLevelDescriptionRepositoryTest.kt
@@ -24,7 +24,7 @@ class HabitLevelDescriptionRepositoryTest {
     fun setUp() {
         mockkStatic("androidx.room.RoomDatabaseKt")
         coEvery { db.withTransaction(captureLambda<suspend () -> Any?>()) } coAnswers {
-            lambda<suspend () -> Any?>().coInvoke()
+            lambda<suspend () -> Any?>().invoke()
         }
     }
 

--- a/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitLevelDescriptionRepositoryTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitLevelDescriptionRepositoryTest.kt
@@ -1,16 +1,37 @@
 package net.interstellarai.unreminder.data.repository
 
+import androidx.room.withTransaction
+import net.interstellarai.unreminder.data.db.AppDatabase
 import net.interstellarai.unreminder.data.db.HabitLevelDescriptionDao
 import net.interstellarai.unreminder.data.db.HabitLevelDescriptionEntity
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 
 class HabitLevelDescriptionRepositoryTest {
 
     private val dao: HabitLevelDescriptionDao = mockk(relaxUnitFun = true)
-    private val repo = HabitLevelDescriptionRepository(dao)
+    private val db: AppDatabase = mockk()
+    private val repo = HabitLevelDescriptionRepository(dao, db)
+
+    @Before
+    fun setUp() {
+        mockkStatic("androidx.room.RoomDatabaseKt")
+        coEvery { db.withTransaction(captureLambda<suspend () -> Any?>()) } coAnswers {
+            lambda<suspend () -> Any?>().coInvoke()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic("androidx.room.RoomDatabaseKt")
+    }
 
     @Test
     fun `setDescriptions skips blank entries and preserves level index`() = runTest {

--- a/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitLevelDescriptionRepositoryTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitLevelDescriptionRepositoryTest.kt
@@ -24,7 +24,7 @@ class HabitLevelDescriptionRepositoryTest {
     fun setUp() {
         mockkStatic("androidx.room.RoomDatabaseKt")
         coEvery { db.withTransaction(captureLambda<suspend () -> Any?>()) } coAnswers {
-            lambda<suspend () -> Any?>().invoke()
+            firstArg<suspend () -> Any?>().invoke()
         }
     }
 

--- a/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitLevelDescriptionRepositoryTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitLevelDescriptionRepositoryTest.kt
@@ -24,7 +24,7 @@ class HabitLevelDescriptionRepositoryTest {
     fun setUp() {
         mockkStatic("androidx.room.RoomDatabaseKt")
         coEvery { db.withTransaction(captureLambda<suspend () -> Any?>()) } coAnswers {
-            firstArg<suspend () -> Any?>().invoke()
+            lambda<suspend () -> Any?>().captured.invoke()
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace `@Transaction` annotation (silently ignored on non-`@Dao` class) with explicit `db.withTransaction {}` in `HabitLevelDescriptionRepository.setDescriptions`
- Inject `AppDatabase` into repository constructor for transaction support
- Update unit tests to mock Room's `withTransaction` extension

## Context

Post-merge review of PR #108 identified that Room's `@Transaction` annotation only works on `@Dao`-annotated classes. `HabitLevelDescriptionRepository` is a `@Singleton` — the annotation compiled but had no runtime effect, leaving `deleteByHabit` and `insertAll` as independent operations vulnerable to data loss on crash.

## Test plan

- [ ] Existing `HabitLevelDescriptionRepositoryTest` tests pass with mocked `withTransaction`
- [ ] Verify Hilt DI graph compiles (AppDatabase already provided in AppModule)
- [ ] Manual: edit habit level descriptions and verify they persist correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)