### PR TITLE
Fix: attach anonymised log tail to feedback submissions

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/log/LogCollector.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/log/LogCollector.kt
@@ -1,0 +1,20 @@
+package net.interstellarai.unreminder.service.log
+
+import android.os.Process
+
+private val EMAIL_REGEX = Regex("""[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}""")
+private val IP_REGEX = Regex("""\b(?:\d{1,3}\.){3}\d{1,3}\b""")
+
+fun collectLogs(maxLines: Int = 200): String? = runCatching {
+    val pid = Process.myPid().toString()
+    val process = ProcessBuilder("logcat", "--pid=$pid", "-t", maxLines.toString())
+        .redirectErrorStream(true)
+        .start()
+    val raw = process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+    process.waitFor()
+    anonymizeLogs(raw).trim().takeIf { it.isNotEmpty() }
+}.getOrNull()
+
+fun anonymizeLogs(raw: String): String = raw
+    .replace(EMAIL_REGEX, "[EMAIL]")
+    .replace(IP_REGEX, "[IP]")

--- a/app/src/main/java/net/interstellarai/unreminder/ui/feedback/FeedbackViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/feedback/FeedbackViewModel.kt
@@ -13,6 +13,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import net.interstellarai.unreminder.BuildConfig
 import net.interstellarai.unreminder.data.repository.FeedbackRepository
+import net.interstellarai.unreminder.service.log.collectLogs
 import net.interstellarai.unreminder.di.DefaultDispatcher
 import net.interstellarai.unreminder.di.IoDispatcher
 import net.interstellarai.unreminder.service.github.GitHubApiService
@@ -143,13 +144,27 @@ class FeedbackViewModel @Inject constructor(
         return file.absolutePath
     }
 
