### PR TITLE
feat: Play In-App Updates with flexible update flow

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,6 +154,7 @@ dependencies {
 
     // Play Services Location (geofencing)
     implementation(libs.play.services.location)
+    implementation(libs.play.app.update)
     implementation(libs.osmdroid.android)
 
     // DataStore

--- a/app/src/main/java/net/interstellarai/unreminder/MainActivity.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/MainActivity.kt
@@ -4,19 +4,61 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dagger.hilt.android.AndroidEntryPoint
+import net.interstellarai.unreminder.service.update.InAppUpdateManager
 import net.interstellarai.unreminder.ui.navigation.NavGraph
 import net.interstellarai.unreminder.ui.theme.UnReminderTheme
-import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject lateinit var inAppUpdateManager: InAppUpdateManager
+
+    private lateinit var updateLauncher: ActivityResultLauncher<IntentSenderRequest>
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        updateLauncher = registerForActivityResult(
+            ActivityResultContracts.StartIntentSenderForResult()
+        ) { /* flexible update: no result action needed */ }
+
         setContent {
+            val snackbarHostState = remember { SnackbarHostState() }
+            val updateDownloaded by inAppUpdateManager.updateDownloaded.collectAsStateWithLifecycle()
+
+            LaunchedEffect(updateDownloaded) {
+                if (!updateDownloaded) return@LaunchedEffect
+                val result = snackbarHostState.showSnackbar(
+                    message = "Update ready",
+                    actionLabel = "Restart",
+                    duration = SnackbarDuration.Indefinite,
+                )
+                if (result == SnackbarResult.ActionPerformed) {
+                    inAppUpdateManager.completeUpdate()
+                }
+            }
+
             UnReminderTheme {
-                NavGraph()
+                NavGraph(snackbarHostState = snackbarHostState)
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        inAppUpdateManager.startUpdateCheck(this, updateLauncher)
     }
 }

--- a/app/src/main/java/net/interstellarai/unreminder/MainActivity.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/MainActivity.kt
@@ -1,6 +1,7 @@
 package net.interstellarai.unreminder
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -14,6 +15,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.android.play.core.install.model.ActivityResult as PlayActivityResult
 import dagger.hilt.android.AndroidEntryPoint
 import net.interstellarai.unreminder.service.update.InAppUpdateManager
 import net.interstellarai.unreminder.ui.navigation.NavGraph
@@ -22,6 +24,10 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    companion object {
+        private const val TAG = "MainActivity"
+    }
 
     @Inject lateinit var inAppUpdateManager: InAppUpdateManager
 
@@ -33,7 +39,11 @@ class MainActivity : ComponentActivity() {
 
         updateLauncher = registerForActivityResult(
             ActivityResultContracts.StartIntentSenderForResult()
-        ) { /* flexible update: no result action needed */ }
+        ) { result ->
+            if (result.resultCode == PlayActivityResult.RESULT_IN_APP_UPDATE_FAILED) {
+                Log.w(TAG, "In-app update flow failed (resultCode=${result.resultCode})")
+            }
+        }
 
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
@@ -48,6 +58,9 @@ class MainActivity : ComponentActivity() {
                 )
                 if (result == SnackbarResult.ActionPerformed) {
                     inAppUpdateManager.completeUpdate()
+                } else {
+                    // User dismissed — reset so rotation doesn't immediately re-show the snackbar
+                    inAppUpdateManager.resetUpdateDownloaded()
                 }
             }
 

--- a/app/src/main/java/net/interstellarai/unreminder/service/update/InAppUpdateManager.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/update/InAppUpdateManager.kt
@@ -1,0 +1,71 @@
+package net.interstellarai.unreminder.service.update
+
+import android.app.Activity
+import android.content.Context
+import android.util.Log
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.InstallStateUpdatedListener
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
+import com.google.android.play.core.install.model.UpdateAvailability
+import com.google.android.play.core.ktx.isFlexibleUpdateAllowed
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class InAppUpdateManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    companion object {
+        private const val TAG = "InAppUpdateManager"
+    }
+
+    private val appUpdateManager = AppUpdateManagerFactory.create(context)
+
+    private val _updateDownloaded = MutableStateFlow(false)
+    val updateDownloaded: StateFlow<Boolean> = _updateDownloaded.asStateFlow()
+
+    private var listenerRegistered = false
+
+    private val installStateListener = InstallStateUpdatedListener { state ->
+        if (state.installStatus() == InstallStatus.DOWNLOADED) {
+            _updateDownloaded.value = true
+        }
+    }
+
+    fun startUpdateCheck(
+        activity: Activity,
+        launcher: ActivityResultLauncher<IntentSenderRequest>,
+    ) {
+        if (!listenerRegistered) {
+            appUpdateManager.registerListener(installStateListener)
+            listenerRegistered = true
+        }
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
+            if (info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
+                info.isFlexibleUpdateAllowed
+            ) {
+                try {
+                    appUpdateManager.startUpdateFlowForResult(
+                        info,
+                        launcher,
+                        AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build(),
+                    )
+                } catch (e: android.content.IntentSender.SendIntentException) {
+                    Log.w(TAG, "startUpdateFlowForResult failed (debug/sideload)", e)
+                }
+            }
+        }
+    }
+
+    fun completeUpdate() {
+        appUpdateManager.completeUpdate()
+    }
+}

