### PR TITLE
ci: fix invalid secrets reference in Play Store upload step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,6 @@ jobs:
         run: ./gradlew bundleRelease --stacktrace
 
       - name: Publish to Play Store internal track
-        if: secrets.PLAY_SERVICE_ACCOUNT_JSON != ''
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}


### PR DESCRIPTION
GitHub Actions does not allow `secrets.*` in `if:` conditions — causes workflow file parse error. Remove the guard; the secret is set so the step runs unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)