### PR TITLE
fix: align worker /v1/habit-fields schema with 6-level dedication ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Generates a sample notification via the worker's `/v1/preview` endpoint. Shown i
 2. **Habit editor** — name, dedication level progress bar (0–5), auto-adjust toggle, 6-level
    description fields (level 0 = minimum/low-floor, level 5 = full version; current level highlighted),
    location chips (multi-select from saved locations; no selection = "Anywhere"), active toggle.
-   AI-assist row: **Autofill with AI** (populates levels 0 and 5 from the habit name via cloud AI;
+   AI-assist row: **Autofill with AI** (populates all 6 levels (0–5) from the habit name via cloud AI;
    enabled when name ≥ 2 chars) · **Preview notification** (generates a sample notification text;
    enabled when at least one level description is non-blank).
 3. **Windows screen** — list of windows. FAB → add window. Tap → edit.

--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RequestyProxyClient.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RequestyProxyClient.kt
@@ -24,28 +24,28 @@ private fun Response.throwOnError(): Nothing = when (code) {
 class RequestyProxyClient @Inject constructor(
     private val okHttpClient: OkHttpClient,
 ) {
+    private suspend fun postJson(path: String, payload: JSONObject, workerUrl: String, secret: String): String =
+        withContext(Dispatchers.IO) {
+            val request = Request.Builder()
+                .url("${workerUrl.trimEnd('/')}/v1$path")
+                .addHeader("X-UR-Secret", secret)
+                .addHeader("Accept", "application/json")
+                .post(payload.toString().toRequestBody("application/json".toMediaType()))
+                .build()
+            okHttpClient.newCall(request).execute().use { response ->
+                if (response.code !in 200..299) response.throwOnError()
+                response.body?.string() ?: throw RuntimeException("Worker returned empty body")
+            }
+        }
+
     suspend fun habitFields(
         title: String,
         workerUrl: String,
         secret: String,
-    ): AiHabitFields = withContext(Dispatchers.IO) {
+    ): AiHabitFields {
         val payload = JSONObject().apply { put("title", title) }
-        val request = Request.Builder()
-            .url("${workerUrl.trimEnd('/')}/v1/habit-fields")
-            .addHeader("X-UR-Secret", secret)
-            .addHeader("Accept", "application/json")
-            .post(payload.toString().toRequestBody("application/json".toMediaType()))
-            .build()
-
-        okHttpClient.newCall(request).execute().use { response ->
-            if (response.code !in 200..299) response.throwOnError()
-            val rawBody = response.body?.string()
-                ?: throw RuntimeException("Worker returned empty body")
-            val body = JSONObject(rawBody)
-            val arr = body.getJSONArray("descriptionLadder")
-            val ladder = (0 until arr.length()).map { arr.getString(it) }
-            AiHabitFields(descriptionLadder = ladder)
-        }
+        val arr = JSONObject(postJson("/habit-fields", payload, workerUrl, secret)).getJSONArray("descriptionLadder")
+        return AiHabitFields(descriptionLadder = (0 until arr.length()).map { arr.getString(it) })
     }
 
     suspend fun preview(
@@ -53,31 +53,18 @@ class RequestyProxyClient @Inject constructor(
         locationName: String,
         workerUrl: String,
         secret: String,
-    ): String = withContext(Dispatchers.IO) {
+    ): String {
         val habitObj = JSONObject().apply {
             put("title", habit.name)
             // TODO: pass real tags once HabitEntity carries them (currently loaded via junction table)
             put("tags", JSONArray())
-            // maps current dedication level description -> notes
             put("notes", habit.descriptionLadder.getOrElse(habit.dedicationLevel) { "" })
         }
         val payload = JSONObject().apply {
             put("habit", habitObj)
             put("locationName", locationName)
         }
-        val request = Request.Builder()
-            .url("${workerUrl.trimEnd('/')}/v1/preview")
-            .addHeader("X-UR-Secret", secret)
-            .addHeader("Accept", "application/json")
-            .post(payload.toString().toRequestBody("application/json".toMediaType()))
-            .build()
-
-        okHttpClient.newCall(request).execute().use { response ->
-            if (response.code !in 200..299) response.throwOnError()
-            val rawBody = response.body?.string()
-                ?: throw RuntimeException("Worker returned empty body")
-            JSONObject(rawBody).getString("text")
-        }
+        return JSONObject(postJson("/preview", payload, workerUrl, secret)).getString("text")
     }
 
     suspend fun generateBatch(
@@ -88,7 +75,7 @@ class RequestyProxyClient @Inject constructor(
         n: Int,
         workerUrl: String,
         workerSecret: String,
-    ): List<String> = withContext(Dispatchers.IO) {
+    ): List<String> {
         val payload = JSONObject().apply {
             put("habitTitle", habitTitle)
             put("habitTags", JSONArray(habitTags))
@@ -96,19 +83,7 @@ class RequestyProxyClient @Inject constructor(
             put("timeOfDay", timeOfDay)
             put("n", n)
         }
-        val request = Request.Builder()
-            .url("${workerUrl.trimEnd('/')}/v1/generate/batch")
-            .addHeader("X-UR-Secret", workerSecret)
-            .addHeader("Accept", "application/json")
-            .post(payload.toString().toRequestBody("application/json".toMediaType()))
-            .build()
-
-        okHttpClient.newCall(request).execute().use { response ->
-            if (response.code !in 200..299) response.throwOnError()
-            val rawBody = response.body?.string()
-                ?: throw RuntimeException("Worker returned empty body")
-            val arr = JSONObject(rawBody).getJSONArray("variants")
-            (0 until arr.length()).map { arr.getString(it) }
-        }
+        val arr = JSONObject(postJson("/generate/batch", payload, workerUrl, workerSecret)).getJSONArray("variants")
+        return (0 until arr.length()).map { arr.getString(it) }
     }
 }

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
@@ -71,8 +71,8 @@ import net.interstellarai.unreminder.ui.theme.UnReminderShapes
 // Habit editor — mirrors `components/editor.jsx`:
 //   - Thin top bar ("← back · EDITING · save")
 //   - "habit name" label + big display-serif field underlined in accent
-//   - "gemma · on-device" AI-assist strip with an "✦ autofill" accent pill
-//   - Full + low-floor description fields rendered as italic serif blocks
+//   - "gemini · cloud" AI-assist strip with an "✦ autofill" accent pill
+//   - 6-level description ladder (just starting → your practice)
 //   - Location chips with sharp corners, filled-accent when selected
 //   - Dark "preview" card at the bottom (ink bg, bg ink)
 //   - Bottom row: active toggle + delete habit link

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
@@ -433,7 +433,7 @@ private fun AiAssistStrip(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(modifier = Modifier.weight(1f)) {
-                MonoSectionLabel("gemma · on-device")
+                MonoSectionLabel("gemini · cloud")
                 Spacer(Modifier.height(2.dp))
                 Text(
                     "Autofill descriptions",
@@ -610,7 +610,7 @@ private fun PreviewCard(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.padding(horizontal = Dimens.xs)) {
-        MonoSectionLabel("preview · sampled from gemma")
+        MonoSectionLabel("preview · gemini cloud")
         Spacer(Modifier.height(Dimens.md - 2.dp))
         Box(
             modifier = Modifier

--- a/worker/src/routes/habitFields.ts
+++ b/worker/src/routes/habitFields.ts
@@ -8,20 +8,23 @@ interface HabitFieldsRequest {
 }
 
 interface HabitFieldsResult {
-  fullDescription: string
-  lowFloorDescription: string
+  descriptionLadder: string[]
 }
 
 function buildPrompt(title: string, strict = false): string {
   const outputInstruction = strict
-    ? `Output ONLY valid JSON with exactly the keys fullDescription and lowFloorDescription. No markdown, no commentary, no code blocks.`
-    : `Output JSON with exactly the keys "fullDescription" and "lowFloorDescription". No markdown, no commentary.`
+    ? `Output ONLY valid JSON with exactly the key descriptionLadder whose value is a JSON array of exactly 6 strings. No markdown, no commentary, no code blocks.`
+    : `Output JSON with exactly the key "descriptionLadder" whose value is an array of exactly 6 strings. No markdown, no commentary.`
   return (
     `You are a habit description generator for a habit-tracker app.\n` +
     `Habit title: "${title}"\n\n` +
-    `Write two descriptions for this habit:\n` +
-    `1. "fullDescription": A clear, motivating description of the habit (1-2 sentences).\n` +
-    `2. "lowFloorDescription": A minimal, easy version of the habit to do on low-motivation days (1 sentence).\n\n` +
+    `Write exactly 6 short descriptions for this habit, one per dedication level (index 0–5):\n` +
+    `  0 — just starting: a minimal, one-time or exploratory version (1 sentence)\n` +
+    `  1 — unblocked: a low-effort, any-day version (1 sentence)\n` +
+    `  2 — regular: a consistent baseline version (1 sentence)\n` +
+    `  3 — committed: a meaningful, deliberate version (1 sentence)\n` +
+    `  4 — routine: a deep, habitual version (1 sentence)\n` +
+    `  5 — your practice: a full, immersive version that defines the habit (1-2 sentences)\n\n` +
     outputInstruction
   )
 }
@@ -29,8 +32,10 @@ function buildPrompt(title: string, strict = false): string {
 function validate(parsed: unknown): HabitFieldsResult | null {
   if (typeof parsed !== 'object' || parsed === null) return null
   const p = parsed as Record<string, unknown>
-  if (typeof p.fullDescription !== 'string' || typeof p.lowFloorDescription !== 'string') return null
-  return { fullDescription: p.fullDescription, lowFloorDescription: p.lowFloorDescription }
+  if (!Array.isArray(p.descriptionLadder)) return null
+  if (p.descriptionLadder.length !== 6) return null
+  if (!p.descriptionLadder.every((s) => typeof s === 'string')) return null
+  return { descriptionLadder: p.descriptionLadder as string[] }
 }
 
 export async function habitFieldsHandler(c: Context<{ Bindings: Env }>): Promise<Response> {

--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -436,8 +436,15 @@ describe('un-reminder-worker', () => {
   })
 
   it('returns 200 with habit fields on success', async () => {
-    const fields = { fullDescription: 'Sit quietly for 10 minutes', lowFloorDescription: 'Just sit down' }
-    mockRequestySuccess(fields)
+    const ladder = [
+      'Just try sitting for one minute.',
+      'Sit quietly for 3 minutes.',
+      'A 10-minute daily sit.',
+      'A focused 20-minute session.',
+      'A structured 30-minute sit each morning.',
+      'A dedicated meditation session that defines your relationship with stillness.',
+    ]
+    mockRequestySuccess({ descriptionLadder: ladder })
 
     const req = makeRequest('/v1/habit-fields', {
       method: 'POST',
@@ -448,9 +455,8 @@ describe('un-reminder-worker', () => {
     const res = await app.fetch(req, testEnv(), ctx)
     await waitOnExecutionContext(ctx)
     expect(res.status).toBe(200)
-    const body = (await res.json()) as { fullDescription: string; lowFloorDescription: string }
-    expect(body.fullDescription).toBe(fields.fullDescription)
-    expect(body.lowFloorDescription).toBe(fields.lowFloorDescription)
+    const body = (await res.json()) as { descriptionLadder: string[] }
+    expect(body.descriptionLadder).toEqual(ladder)
   })
 
   it('returns 502 on /v1/habit-fields when response is persistently malformed', async () => {
@@ -581,8 +587,7 @@ describe('un-reminder-worker', () => {
   })
 
   it('increments spend counter after successful /v1/habit-fields call', async () => {
-    const fields = { fullDescription: 'Sit quietly', lowFloorDescription: 'Just sit' }
-    mockRequestySuccess(fields)
+    mockRequestySuccess({ descriptionLadder: Array(6).fill('A description.') })
 
     const e = testEnv()
     const req = makeRequest('/v1/habit-fields', {

--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -474,6 +474,51 @@ describe('un-reminder-worker', () => {
     expect(res.status).toBe(502)
   })
 
+  it('returns 502 on /v1/habit-fields when descriptionLadder has fewer than 6 entries', async () => {
+    mockRequestySuccess({ descriptionLadder: ['a', 'b', 'c'] })
+    mockRequestySuccess({ descriptionLadder: ['a', 'b', 'c'] })
+
+    const req = makeRequest('/v1/habit-fields', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-UR-Secret': SECRET },
+      body: { title: 'Meditate' },
+    })
+    const ctx = createExecutionContext()
+    const res = await app.fetch(req, testEnv(), ctx)
+    await waitOnExecutionContext(ctx)
+    expect(res.status).toBe(502)
+  })
+
+  it('returns 502 on /v1/habit-fields when descriptionLadder has more than 6 entries', async () => {
+    mockRequestySuccess({ descriptionLadder: Array(7).fill('A description.') })
+    mockRequestySuccess({ descriptionLadder: Array(7).fill('A description.') })
+
+    const req = makeRequest('/v1/habit-fields', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-UR-Secret': SECRET },
+      body: { title: 'Meditate' },
+    })
+    const ctx = createExecutionContext()
+    const res = await app.fetch(req, testEnv(), ctx)
+    await waitOnExecutionContext(ctx)
+    expect(res.status).toBe(502)
+  })
+
+  it('returns 502 on /v1/habit-fields when descriptionLadder contains non-string entries', async () => {
+    mockRequestySuccess({ descriptionLadder: [1, 2, 3, 4, 5, 6] })
+    mockRequestySuccess({ descriptionLadder: [1, 2, 3, 4, 5, 6] })
+
+    const req = makeRequest('/v1/habit-fields', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-UR-Secret': SECRET },
+      body: { title: 'Meditate' },
+    })
+    const ctx = createExecutionContext()
+    const res = await app.fetch(req, testEnv(), ctx)
+    await waitOnExecutionContext(ctx)
+    expect(res.status).toBe(502)
+  })
+
   it('returns 400 on /v1/habit-fields with empty title', async () => {
     const req = makeRequest('/v1/habit-fields', {
       method: 'POST',


### PR DESCRIPTION
## Summary

PR #109 updated the Android client to read `descriptionLadder` (a 6-element array) from the autofill endpoint, but the CF Worker's `/v1/habit-fields` route was never updated. The worker still returned the old binary schema `{ fullDescription, lowFloorDescription }`. 

This mismatch caused every autofill tap to throw a `JSONException` (key not found), which was caught and displayed as "AI unavailable — fill in manually" to all users.

## Changes

**Worker Schema Update** (`worker/src/routes/habitFields.ts`)
- Changed `HabitFieldsResult` interface to return `descriptionLadder: string[]` instead of binary fields
- Updated `buildPrompt()` to request exactly 6 descriptions (one per dedication level: just starting, unblocked, regular, committed, routine, your practice)
- Updated `validate()` to require an array of exactly 6 strings

**Worker Tests** (`worker/test/index.test.ts`)
- Updated success test to verify new `descriptionLadder` schema
- Updated spend counter test mock to use new schema
- All 52 tests pass

**UI Labels** (`app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt`)
- Replaced stale "gemma · on-device" label with "gemini · cloud"
- Replaced "preview · sampled from gemma" with "preview · gemini cloud"
- (The on-device stack was removed in Phase 5; these labels were misleading)

## Validation

✅ **Type check**: No errors  
✅ **Tests**: 52 passed, 0 failed  
✅ **Manual verification**:
- App autofill now populates all 6 description ladder fields
- Preview feature works unchanged
- UI labels correctly reflect cloud-based Gemini model

Fixes #143