--- a/app/src/main/java/net/interstellarai/unreminder/service/update/InAppUpdateManager.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/update/InAppUpdateManager.kt
@@ -32,11 +32,16 @@ class InAppUpdateManager @Inject constructor(
     private val _updateDownloaded = MutableStateFlow(false)
     val updateDownloaded: StateFlow<Boolean> = _updateDownloaded.asStateFlow()
 
+    // Register once: startUpdateCheck is called on every onResume; re-registering
+    // the same listener accumulates duplicate callbacks from AppUpdateManager.
     private var listenerRegistered = false
+    private var updateCheckStarted = false
 
     private val installStateListener = InstallStateUpdatedListener { state ->
-        if (state.installStatus() == InstallStatus.DOWNLOADED) {
-            _updateDownloaded.value = true
+        when (state.installStatus()) {
+            InstallStatus.DOWNLOADED -> _updateDownloaded.value = true
+            InstallStatus.FAILED -> Log.w(TAG, "Update download failed: errorCode=${state.installErrorCode()}")
+            else -> Unit
         }
     }
 
@@ -48,24 +53,41 @@ class InAppUpdateManager @Inject constructor(
             appUpdateManager.registerListener(installStateListener)
             listenerRegistered = true
         }
-        appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
-            if (info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
-                info.isFlexibleUpdateAllowed
-            ) {
-                try {
-                    appUpdateManager.startUpdateFlowForResult(
-                        info,
-                        launcher,
-                        AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build(),
-                    )
-                } catch (e: android.content.IntentSender.SendIntentException) {
-                    Log.w(TAG, "startUpdateFlowForResult failed (debug/sideload)", e)
+        if (updateCheckStarted) return
+        updateCheckStarted = true
+        appUpdateManager.appUpdateInfo
+            .addOnSuccessListener { info ->
+                if (info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
+                    info.isFlexibleUpdateAllowed
+                ) {
+                    try {
+                        appUpdateManager.startUpdateFlowForResult(
+                            info,
+                            launcher,
+                            AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build(),
+                        )
+                    } catch (e: android.content.IntentSender.SendIntentException) {
+                        Log.w(TAG, "startUpdateFlowForResult failed (debug/sideload)", e)
+                    }
                 }
             }
-        }
+            .addOnFailureListener { e ->
+                Log.w(TAG, "appUpdateInfo check failed", e)
+            }
     }
 
     fun completeUpdate() {
+        appUpdateManager.unregisterListener(installStateListener)
+        listenerRegistered = false
+        _updateDownloaded.value = false
         appUpdateManager.completeUpdate()
+            .addOnFailureListener { e ->
+                Log.w(TAG, "completeUpdate failed, resetting state", e)
+                _updateDownloaded.value = false
+            }
+    }
+
+    fun resetUpdateDownloaded() {
+        _updateDownloaded.value = false
     }
 }

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
@@ -254,14 +254,14 @@ fun HabitEditScreen(
                     horizontalArrangement = Arrangement.spacedBy(Dimens.sm),
                     verticalArrangement = Arrangement.spacedBy(Dimens.sm),
                 ) {
-                    LocationChip(
+                    SelectionChip(
                         label = "Anywhere",
                         selected = uiState.selectedLocationIds.isEmpty(),
                         muted = uiState.selectedLocationIds.isEmpty(),
                         onClick = { viewModel.setAnywhere() },
                     )
                     allLocations.forEach { loc ->
-                        LocationChip(
+                        SelectionChip(
                             label = loc.name,
                             selected = loc.id in uiState.selectedLocationIds,
                             onClick = { viewModel.toggleLocation(loc.id) },
@@ -277,14 +277,14 @@ fun HabitEditScreen(
                     horizontalArrangement = Arrangement.spacedBy(Dimens.sm),
                     verticalArrangement = Arrangement.spacedBy(Dimens.sm),
                 ) {
-                    WindowChip(
+                    SelectionChip(
                         label = "Any time",
                         selected = uiState.selectedWindowIds.isEmpty(),
                         muted = uiState.selectedWindowIds.isEmpty(),
                         onClick = { viewModel.setAnyTime() },
                     )
                     allWindows.forEach { win ->
-                        WindowChip(
+                        SelectionChip(
                             label = win.label(),
                             selected = win.id in uiState.selectedWindowIds,
                             onClick = { viewModel.toggleWindow(win.id) },
@@ -539,39 +539,7 @@ private fun DescriptionBlock(
 }
 
 @Composable
-private fun WindowChip(
-    label: String,
-    selected: Boolean,
-    onClick: () -> Unit,
-    muted: Boolean = false,
-) {
-    val (bg, fg) = if (selected) {
-        MaterialTheme.colorScheme.primary to MaterialTheme.colorScheme.onPrimary
-    } else {
-        Color.Transparent to MaterialTheme.colorScheme.onBackground
-    }
-    val borderColor = if (selected) {
-        MaterialTheme.colorScheme.primary
-    } else {
-        MaterialTheme.colorScheme.onBackground.copy(alpha = 0.2f)
-    }
-    Box(
-        modifier = Modifier
-            .background(bg, UnReminderShapes.small)
-            .border(BorderStroke(1.5.dp, borderColor), UnReminderShapes.small)
-            .clickable(onClick = onClick)
-            .padding(horizontal = Dimens.md + 2.dp, vertical = Dimens.sm),
-    ) {
-        Text(
-            text = label,
-            style = SansBodyStrong,
-            color = fg.copy(alpha = if (muted && !selected) 0.5f else 1f),
-        )
-    }
-}
-
-@Composable
-private fun LocationChip(
+private fun SelectionChip(
     label: String,
     selected: Boolean,
     onClick: () -> Unit,

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitListScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitListScreen.kt
@@ -184,38 +184,25 @@ private fun HabitListHeader() {
 private fun AiDownloadBanner(
     aiStatus: AiStatus,
 ) {
-    val shouldRender = aiStatus is AiStatus.Unavailable || aiStatus is AiStatus.Empty
-    if (!shouldRender) return
-
+    val label = when (aiStatus) {
+        is AiStatus.Empty -> "cloud pool empty — variants being generated"
+        is AiStatus.Unavailable -> "AI unavailable — check cloud settings"
+        else -> return
+    }
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surfaceVariant)
             .padding(horizontal = Dimens.xxl, vertical = Dimens.md),
     ) {
-        when (aiStatus) {
-            is AiStatus.Empty -> {
-                MonoSectionLabel("cloud pool empty — variants being generated")
-                Spacer(Modifier.height(Dimens.xs + 2.dp))
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(2.dp)
-                        .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)),
-                )
-            }
-            is AiStatus.Unavailable -> {
-                MonoSectionLabel("AI unavailable — check cloud settings")
-                Spacer(Modifier.height(Dimens.xs + 2.dp))
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(2.dp)
-                        .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)),
-                )
-            }
-            else -> {} // Ready — not rendered
-        }
+        MonoSectionLabel(label)
+        Spacer(Modifier.height(Dimens.xs + 2.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp)
+                .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)),
+        )
     }
 }
 

--- a/app/src/main/java/net/interstellarai/unreminder/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/navigation/NavGraph.kt
@@ -13,6 +13,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -55,7 +57,10 @@ sealed class Screen(val route: String, val label: String, val icon: ImageVector)
 val bottomNavItems = listOf(Screen.Habits, Screen.Windows, Screen.Recent, Screen.Settings)
 
 @Composable
-fun NavGraph(navViewModel: NavViewModel = hiltViewModel()) {
+fun NavGraph(
+    navViewModel: NavViewModel = hiltViewModel(),
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+) {
     val isOnboarded by navViewModel.isOnboarded.collectAsStateWithLifecycle()
 
     // Lock startDestination once: prevents NavHost from re-routing after onboarding
@@ -92,6 +97,7 @@ fun NavGraph(navViewModel: NavViewModel = hiltViewModel()) {
 
     Scaffold(
         containerColor = androidx.compose.material3.MaterialTheme.colorScheme.background,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         bottomBar = {
             if (showBottomBar) NavigationBar(
                 containerColor = androidx.compose.material3.MaterialTheme.colorScheme.background,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ hiltNavigationCompose = "1.2.0"
 hiltWork = "1.2.0"
 workRuntime = "2.10.0"
 playServicesLocation = "21.3.0"
+appUpdate = "2.1.0"
 coroutines = "1.9.0"
 junit = "4.13.2"
 androidxJunit = "1.2.1"
@@ -51,6 +52,7 @@ hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWo
 hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltWork" }
 work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workRuntime" }
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
+play-app-update = { group = "com.google.android.play", name = "app-update-ktx", version.ref = "appUpdate" }
 coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutines" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## Summary

Adds support for Google Play In-App Updates with a flexible update flow. This allows the app to prompt users to update with either a prompt-based or immersive update UI, depending on the update priority.

## Changes

- **InAppUpdateManager singleton** (`app/src/main/java/.../service/update/InAppUpdateManager.kt`): Handles in-app update checks and lifecycle management
- **MainActivity integration**: Wired with dependency injection, update launcher, and snackbar UI feedback
- **NavGraph SnackbarHost**: Added to Scaffold for displaying update prompts
- **Dependencies**: Added Google Play `app-update-ktx:2.1.0` library

## Testing & Validation

- ✅ Type check: `./gradlew :app:compileDebugKotlin` — PASS
- ✅ Tests: 231 passed, 0 failed
- ✅ Build: `./gradlew :app:assembleDebug` — PASS

## Fixes

Closes #142