### PR TITLE
ci: publish to Play Store production track on v* tag releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,8 @@ jobs:
           WORKER_SECRET: ${{ secrets.WORKER_SECRET }}
         run: ./gradlew bundleRelease --stacktrace
 
-      - name: Publish to Play Store internal track
+      - name: Publish to Play Store (internal draft — non-tag)
+        if: "!startsWith(github.ref, 'refs/tags/v')"
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
@@ -80,6 +81,17 @@ jobs:
           track: internal
           # App is in Play Store draft state until first public release; use 'completed' after first publish
           status: draft
+          releaseName: ${{ env.VERSION_NAME }}
+
+      - name: Publish to Play Store production (tag release)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: net.interstellarai.unreminder
+          releaseFiles: app/build/outputs/bundle/release/*.aab
+          track: production
+          status: completed
           releaseName: ${{ env.VERSION_NAME }}
 
       - name: Build signed universal APK (for sideload)


### PR DESCRIPTION
## Summary
- Non-tag pushes to \`main\` → internal track, draft (unchanged, for QA)
- \`v*\` tag pushes → production track, \`completed\` (auto-ships to all users)

To release: \`git tag v1.0.0 && git push origin v1.0.0\`