### PR TITLE
Route caught exceptions through Sentry in workers and receivers

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/geofence/GeofenceBroadcastReceiver.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/geofence/GeofenceBroadcastReceiver.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.GeofencingEvent
 import dagger.hilt.android.AndroidEntryPoint
+import io.sentry.Sentry
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -35,6 +36,9 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         val event = GeofencingEvent.fromIntent(intent) ?: return
         if (event.hasError()) {
             Log.e(TAG, "Geofence error: code=${event.errorCode}")
+            Sentry.captureMessage("Geofence error: code=${event.errorCode}") { scope ->
+                scope.setTag("component", "geofence")
+            }
             return
         }
 

--- a/app/src/main/java/net/interstellarai/unreminder/service/geofence/GeofenceBroadcastReceiver.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/geofence/GeofenceBroadcastReceiver.kt
@@ -9,6 +9,7 @@ import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.GeofencingEvent
 import dagger.hilt.android.AndroidEntryPoint
 import io.sentry.Sentry
+import io.sentry.SentryLevel
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -36,8 +37,10 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         val event = GeofencingEvent.fromIntent(intent) ?: return
         if (event.hasError()) {
             Log.e(TAG, "Geofence error: code=${event.errorCode}")
-            Sentry.captureMessage("Geofence error: code=${event.errorCode}") { scope ->
+            Sentry.captureMessage("Geofence error") { scope ->
                 scope.setTag("component", "geofence")
+                scope.setTag("error_code", event.errorCode.toString())
+                scope.level = SentryLevel.ERROR
             }
             return
         }

--- a/app/src/main/java/net/interstellarai/unreminder/service/notification/NotificationActionReceiver.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/notification/NotificationActionReceiver.kt
@@ -9,6 +9,7 @@ import net.interstellarai.unreminder.data.repository.TriggerRepository
 import net.interstellarai.unreminder.domain.model.TriggerStatus
 import net.interstellarai.unreminder.service.trigger.DismissalTracker
 import dagger.hilt.android.AndroidEntryPoint
+import io.sentry.Sentry
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -54,6 +55,7 @@ class NotificationActionReceiver : BroadcastReceiver() {
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
                 Log.e(TAG, "onReceive: failed for trigger=$triggerId action=$action", e)
+                Sentry.captureException(e) { scope -> scope.setTag("component", "notification-action") }
             } finally {
                 pendingResult.finish()
             }

--- a/app/src/main/java/net/interstellarai/unreminder/service/notification/NotificationActionReceiver.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/notification/NotificationActionReceiver.kt
@@ -55,7 +55,11 @@ class NotificationActionReceiver : BroadcastReceiver() {
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
                 Log.e(TAG, "onReceive: failed for trigger=$triggerId action=$action", e)
-                Sentry.captureException(e) { scope -> scope.setTag("component", "notification-action") }
+                Sentry.captureException(e) { scope ->
+                    scope.setTag("component", "notification-action")
+                    scope.setTag("trigger_id", triggerId.toString())
+                    scope.setTag("action", action)
+                }
             } finally {
                 pendingResult.finish()
             }

--- a/app/src/main/java/net/interstellarai/unreminder/service/trigger/TriggerPipeline.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/trigger/TriggerPipeline.kt
@@ -97,6 +97,7 @@ class TriggerPipeline @Inject constructor(
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             Log.e(TAG, "Trigger pipeline failed for trigger=$triggerId", e)
+            Sentry.captureException(e) { scope -> scope.setTag("component", "trigger-pipeline") }
             triggerRepository.updateOutcome(triggerId, TriggerStatus.DISMISSED)
         }
     }

--- a/app/src/main/java/net/interstellarai/unreminder/service/trigger/TriggerPipeline.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/trigger/TriggerPipeline.kt
@@ -97,7 +97,10 @@ class TriggerPipeline @Inject constructor(
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             Log.e(TAG, "Trigger pipeline failed for trigger=$triggerId", e)
-            Sentry.captureException(e) { scope -> scope.setTag("component", "trigger-pipeline") }
+            Sentry.captureException(e) { scope ->
+                scope.setTag("component", "trigger-pipeline")
+                scope.setTag("trigger_id", triggerId.toString())
+            }
             triggerRepository.updateOutcome(triggerId, TriggerStatus.DISMISSED)
         }
     }

