### PR TITLE
Fix: prune consumed variations before refill to prevent pool exhaustion

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/data/db/VariationDao.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/VariationDao.kt
@@ -24,6 +24,9 @@ interface VariationDao {
     @Query("DELETE FROM variations WHERE habit_id = :habitId")
     suspend fun deleteByHabit(habitId: Long)
 
+    @Query("DELETE FROM variations WHERE habit_id = :habitId AND consumed_at IS NOT NULL")
+    suspend fun deleteConsumedByHabit(habitId: Long)
+
     /** Inserts variations, silently ignoring duplicates that match the unique (habit_id, prompt_fingerprint, text) index. */
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(variants: List<VariationEntity>)

--- a/app/src/main/java/net/interstellarai/unreminder/data/repository/VariationRepository.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/repository/VariationRepository.kt
@@ -50,6 +50,8 @@ class VariationRepository @Inject constructor(
 
     suspend fun deleteForHabit(habitId: Long) = dao.deleteByHabit(habitId)
 
+    suspend fun deleteConsumedForHabit(habitId: Long) = dao.deleteConsumedByHabit(habitId)
+
     fun unusedVariationsFlow(habitId: Long): Flow<List<VariationEntity>> =
         dao.getUnusedFlow(habitId)
 

--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
@@ -77,6 +77,7 @@ class RefillWorker @AssistedInject constructor(
                     generatedAt = now,
                 )
             }
+            variationRepository.deleteConsumedForHabit(habitId)
             variationRepository.insertAll(entities)
             Result.success()
         } catch (e: CancellationException) {

--- a/app/src/test/java/net/interstellarai/unreminder/service/worker/RefillWorkerTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/worker/RefillWorkerTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.work.Data
 import androidx.work.ListenableWorker.Result
 import androidx.work.WorkerParameters
+import io.mockk.Ordering
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -96,6 +97,24 @@ class RefillWorkerTest {
         assertEquals(Result.success(), result)
         coVerify(exactly = 1) {
             mockVariationRepository.insertAll(match<List<VariationEntity>> { it.size == 20 })
+        }
+    }
+
+    @Test
+    fun `doWork prunes consumed variations before inserting new ones`() = runTest {
+        val habit = HabitEntity(id = 1L, name = "Meditate")
+        coEvery { mockHabitRepository.getByIdOnce(1L) } returns habit
+        val variants = (1..20).map { "variant $it" }
+        coEvery {
+            mockProxyClient.generateBatch(any(), any(), any(), any(), any(), any(), any())
+        } returns variants
+
+        val worker = createWorker()
+        worker.doWork()
+
+        coVerify(ordering = Ordering.ORDERED) {
+            mockVariationRepository.deleteConsumedForHabit(1L)
+            mockVariationRepository.insertAll(any())
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #134: Prevents pool exhaustion for long-standing habits by pruning consumed variations before refill.

The unique constraint on `(habit_id, prompt_fingerprint, text)` includes consumed rows, which blocks the LLM from regenerating previously-delivered texts during refill. This causes the pool to stay empty and triggers repeated Sentry "pool empty" errors.

## Root Cause

1. `RefillWorker` generates 20 new variation texts via LLM
2. LLM tends to regenerate previously-used texts for the same habit
3. `VariationDao.insert` uses `OnConflictStrategy.IGNORE`, silently dropping all duplicates
4. Consumed rows still occupy slots in the unique index, preventing any re-use
5. Pool refill inserts 0 or too few rows; pool stays empty on next trigger

## Solution

Delete consumed variations (rows with `consumed_at IS NOT NULL`) before inserting new ones. This frees unique-constraint slots so the LLM can safely recycle previously-delivered texts as fresh unconsumed rows.

## Changes

- **VariationDao.kt**: Add `deleteConsumedByHabit()` query (+3 lines)
- **VariationRepository.kt**: Add `deleteConsumedForHabit()` method (+2 lines)  
- **RefillWorker.kt**: Call `deleteConsumedForHabit()` before `insertAll()` (+1 line)
- **RefillWorkerTest.kt**: Add test verifying ordered execution of delete-then-insert (+19 lines)

## Validation

✅ Type check (compileDebugKotlin)  
✅ Lint (0 errors in changed files)  
✅ Android unit tests (231 passed)  
✅ Worker tests (56 passed)  
✅ Debug build (APK compiled)  
✅ Worker typecheck (no TypeScript errors)  

RefillWorkerTest includes ordered verification that `deleteConsumedForHabit` is called before `insertAll`.

## Trade-offs

- Recently-used UI list will empty after refill (acceptable: consumed rows are historical, pool health is higher priority)
- Consumed rows are no longer queryable after a refill (acceptable: they've already been delivered)