### PR TITLE
fix: show retry message instead of "AI unavailable" on 5xx worker errors

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
@@ -17,6 +17,7 @@ import net.interstellarai.unreminder.service.llm.PromptGenerator
 import net.interstellarai.unreminder.service.worker.RefillScheduler
 import net.interstellarai.unreminder.service.worker.SpendCapExceededException
 import net.interstellarai.unreminder.service.worker.WorkerAuthException
+import net.interstellarai.unreminder.service.worker.WorkerError
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.sentry.Sentry
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -229,6 +230,13 @@ class HabitEditViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(showSpendCapLink = true)
             } catch (e: LlmUnavailableException) {
                 _uiState.value = _uiState.value.copy(errorMessage = errorMsg)
+            } catch (e: WorkerError) {
+                if (e.code in 500..599) {
+                    _uiState.value = _uiState.value.copy(errorMessage = "Service temporarily unavailable — please try again.")
+                } else {
+                    Sentry.captureException(e) { scope -> scope.setTag("component", "ai-ui") }
+                    _uiState.value = _uiState.value.copy(errorMessage = errorMsg)
+                }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
                 Log.e(TAG, "launchWithAi failed", e)

--- a/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModelTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModelTest.kt
@@ -12,6 +12,7 @@ import net.interstellarai.unreminder.service.llm.PromptGenerator
 import net.interstellarai.unreminder.service.worker.RefillScheduler
 import net.interstellarai.unreminder.service.worker.SpendCapExceededException
 import net.interstellarai.unreminder.service.worker.WorkerAuthException
+import net.interstellarai.unreminder.service.worker.WorkerError
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -480,5 +481,35 @@ class HabitEditViewModelTest {
     fun `updateAutoAdjustLevel updates autoAdjustLevel in uiState`() = runTest(testDispatcher) {
         viewModel.updateAutoAdjustLevel(false)
         assertFalse(viewModel.uiState.value.autoAdjustLevel)
+    }
+
+    @Test
+    fun `autofillWithAi shows retry message and does not capture to Sentry on 5xx WorkerError`() = runTest(testDispatcher) {
+        mockkStatic(Sentry::class)
+        every { Sentry.captureException(any(), any<ScopeCallback>()) } returns SentryId.EMPTY_ID
+
+        coEvery { mockPromptGenerator.generateHabitFields(any()) } throws WorkerError(502, """{"error":"Upstream unavailable or returned invalid response"}""")
+
+        viewModel.autofillWithAi()
+        advanceUntilIdle()
+
+        assertEquals("Service temporarily unavailable — please try again.", viewModel.uiState.value.errorMessage)
+        verify(exactly = 0) { Sentry.captureException(any(), any<ScopeCallback>()) }
+        unmockkStatic(Sentry::class)
+    }
+
+    @Test
+    fun `autofillWithAi captures to Sentry and shows generic message on non-5xx WorkerError`() = runTest(testDispatcher) {
+        mockkStatic(Sentry::class)
+        every { Sentry.captureException(any(), any<ScopeCallback>()) } returns SentryId.EMPTY_ID
+
+        coEvery { mockPromptGenerator.generateHabitFields(any()) } throws WorkerError(422, """{"error":"Invalid input"}""")
+
+        viewModel.autofillWithAi()
+        advanceUntilIdle()
+
+        assertEquals("AI unavailable — fill in manually.", viewModel.uiState.value.errorMessage)
+        verify(exactly = 1) { Sentry.captureException(any(), any<ScopeCallback>()) }
+        unmockkStatic(Sentry::class)
     }
 }


### PR DESCRIPTION
Fixes Sentry issue 116410603.

A `WorkerError(502, …)` from Requesty being temporarily down was hitting the generic `catch (e: Exception)` branch in `launchWithAi`, which showed "AI unavailable — fill in manually" and captured the event to Sentry. Both behaviours were wrong for a transient upstream error.

**Change:** add a dedicated `catch (e: WorkerError)` before the generic handler:
- 5xx → "Service temporarily unavailable — please try again." / no Sentry noise
- non-5xx (bad input, etc.) → original generic message + Sentry capture as before

Mirrors the existing logic in `RefillWorker` which already does `Result.retry()` on 5xx.