--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
@@ -102,7 +102,10 @@ class RefillWorker @AssistedInject constructor(
             Result.retry()
         } catch (e: Exception) {
             Log.e(TAG, "Unexpected error for habit $habitId", e)
-            Sentry.captureException(e) { scope -> scope.setTag("component", "refill-worker") }
+            Sentry.captureException(e) { scope ->
+                scope.setTag("component", "refill-worker")
+                scope.setTag("habit_id", habitId.toString())
+            }
             Result.failure()
         }
     }

--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
@@ -13,6 +13,7 @@ import net.interstellarai.unreminder.data.db.VariationEntity
 import net.interstellarai.unreminder.data.repository.HabitRepository
 import net.interstellarai.unreminder.data.repository.VariationRepository
 import net.interstellarai.unreminder.data.repository.WorkerSettingsRepository
+import io.sentry.Sentry
 import java.io.IOException
 import java.time.Instant
 
@@ -101,6 +102,7 @@ class RefillWorker @AssistedInject constructor(
             Result.retry()
         } catch (e: Exception) {
             Log.e(TAG, "Unexpected error for habit $habitId", e)
+            Sentry.captureException(e) { scope -> scope.setTag("component", "refill-worker") }
             Result.failure()
         }
     }

--- a/app/src/main/java/net/interstellarai/unreminder/worker/RandomIntervalWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/worker/RandomIntervalWorker.kt
@@ -116,7 +116,10 @@ class RandomIntervalWorker @AssistedInject constructor(
             throw e
         } catch (e: Exception) {
             Log.e(TAG, "Random interval worker failed at step=$step", e)
-            Sentry.captureException(e) { scope -> scope.setTag("component", "random-interval-worker") }
+            Sentry.captureException(e) { scope ->
+                scope.setTag("component", "random-interval-worker")
+                scope.setTag("step", step)
+            }
         }
 
         scheduleNext()

--- a/app/src/main/java/net/interstellarai/unreminder/worker/RandomIntervalWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/worker/RandomIntervalWorker.kt
@@ -10,6 +10,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import io.sentry.Sentry
 import kotlinx.coroutines.CancellationException
 import net.interstellarai.unreminder.data.db.TriggerEntity
 import net.interstellarai.unreminder.data.repository.HabitRepository
@@ -115,6 +116,7 @@ class RandomIntervalWorker @AssistedInject constructor(
             throw e
         } catch (e: Exception) {
             Log.e(TAG, "Random interval worker failed at step=$step", e)
+            Sentry.captureException(e) { scope -> scope.setTag("component", "random-interval-worker") }
         }
 
         scheduleNext()

--- a/app/src/test/java/net/interstellarai/unreminder/service/trigger/TriggerPipelineTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/trigger/TriggerPipelineTest.kt
@@ -17,6 +17,12 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import io.sentry.Sentry
+import io.sentry.ScopeCallback
+import io.sentry.protocol.SentryId
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -274,6 +280,20 @@ class TriggerPipelineTest {
         pipeline.execute(42L)
 
         coVerify { triggerRepository.updateOutcome(42L, TriggerStatus.DISMISSED) }
+    }
+
+    @Test
+    fun `pipeline runtime exception reports to Sentry with trigger_id tag`() = runTest {
+        mockkStatic(Sentry::class)
+        every { Sentry.captureException(any(), any<ScopeCallback>()) } returns SentryId.EMPTY_ID
+
+        coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
+        coEvery { habitRepository.getEligibleHabits(any(), any()) } throws RuntimeException("boom")
+
+        pipeline.execute(42L)
+
+        verify(exactly = 1) { Sentry.captureException(any(), any<ScopeCallback>()) }
+        unmockkStatic(Sentry::class)
     }
 }
 

--- a/app/src/test/java/net/interstellarai/unreminder/service/worker/RefillWorkerTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/worker/RefillWorkerTest.kt
@@ -9,6 +9,12 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import io.sentry.Sentry
+import io.sentry.ScopeCallback
+import io.sentry.protocol.SentryId
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import net.interstellarai.unreminder.data.db.HabitEntity
@@ -176,5 +182,22 @@ class RefillWorkerTest {
 
         val worker = createWorker()
         assertEquals(Result.failure(), worker.doWork())
+    }
+
+    @Test
+    fun `doWork returns failure and reports to Sentry on unexpected exception`() = runTest {
+        mockkStatic(Sentry::class)
+        every { Sentry.captureException(any(), any<ScopeCallback>()) } returns SentryId.EMPTY_ID
+
+        val habit = HabitEntity(id = 1L, name = "Meditate")
+        coEvery { mockHabitRepository.getByIdOnce(1L) } returns habit
+        coEvery {
+            mockProxyClient.generateBatch(any(), any(), any(), any(), any(), any(), any())
+        } throws RuntimeException("unexpected failure")
+
+        val worker = createWorker()
+        assertEquals(Result.failure(), worker.doWork())
+        verify(exactly = 1) { Sentry.captureException(any(), any<ScopeCallback>()) }
+        unmockkStatic(Sentry::class)
     }
 }

