### PR TITLE
Fix: restore Play Store draft status for release uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           packageName: net.interstellarai.unreminder
           releaseFiles: app/build/outputs/bundle/release/*.aab
           track: internal
-          status: completed
+          status: draft
           releaseName: ${{ env.VERSION_NAME }}
 
       - name: Build signed universal APK (for sideload)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
           packageName: net.interstellarai.unreminder
           releaseFiles: app/build/outputs/bundle/release/*.aab
           track: internal
+          # App is in Play Store draft state until first public release; use 'completed' after first publish
           status: draft
           releaseName: ${{ env.VERSION_NAME }}
 


### PR DESCRIPTION
## Problem

The Play Store upload step in the release workflow was failing with:
```
Only releases with status draft may be created on draft app.
```

This regression was introduced in PR #161 (`aa20e20`), which reverted the `status: draft` setting back to `status: completed`. However, the Play Store app is still in draft state and the API rejects non-draft uploads against draft apps.

## Root Cause

PR #120 (`cf0a86f`) correctly set `status: draft` as a workaround for the Play Store constraint while the app remains in draft mode. PR #161 prematurely reverted this without verifying the app had exited draft state.

## Changes

- Restore `status: draft` in `.github/workflows/release.yml` line 81

This allows the Play Store API to accept the release upload against the draft app.

## Validation

- Single-line YAML change verified
- Change restores previous working state from PR #120
- No code-level changes; workflow-only modification

Fixes #162