### PR TITLE
ci: revert internal track to draft until first Play Store publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           packageName: net.interstellarai.unreminder
           releaseFiles: app/build/outputs/bundle/release/*.aab
           track: internal
-          status: completed
+          status: draft
           releaseName: ${{ env.VERSION_NAME }}
 
       - name: Publish to Play Store production (tag release)


### PR DESCRIPTION
Play Store rejects `status: completed` on apps that haven't been manually published yet. Reverting to `draft` until first publish is done in Play Console.