### PR TITLE
ci: re-enable internal track completed status after first publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           packageName: net.interstellarai.unreminder
           releaseFiles: app/build/outputs/bundle/release/*.aab
           track: internal
-          status: draft
+          status: completed
           releaseName: ${{ env.VERSION_NAME }}
 
       - name: Publish to Play Store production (tag release)


### PR DESCRIPTION
App has been manually published once — switching internal track back to `status: completed` so CI publishes automatically on every main merge.