### PR TITLE
docs: close issue #140 as fixed by PR #104

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
@@ -241,9 +241,7 @@ class HabitEditViewModel @Inject constructor(
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
                 Log.e(TAG, "launchWithAi failed", e)
-                Sentry.captureException(e) { scope ->
-                    scope.setTag("component", "ai-ui")
-                }
+                Sentry.captureException(e) { scope -> scope.setTag("component", "ai-ui") }
                 _uiState.value = _uiState.value.copy(isGeneratingFields = false, errorMessage = errorMsg)
             }
         }


### PR DESCRIPTION
## Summary

Issue #140 reports a Sentry crash `LiteRtLmJniException: Failed to create engine: UNKNOWN: Unable to open zip archive`. Investigation confirms this issue **has already been permanently fixed** by PR #104 (commit `a78f208`, 2026-04-20), which removed the entire on-device LLM stack as part of the Phase 5 migration to cloud-based variation generation.

## Root Cause Analysis

The crash originated in the now-deleted `PromptGeneratorImpl.kt` when the on-device LiteRT-LM engine attempted to initialize with a corrupt, truncated, or invalid model file. The code only validated the first 4–8 magic bytes before passing the file to the native JNI layer, allowing partially-valid files to reach the engine and trigger the exception.

## Fix Already Applied

**Commit**: `a78f208` — "Phase 5: remove on-device LLM stack (#104)" (2026-04-20)

The fix removed 7 source files and 6 test files:
- `ModelCatalog.kt`, `ModelConfig.kt`, `PromptGeneratorImpl.kt`
- `ModelDownloadWorker.kt`, `ModelDownloadProgressRepository.kt`, `ActiveModelRepository.kt`
- `FeatureFlagsRepository.kt`

These files are no longer in the codebase. `CloudPromptGenerator` replaced them and has zero model-file loading — it calls a remote API for variation generation.

## Verification

✅ No LiteRT/LiteRtLm references exist in the codebase  
✅ No LiteRtLmJniException references exist  
✅ CloudPromptGenerator is the sole PromptGenerator binding  
✅ All validation checks pass (type check, lint, tests, build)

## User Impact

Sentry reports are from users still running pre-Phase-5 app versions. The crash is self-resolving as users update, and no Sentry filter is needed in the current version since the exception class no longer exists in the classpath.

---

Fixes #140