### PR TITLE
feat: add Sentry error tracking to CF Worker

### DIFF
--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -8,6 +8,7 @@
       "name": "un-reminder-worker",
       "version": "0.0.1",
       "dependencies": {
+        "@sentry/cloudflare": "^10.0",
         "hono": "^4.12.0"
       },
       "devDependencies": {
@@ -76,7 +77,7 @@
     },
     "node_modules/@cloudflare/workers-types": {
       "version": "4.20260420.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -207,6 +208,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.126.0",
       "dev": true,
@@ -257,6 +267,36 @@
       "version": "1.0.0-rc.16",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry/cloudflare": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.51.0.tgz",
+      "integrity": "sha512-oDv2i70q25QPG9zN2GbdtkAjxBdvwHjZL+2aAuilDsagz+jUMq89EXrdh3RPdqnSlaTOqMJovIRDJVbTvpOCsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.x"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
+      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@sentry/cloudflare": "^10.0",
     "hono": "^4.12.0"
   },
   "devDependencies": {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,3 +1,4 @@
+import { withSentry } from '@sentry/cloudflare'
 import { Hono } from 'hono'
 import type { Env } from './types'
 import { authMiddleware } from './middleware/auth'
@@ -22,4 +23,7 @@ app.post('/v1/generate/batch', generateBatchHandler)
 app.post('/v1/habit-fields', habitFieldsHandler)
 app.post('/v1/preview', previewHandler)
 
-export default app
+export default withSentry(
+  (env: Env) => ({ dsn: env.SENTRY_DSN ?? '' }),
+  { fetch: app.fetch }
+)

--- a/worker/src/lib/requesty.ts
+++ b/worker/src/lib/requesty.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/cloudflare'
+
 const REQUESTY_URL = 'https://router.requesty.ai/v1/chat/completions'
 
 // Pricing per token via Requesty for gemini-3-flash-preview (2026-04).
@@ -75,6 +77,7 @@ export async function callRequestyWithSchemaRetry<T>(
       const match = err instanceof Error ? err.message.match(/Requesty (\d+)/) : null
       const status = match ? parseInt(match[1], 10) : 0
       console.error('[requesty] callRequesty failed', { isRetry, status, err })
+      Sentry.captureException(err instanceof Error ? err : new Error(String(err)), scope => { scope.setTag('requesty.failure', 'http'); scope.setContext('requesty', { isRetry, status }); return scope })
       return null
     }
 
@@ -88,8 +91,10 @@ export async function callRequestyWithSchemaRetry<T>(
         return { data: validated, outputTokens: totalOutputTokens, inputTokens: totalInputTokens }
       }
       console.warn('[requesty] schema validation failed', { isRetry, text: result.text.slice(0, 200) })
+      Sentry.captureMessage('Requesty schema validation failed', { level: 'warning', contexts: { requesty: { isRetry, text: result.text.slice(0, 200) } } })
     } catch (err) {
       console.warn('[requesty] JSON.parse failed', { isRetry, err, text: result.text.slice(0, 200) })
+      Sentry.captureException(err instanceof Error ? err : new Error(String(err)), scope => { scope.setTag('requesty.failure', 'json-parse'); scope.setContext('requesty', { isRetry, text: result.text.slice(0, 200) }); return scope })
     }
 
     if (isRetry) return null

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -6,6 +6,7 @@ export interface Env {
   // Secrets (set via `wrangler secret put`)
   UR_SHARED_SECRET: string
   UR_REQUESTY_KEY: string
+  SENTRY_DSN?: string
   // Vars (from wrangler.toml [vars])
   UR_DAILY_CAP_CENTS: string
   UR_MONTHLY_CAP_CENTS: string

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,4 +1,5 @@
 # Required secrets (set via wrangler secret put):
+#   SENTRY_DSN       — (optional) Sentry DSN for error tracking
 #   UR_SHARED_SECRET — shared auth secret for X-UR-Secret header
 #   UR_REQUESTY_KEY  — Requesty.ai API key for LLM calls
 


### PR DESCRIPTION
## Summary
- Adds `@sentry/cloudflare` to the Worker
- Wraps `index.ts` export with `withSentry` for automatic request context
- Instruments the three failure modes in `callRequestyWithSchemaRetry`:
  1. **HTTP error** from Requesty (non-200) → `captureException` tagged `requesty.failure=http`
  2. **JSON parse failure** on LLM response → `captureException` tagged `requesty.failure=json-parse`
  3. **Schema validation failure** → `captureMessage` at warning level

## Setup
After merging, add `SENTRY_DSN` as a Cloudflare Worker secret:
```
wrangler secret put SENTRY_DSN
```
Or merge PR #196 first — the deploy workflow will sync it automatically from the `SENTRY_DSN` GitHub secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)