### PR TITLE
Fix: set fixed Sentry fingerprint on launch smoke test to prevent per-deploy GitHub issues

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/sentry/LaunchSmokeTest.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/sentry/LaunchSmokeTest.kt
@@ -19,7 +19,9 @@ object LaunchSmokeTest {
 
     /**
      * Fires the smoke event for [versionCode] if not already reported. Uses [Sentry.captureMessage]
-     * by default; the [capture] and [store] parameters exist for dependency injection in tests.
+     * by default, wrapped in [Sentry.withScope] to set a fixed fingerprint so all smoke events
+     * group under one Sentry issue across deploys; the [capture] and [store] parameters exist for
+     * dependency injection in tests.
      *
      * @return true if a message was fired, false if already reported for this versionCode.
      */

--- a/app/src/main/java/net/interstellarai/unreminder/service/sentry/LaunchSmokeTest.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/sentry/LaunchSmokeTest.kt
@@ -27,7 +27,12 @@ object LaunchSmokeTest {
         context: Context,
         versionName: String,
         versionCode: Int,
-        capture: (String) -> Unit = { Sentry.captureMessage(it) },
+        capture: (String) -> Unit = { msg ->
+            Sentry.withScope { scope ->
+                scope.fingerprint = listOf("launch-smoke")
+                Sentry.captureMessage(msg)
+            }
+        },
         store: SmokeStore = SharedPrefsSmokeStore(context)
     ): Boolean {
         val last = store.lastReportedVersionCode()


### PR DESCRIPTION
## Summary

The launch smoke test was capturing a Sentry message with the app version code embedded in the text, causing Sentry to generate a unique fingerprint for each deployment. This triggered the Sentry→GitHub auto-integration to create a new GitHub issue with every app release, generating noise.

## Problem

`LaunchSmokeTest.maybeFire()` captures a Sentry message like `"launch-smoke vmain-3c612c0+74"`. Because Sentry defaults to fingerprinting by message text, each new deployment produces a different fingerprint, which Sentry treats as a new issue. The GitHub auto-integration then fires and creates a new GitHub issue per deployment.

## Solution

Set a fixed Sentry fingerprint `["launch-smoke"]` on the smoke test message using `Sentry.withScope`. This ensures all smoke test events (across all deployments) are grouped into a single Sentry issue, preventing repeated GitHub issue creation.

**File modified**: `app/src/main/java/net/interstellarai/unreminder/service/sentry/LaunchSmokeTest.kt`

**Change**: Default `capture` lambda now wraps `captureMessage` in a Sentry scope with fixed fingerprint:
```kotlin
capture: (String) -> Unit = { msg ->
    Sentry.withScope { scope ->
        scope.fingerprint = listOf("launch-smoke")
        Sentry.captureMessage(msg)
    }
},
```

## Validation

- ✅ Kotlin compilation: `./gradlew :app:compileDebugKotlin` SUCCESSFUL
- ⚠️ Unit tests: Skipped (environment constraint — JDK missing for Hilt annotation processing), but all 4 existing tests inject their own `capture` lambda and are transparent to this default parameter change
- ✅ Code review: Change isolated to default lambda; no other callers affected

## Impact

- **Severity**: LOW — working-as-designed code path that reduces noise
- **Complexity**: LOW — single-line change in one file
- **Scope**: Isolated change with no side effects to existing tests or call sites

Fixes #130