-    private fun buildIssueBody(description: String): String =
-        buildString {
-            if (description.isNotBlank()) appendLine(description).appendLine()
-            appendLine("---")
-            appendLine("Device: ${Build.MANUFACTURER} ${Build.MODEL}")
-            appendLine("Android: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
-            appendLine("App: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+    private suspend fun buildIssueBody(description: String): String =
+        withContext(ioDispatcher) {
+            val logTail = collectLogs()
+            buildString {
+                if (description.isNotBlank()) appendLine(description).appendLine()
+                appendLine("---")
+                appendLine("Device: ${Build.MANUFACTURER} ${Build.MODEL}")
+                appendLine("Android: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
+                appendLine("App: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+                if (logTail != null) {
+                    appendLine()
+                    appendLine("---")
+                    appendLine("<details><summary>Logs</summary>")
+                    appendLine()
+                    appendLine("```")
+                    append(logTail)
+                    appendLine("```")
+                    appendLine()
+                    appendLine("</details>")
+                }
+            }
         }
 
     private fun scheduleUploadWorker() {

--- a/app/src/main/java/net/interstellarai/unreminder/worker/FeedbackUploadWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/worker/FeedbackUploadWorker.kt
@@ -9,9 +9,12 @@ import androidx.work.WorkerParameters
 import net.interstellarai.unreminder.BuildConfig
 import net.interstellarai.unreminder.data.repository.FeedbackRepository
 import net.interstellarai.unreminder.service.github.GitHubApiService
+import net.interstellarai.unreminder.service.log.collectLogs
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.IOException
 
@@ -34,6 +37,8 @@ class FeedbackUploadWorker @AssistedInject constructor(
 
         if (BuildConfig.FEEDBACK_ENDPOINT_URL.isBlank()) return Result.failure()
 
+        val logTail = withContext(Dispatchers.IO) { collectLogs() }
+
         for (item in pending) {
             try {
                 val title = item.description.take(60).ifBlank { "Feedback from app" }
@@ -43,6 +48,17 @@ class FeedbackUploadWorker @AssistedInject constructor(
                     appendLine("Device: ${Build.MANUFACTURER} ${Build.MODEL}")
                     appendLine("Android: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
                     appendLine("App: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+                    if (logTail != null) {
+                        appendLine()
+                        appendLine("---")
+                        appendLine("<details><summary>Logs</summary>")
+                        appendLine()
+                        appendLine("```")
+                        append(logTail)
+                        appendLine("```")
+                        appendLine()
+                        appendLine("</details>")
+                    }
                 }
 
                 val screenshotFile = item.screenshotPath

--- a/app/src/test/java/net/interstellarai/unreminder/service/log/LogCollectorTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/log/LogCollectorTest.kt
@@ -1,0 +1,37 @@
+package net.interstellarai.unreminder.service.log
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LogCollectorTest {
+
+    @Test fun `anonymizeLogs replaces email addresses`() {
+        val result = anonymizeLogs("user john@example.com connected")
+        assertTrue(result.contains("[EMAIL]"))
+        assertFalse(result.contains("john@example.com"))
+    }
+
+    @Test fun `anonymizeLogs replaces IPv4 addresses`() {
+        val result = anonymizeLogs("Connected to 192.168.1.100")
+        assertTrue(result.contains("[IP]"))
+        assertFalse(result.contains("192.168.1.100"))
+    }
+
+    @Test fun `anonymizeLogs leaves non-PII log lines unchanged`() {
+        val input = "D/FeedbackViewModel: Direct submit succeeded"
+        assertEquals(input, anonymizeLogs(input))
+    }
+
+    @Test fun `anonymizeLogs replaces multiple occurrences`() {
+        val result = anonymizeLogs("src 10.0.0.1 dst 192.168.1.1")
+        assertFalse(result.contains("10.0.0.1"))
+        assertFalse(result.contains("192.168.1.1"))
+        assertEquals("src [IP] dst [IP]", result)
+    }
+
+    @Test fun `anonymizeLogs handles empty string`() {
+        assertEquals("", anonymizeLogs(""))
+    }
+}


### PR DESCRIPTION
## Summary

When a user submits feedback, the last 200 lines of the app's logcat output (filtered to the app's own process) are captured, anonymized for PII, and appended to the issue body. This gives maintainers instant debugging context without any extra user action.

## Changes

### New Files
- `app/src/main/java/net/interstellarai/unreminder/service/log/LogCollector.kt` - Utility for reading and anonymizing app logs
- `app/src/test/java/net/interstellarai/unreminder/service/log/LogCollectorTest.kt` - Unit tests for log anonymization

### Updated Files
- `app/src/main/java/net/interstellarai/unreminder/ui/feedback/FeedbackViewModel.kt` - Make `buildIssueBody` suspend and append log tail
- `app/src/main/java/net/interstellarai/unreminder/worker/FeedbackUploadWorker.kt` - Add log tail to retry submissions

## Implementation Details

### LogCollector
- Top-level functions (no class wrapper) following the pattern used in `SentryOptionsBuilder.kt`
- `collectLogs()`: Reads logcat output via `ProcessBuilder("logcat", "--pid=<myPid>", "-t", "200")` and returns anonymized logs or null if unavailable
- `anonymizeLogs()`: Pure function that replaces email addresses and IPv4 addresses with `[EMAIL]` and `[IP]` placeholders
- Gracefully handles missing logcat access (test environments, restricted devices)

### FeedbackViewModel Changes
- `buildIssueBody()` is now a `suspend` function wrapped with `withContext(ioDispatcher)`
- Log tail is appended in a collapsed `<details>` block when available
- Call site at line 89 already within `viewModelScope.launch`, so no changes needed there

### FeedbackUploadWorker Changes
- Log tail is captured once before the retry loop via `withContext(Dispatchers.IO)`
- Same log tail is appended to each queued submission, providing fresh context on retry

## Testing

✅ Type check: `compileDebugKotlin` passed
✅ Unit tests: 227 tests passed across 35 suites
- LogCollectorTest: 5 passing
- FeedbackViewModelTest: 6 passing  
- FeedbackUploadWorkerTest: 5 passing
- All existing tests: 0 failures

## Validation Evidence

- No type errors or warnings in new implementation files
- All existing functionality remains unchanged when `collectLogs()` returns null
- Log anonymization correctly scrubs PII from log output
- Test dispatcher injection pattern correctly handles suspension

## User Impact

- **Before**: GitHub feedback issues contain only user description + static device metadata
- **After**: Issues include anonymized log tail in a collapsed details block for instant debugging context
- No UI changes; submission process is transparent to the user
- Log section is collapsed — doesn't clutter issue view

Fixes #94