--- a/app/src/test/java/net/interstellarai/unreminder/worker/RandomIntervalWorkerTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/worker/RandomIntervalWorkerTest.kt
@@ -8,8 +8,14 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
+import io.sentry.Sentry
+import io.sentry.ScopeCallback
+import io.sentry.protocol.SentryId
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import net.interstellarai.unreminder.data.db.TriggerEntity
@@ -111,6 +117,22 @@ class RandomIntervalWorkerTest {
 
         assertEquals(Result.success(), result)
         verify(exactly = 1) { mockWorkManager.enqueueUniqueWork(any<String>(), any<ExistingWorkPolicy>(), any<OneTimeWorkRequest>()) }
+    }
+
+    @Test
+    fun `doWork reports to Sentry when pipeline throws non-cancellation exception`() = runTest {
+        mockkStatic(Sentry::class)
+        every { Sentry.captureException(any(), any<ScopeCallback>()) } returns SentryId.EMPTY_ID
+
+        coEvery { mockWindowRepository.getActiveWindows() } returns listOf(windowCoveringAllDay())
+        coEvery { mockHabitRepository.getEligibleHabits(any()) } returns listOf(mockk())
+        coEvery { mockTriggerRepository.insert(any()) } returns 1L
+        coEvery { mockTriggerPipeline.execute(any()) } throws RuntimeException("pipeline error")
+
+        worker.doWork()
+
+        verify(exactly = 1) { Sentry.captureException(any(), any<ScopeCallback>()) }
+        unmockkStatic(Sentry::class)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Add `Sentry.captureException()` calls alongside existing `Log.e()` calls in all worker and receiver classes to surface production errors in the Sentry dashboard. Sentry is already initialized in the app, but five catch blocks swallow exceptions silently with only `Log.e()` calls. This change makes production failures visible in Sentry without changing error-handling behavior.

## Motivation

Caught exceptions in background workers and receivers currently only log to logcat via `Log.e()`, which is invisible in production. This limits visibility into production failures that occur in these background components. Routing these exceptions through Sentry provides developers with centralized error tracking and alerting for production incidents.

## Changes

### Files Modified (5 total)

| File | Change | Lines |
|------|--------|-------|
| `service/notification/NotificationActionReceiver.kt` | Add `import io.sentry.Sentry` + `Sentry.captureException()` | +2 |
| `service/worker/RefillWorker.kt` | Add `import io.sentry.Sentry` + `Sentry.captureException()` | +2 |
| `service/geofence/GeofenceBroadcastReceiver.kt` | Add `import io.sentry.Sentry` + `Sentry.captureMessage()` | +4 |
| `worker/RandomIntervalWorker.kt` | Add `import io.sentry.Sentry` + `Sentry.captureException()` | +2 |
| `service/trigger/TriggerPipeline.kt` | Add `Sentry.captureException()` (import already present) | +1 |

### Implementation Details

- Added `Sentry.captureException(e) { scope -> scope.setTag("component", "<component-name>") }` immediately after each `Log.e()` call
- For `GeofenceBroadcastReceiver` (no exception object available), used `Sentry.captureMessage()` with component tag
- All changes are additive side effects with no impact on existing error-handling logic
- CancellationExceptions are re-thrown before reaching Sentry calls and are not captured

## Validation

✅ **Kotlin Compilation**: `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- All five modified files compile cleanly
- Kotlin type-checking validates all imports, method signatures, and lambda syntax

⚠️ **Lint & Unit Tests**: Blocked by pre-existing JDK 25 / Hilt toolchain incompatibility
- Environment has JDK 25; project requires JDK 17
- Compilation gate (above) validates correctness for these additive changes
- No new test files required (Sentry calls are fire-and-forget side effects)

## Related Issue

Fixes #127

## Checklist

- [x] All 5 `Log.e` call sites now have an adjacent `Sentry.captureException()` or `Sentry.captureMessage()` call
- [x] Sentry import added to the 4 files that lacked it (TriggerPipeline already has it)
- [x] CancellationExceptions are not forwarded to Sentry (re-thrown before reaching the call)
- [x] No existing `Log.e` or `Log.w` calls were removed
- [x] Kotlin compilation succeeds (`compileDebugKotlin`)