### PR TITLE
ci: publish AAB to Play Store internal track on every main push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,17 @@ jobs:
           WORKER_SECRET: ${{ secrets.WORKER_SECRET }}
         run: ./gradlew bundleRelease --stacktrace
 
+      - name: Publish to Play Store internal track
+        if: secrets.PLAY_SERVICE_ACCOUNT_JSON != ''
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: net.interstellarai.unreminder
+          releaseFiles: app/build/outputs/bundle/release/*.aab
+          track: internal
+          status: completed
+          releaseName: ${{ env.VERSION_NAME }}
+
       - name: Build signed universal APK (for sideload)
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}


### PR DESCRIPTION
## Summary
- Adds `r0adkll/upload-google-play` step to `release.yml` after `bundleRelease`
- Uploads to the **internal test track** with `status: completed` (immediately available to testers)
- Guarded by `secrets.PLAY_SERVICE_ACCOUNT_JSON` — silently skips until the secret is added, so existing CI is unaffected

## To activate
Add the service account JSON as a repo secret:
\`\`\`
gh secret set PLAY_SERVICE_ACCOUNT_JSON --repo alexsiri7/un-reminder
\`\`\`

See Play Console → Setup → API access to create/download the service account key.

## Test plan
- [ ] Merge once `PLAY_SERVICE_ACCOUNT_JSON` secret is added
- [ ] Verify next `main` push triggers the upload step and appears in Play Console internal track
- [ ] Enroll test device in internal testing, confirm OTA update arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)