### PR TITLE
ci: fix Play Store upload for draft app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,17 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: ./gradlew bundleRelease --stacktrace
 
+      - name: Publish to Play Store internal track
+        if: secrets.PLAY_SERVICE_ACCOUNT_JSON != ''
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: net.interstellarai.unreminder
+          releaseFiles: app/build/outputs/bundle/release/*.aab
+          track: internal
+          status: completed
+          releaseName: ${{ env.VERSION_NAME }}
+
       - name: Build signed universal APK (for sideload)
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           packageName: net.interstellarai.unreminder
           releaseFiles: app/build/outputs/bundle/release/*.aab
           track: internal
-          status: completed
+          status: draft
           releaseName: ${{ env.VERSION_NAME }}
 
       - name: Build signed universal APK (for sideload)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,19 @@
                 tools:node="remove" />
         </provider>
 
+        <!-- Sentry auto-init requires a DSN in meta-data; we init manually in
+             UnReminderApp so the app can run without a DSN (local/dev builds,
+             or release builds where the SENTRY_DSN secret isn't wired). -->
+        <provider
+            android:name="io.sentry.android.core.SentryInitProvider"
+            android:authorities="${applicationId}.SentryInitProvider"
+            tools:node="remove" />
+
+        <provider
+            android:name="io.sentry.android.core.SentryPerformanceProvider"
+            android:authorities="${applicationId}.SentryPerformanceProvider"
+            tools:node="remove" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
App is in draft state in Play Console — API rejects `status: completed` releases until the app has been reviewed/published at least once.

Change `status: completed` → `status: draft` so the upload succeeds. Once the app graduates from draft (after first internal testing publish), this can be reverted to `completed` for auto-delivery to testers.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>