### PR TITLE
ci: fix Play Store upload for draft app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           packageName: net.interstellarai.unreminder
           releaseFiles: app/build/outputs/bundle/release/*.aab
           track: internal
-          status: completed
+          status: draft
           releaseName: ${{ env.VERSION_NAME }}
 
       - name: Build signed universal APK (for sideload)


### PR DESCRIPTION
App is in draft state in Play Console — API rejects `status: completed` releases until the app has been reviewed/published at least once.

Change `status: completed` → `status: draft` so the upload succeeds. Once the app graduates from draft (after first internal testing publish in Play Console), this can be reverted to `completed` for auto-delivery to testers.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>