### PR TITLE
feat: trigger cooldowns (completed=day, dismissed=3h) and pool size 50

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ updated by geofence `ENTER`/`EXIT` callbacks. Empty set means no known location.
    - `active = true`
    - Has **no** entries in `habit_location` (eligible everywhere), OR has at least one
      `location_id` matching a geofence the user is currently inside.
-   - Not fired within the last N minutes (configurable, default 90m) to avoid tight repeats.
+   - Has an active time window covering the current day and time (or no window association).
+   - **Not completed today**: any habit with a `COMPLETED` trigger fired after midnight is excluded for the rest of the day.
+   - **Not on cooldown**: any habit with a `DISMISSED` or unanswered `FIRED` trigger in the last 3 hours is excluded.
 3. Pick **one** habit by weighted-random selection from the eligible set, biased toward habits
    not recently prompted. Weight formula: `1 + min(minutesSince, 1440) / 120`, where
    `minutesSince` is minutes since the habit was last fired (cap: 1440 min = 24 h). A habit
@@ -203,15 +205,17 @@ updated by geofence `ENTER`/`EXIT` callbacks. Empty set means no known location.
 4. Pick an unused variation from the cloud-generated pool (see Variation entity). If the pool is empty, use the level description fallback (see Fallback below).
 5. Post the notification with the generated text. Action buttons: **Did it**, **Dismiss**.
 6. Record the trigger row with the generated prompt and the outcome when the user responds.
-   When `auto_adjust_level` is true: 3 consecutive `COMPLETED` triggers promote `dedication_level`
-   by 1 (up to max 5); 3 consecutive `DISMISSED` triggers demote it by 1. At level 0, 3 consecutive
-   `DISMISSED` triggers auto-pause the habit (`active = false`). The user can re-activate via the habit editor.
+   - **Did it (COMPLETED):** the habit is excluded from the rest of today's triggers (step 2 above). When `auto_adjust_level` is true, consecutive completions promote `dedication_level` (up to max 5).
+   - **Dismiss (DISMISSED):** a 3-hour cooldown applies before this habit is eligible again. When `auto_adjust_level` is true: 3 consecutive `DISMISSED` triggers demote `dedication_level` by 1; at level 0, 3 consecutive dismissals auto-pause the habit (`active = false`). The user can re-activate via the habit editor.
 
 ### Variation pool (cloud-generated)
 
 Notification texts are pre-generated in batches by the Cloudflare Worker (`/v1/generate/batch`) and stored locally in the `Variation` table. At fire time, `TriggerPipeline` picks an unused variation from the pool — no LLM call on the hot path.
 
-When the pool runs low (`VariationRepository.needsRefill`), a `RefillWorker` is enqueued to fetch a fresh batch from the worker.
+**Pool lifecycle:**
+- **Initial fill:** saving a new habit immediately enqueues `RefillWorker`, which calls `/v1/generate/batch` with `n = POOL_SIZE` (50) and stores the results. The pool starts at up to 50 unused variations.
+- **Refill:** when the unused count drops below `REFILL_THRESHOLD` (5), `TriggerPipeline` enqueues another `RefillWorker` run after each notification fire. Consumed variations are pruned before each batch is inserted, so the pool stays near the 50-variation target.
+- **Prompt change:** if a habit's name or description ladder changes on save, the entire pool is cleared and a fresh 50-variation refill is enqueued.
 
 ### Fallback
 If the variation pool is empty at fire time, the notification uses the `HabitLevelDescriptionEntity`
@@ -220,9 +224,11 @@ back to `habit.name`. A refill is enqueued in both cases. AI autofill and notifi
 
 ### Habit-field autofill (cloud)
 
-Used to generate all 6 `description_ladder` slots when the user taps "Autofill with AI" in the Habit editor.
-Calls the worker's `/v1/habit-fields` endpoint with the habit title; the worker returns
-`{ descriptionLadder: string[] }` with one description per dedication level (0–5).
+Used to generate all 6 `description_ladder` slots when the user taps "✦ autofill" in the Habit editor
+(labeled "Autofill descriptions" in the UI). Calls the worker's `/v1/habit-fields` endpoint with the habit
+title; the worker returns `{ descriptionLadder: string[] }` with one description per dedication level (0–5).
+This fills the description fields only — the 50-notification pool is generated separately when the habit is
+saved (see Variation pool above).
 
 ### Notification preview (cloud)
 
@@ -236,9 +242,12 @@ Generates a sample notification via the worker's `/v1/preview` endpoint. Shown i
 2. **Habit editor** — name, dedication level progress bar (0–5), auto-adjust toggle, 6-level
    description fields (level 0 = minimum/low-floor, level 5 = full version; current level highlighted),
    location chips (multi-select from saved locations; no selection = "Anywhere"), active toggle.
-   AI-assist row: **Autofill with AI** (populates all 6 levels (0–5) from the habit name via cloud AI;
-   enabled when name ≥ 2 chars) · **Preview notification** (generates a sample notification text;
-   enabled when at least one level description is non-blank).
+   AI-assist row: **✦ autofill** ("Autofill descriptions" — populates all 6 description-ladder levels (0–5)
+   from the habit name via cloud AI; enabled when name ≥ 2 chars) · **↻ resample** / **Preview** (generates
+   a live sample notification text via cloud AI; enabled when at least one level description is non-blank).
+   Saving the habit (new or edited) automatically queues background generation of up to 50 notification
+   variants via `RefillWorker` — these are the texts that fire as actual notifications. The autofill button
+   fills descriptions only; the pool is built on save.
 3. **Windows screen** — list of windows. FAB → add window. Tap → edit. BugReport icon in header → Feedback screen.
 4. **Window editor** — start/end time pickers, days-of-week chips, frequency slider (1–3), active toggle.
 5. **Locations screen** — dynamic list of named locations (any label, not restricted to HOME/WORK).
@@ -287,7 +296,7 @@ The app is considered MVP-complete when:
 
 1. User can CRUD habits, windows, and locations in the UI.
 2. Daily schedule job correctly populates `Trigger` rows for the next 24h based on active windows.
-3. At least one window trigger fires during its window with a Gemma 3 1B-generated prompt.
+3. At least one window trigger fires during its window using a prompt drawn from the variation pool (Gemini Flash via Requesty.ai, pre-generated by the Cloudflare Worker).
 4. Entering the registered `HOME` geofence triggers exactly one notification 5 minutes later (debounced).
 5. Notification actions correctly record `COMPLETED` or `DISMISSED`.
 6. Recent triggers screen displays the last 20 triggers with their generated prompts.

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/HabitDao.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/HabitDao.kt
@@ -61,12 +61,21 @@ interface HabitDao {
             SELECT habit_id FROM triggers
             WHERE habit_id IS NOT NULL
             AND fired_at IS NOT NULL
-            AND fired_at > :excludeAfter
+            AND status = 'COMPLETED'
+            AND fired_at > :completedCutoff
+        )
+        AND h.id NOT IN (
+            SELECT habit_id FROM triggers
+            WHERE habit_id IS NOT NULL
+            AND fired_at IS NOT NULL
+            AND (status = 'DISMISSED' OR status = 'FIRED')
+            AND fired_at > :dismissedCutoff
         )
     """)
     suspend fun getEligibleHabits(
         locationIds: List<Long>,
-        excludeAfter: Long,
+        completedCutoff: Long,
+        dismissedCutoff: Long,
         currentSecondOfDay: Int,
         dayOfWeekBit: Int
     ): List<HabitEntity>

--- a/app/src/main/java/net/interstellarai/unreminder/data/repository/HabitRepository.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/repository/HabitRepository.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.Flow
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.ZoneId
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -34,16 +35,21 @@ class HabitRepository @Inject constructor(
     suspend fun getByIdOnce(id: Long): HabitEntity? = habitDao.getByIdOnce(id)
 
     suspend fun getEligibleHabits(
-        currentLocationIds: Set<Long>,
-        excludeRecentMinutes: Long = 240
+        currentLocationIds: Set<Long>
     ): List<HabitEntity> {
-        val cutoff = Instant.now().minusSeconds(excludeRecentMinutes * 60).toEpochMilli()
+        // COMPLETED today: excluded until midnight (done for the day).
+        val completedCutoff = LocalDate.now()
+            .atStartOfDay(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli()
+        // DISMISSED or FIRED-but-not-responded: 3-hour cooldown.
+        val dismissedCutoff = Instant.now().minusSeconds(3 * 3600L).toEpochMilli()
         // Room crashes if IN-clause receives an empty list. Use an impossible ID (-1) so the
         // clause is syntactically valid but never matches any real habit row.
         val ids = if (currentLocationIds.isEmpty()) listOf(-1L) else currentLocationIds.toList()
         val currentSecondOfDay = LocalTime.now().toSecondOfDay()
         val dayOfWeekBit = 1 shl (LocalDate.now().dayOfWeek.value - 1)
-        return habitDao.getEligibleHabits(ids, cutoff, currentSecondOfDay, dayOfWeekBit)
+        return habitDao.getEligibleHabits(ids, completedCutoff, dismissedCutoff, currentSecondOfDay, dayOfWeekBit)
     }
 
     suspend fun getLocationIds(habitId: Long): List<Long> =

--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
@@ -65,7 +65,7 @@ class RefillWorker @AssistedInject constructor(
                 habitTags = emptyList(),
                 locationName = "",
                 timeOfDay = "",
-                n = 20,
+                n = VariationRepository.POOL_SIZE,
                 workerUrl = url,
                 workerSecret = secret,
             )

--- a/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitRepositoryTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitRepositoryTest.kt
@@ -27,11 +27,11 @@ class HabitRepositoryTest {
 
     @Test
     fun `getEligibleHabits with empty set uses sentinel -1L`() = runTest {
-        coEvery { habitDao.getEligibleHabits(listOf(-1L), any(), any(), any()) } returns emptyList()
+        coEvery { habitDao.getEligibleHabits(listOf(-1L), any(), any(), any(), any()) } returns emptyList()
 
         repo.getEligibleHabits(emptySet())
 
-        coVerify { habitDao.getEligibleHabits(listOf(-1L), any(), any(), any()) }
+        coVerify { habitDao.getEligibleHabits(listOf(-1L), any(), any(), any(), any()) }
     }
 
     @Test
@@ -45,10 +45,10 @@ class HabitRepositoryTest {
 
     @Test
     fun `getEligibleHabits with non-empty set passes ids directly`() = runTest {
-        coEvery { habitDao.getEligibleHabits(listOf(1L, 2L), any(), any(), any()) } returns emptyList()
+        coEvery { habitDao.getEligibleHabits(listOf(1L, 2L), any(), any(), any(), any()) } returns emptyList()
 
         repo.getEligibleHabits(setOf(1L, 2L))
 
-        coVerify { habitDao.getEligibleHabits(listOf(1L, 2L), any(), any(), any()) }
+        coVerify { habitDao.getEligibleHabits(listOf(1L, 2L), any(), any(), any(), any()) }
     }
 }

--- a/app/src/test/java/net/interstellarai/unreminder/service/trigger/TriggerPipelineTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/trigger/TriggerPipelineTest.kt
@@ -100,14 +100,14 @@ class TriggerPipelineTest {
 
         pipeline.execute(42L)
 
-        coVerify(exactly = 0) { habitRepository.getEligibleHabits(any(), any()) }
+        coVerify(exactly = 0) { habitRepository.getEligibleHabits(any()) }
         coVerify(exactly = 0) { notificationHelper.postTriggerNotification(any(), any(), any()) }
     }
 
     @Test
     fun `no eligible habits - dismisses trigger and no notification`() = runTest {
         coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
-        coEvery { habitRepository.getEligibleHabits(any(), any()) } returns emptyList()
+        coEvery { habitRepository.getEligibleHabits(any()) } returns emptyList()
 
         pipeline.execute(42L)
 
@@ -122,7 +122,7 @@ class TriggerPipelineTest {
             promptFingerprint = "fp", generatedAt = Instant.now(), consumedAt = null
         )
         coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
-        coEvery { habitRepository.getEligibleHabits(any(), any()) } returns listOf(testHabit)
+        coEvery { habitRepository.getEligibleHabits(any()) } returns listOf(testHabit)
         coEvery { variationRepository.pickRandomUnused(1L) } returns variation
         coEvery { variationRepository.needsRefill(1L) } returns false
 
@@ -142,7 +142,7 @@ class TriggerPipelineTest {
     @Test
     fun `pool empty - falls back to habit name when level description is blank`() = runTest {
         coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
-        coEvery { habitRepository.getEligibleHabits(any(), any()) } returns listOf(testHabit)
+        coEvery { habitRepository.getEligibleHabits(any()) } returns listOf(testHabit)
         coEvery { variationRepository.pickRandomUnused(1L) } returns null
         coEvery { levelDescriptionRepository.getDescriptionForLevel(1L, 2) } returns ""
 
@@ -162,7 +162,7 @@ class TriggerPipelineTest {
     @Test
     fun `pool empty - uses level description when available`() = runTest {
         coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
-        coEvery { habitRepository.getEligibleHabits(any(), any()) } returns listOf(testHabit)
+        coEvery { habitRepository.getEligibleHabits(any()) } returns listOf(testHabit)
         coEvery { variationRepository.pickRandomUnused(1L) } returns null
         coEvery { levelDescriptionRepository.getDescriptionForLevel(1L, 2) } returns
             "Take three deep breaths"
@@ -186,7 +186,7 @@ class TriggerPipelineTest {
             promptFingerprint = "fp", generatedAt = Instant.now(), consumedAt = null
         )
         coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
-        coEvery { habitRepository.getEligibleHabits(any(), any()) } returns listOf(testHabit)
+        coEvery { habitRepository.getEligibleHabits(any()) } returns listOf(testHabit)
         coEvery { variationRepository.pickRandomUnused(1L) } returns variation
         coEvery { variationRepository.needsRefill(1L) } returns true
 
@@ -199,7 +199,7 @@ class TriggerPipelineTest {
     @Test
     fun `pickRandomUnused throws - falls back to habit name and enqueues refill`() = runTest {
         coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
-        coEvery { habitRepository.getEligibleHabits(any(), any()) } returns listOf(testHabit)
+        coEvery { habitRepository.getEligibleHabits(any()) } returns listOf(testHabit)
         coEvery { variationRepository.pickRandomUnused(1L) } throws RuntimeException("db error")
         coEvery { levelDescriptionRepository.getDescriptionForLevel(1L, 2) } returns null
 
@@ -212,7 +212,7 @@ class TriggerPipelineTest {
     @Test
     fun `pickRandomUnused throws CancellationException - propagates`() = runTest {
         coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
-        coEvery { habitRepository.getEligibleHabits(any(), any()) } returns listOf(testHabit)
+        coEvery { habitRepository.getEligibleHabits(any()) } returns listOf(testHabit)
         coEvery { variationRepository.pickRandomUnused(1L) } throws CancellationException("cancelled")
 
         try {
@@ -233,7 +233,7 @@ class TriggerPipelineTest {
             promptFingerprint = "fp", generatedAt = Instant.now(), consumedAt = null
         )
         coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
-        coEvery { habitRepository.getEligibleHabits(any(), any()) } returns listOf(testHabit)
+        coEvery { habitRepository.getEligibleHabits(any()) } returns listOf(testHabit)
         coEvery { locationRepository.getByIds(setOf(1L)) } returns listOf(loc)
         coEvery { variationRepository.pickRandomUnused(1L) } returns variation
         coEvery { variationRepository.needsRefill(1L) } returns false
@@ -250,7 +250,7 @@ class TriggerPipelineTest {
             promptFingerprint = "fp", generatedAt = Instant.now(), consumedAt = null
         )
         coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
-        coEvery { habitRepository.getEligibleHabits(any(), any()) } returns listOf(testHabit)
+        coEvery { habitRepository.getEligibleHabits(any()) } returns listOf(testHabit)
         coEvery { locationRepository.getByIds(any()) } returns emptyList()
         coEvery { variationRepository.pickRandomUnused(1L) } returns variation
         coEvery { variationRepository.needsRefill(1L) } returns false
@@ -263,7 +263,7 @@ class TriggerPipelineTest {
     @Test
     fun `pipeline exception is caught and does not propagate`() = runTest {
         coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
-        coEvery { habitRepository.getEligibleHabits(any(), any()) } returns listOf(testHabit)
+        coEvery { habitRepository.getEligibleHabits(any()) } returns listOf(testHabit)
         coEvery { variationRepository.pickRandomUnused(1L) } throws CancellationException("test")
 
         try {
@@ -275,7 +275,7 @@ class TriggerPipelineTest {
     @Test
     fun `pipeline runtime exception dismisses the trigger`() = runTest {
         coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
-        coEvery { habitRepository.getEligibleHabits(any(), any()) } throws RuntimeException("boom")
+        coEvery { habitRepository.getEligibleHabits(any()) } throws RuntimeException("boom")
 
         pipeline.execute(42L)
 
@@ -288,7 +288,7 @@ class TriggerPipelineTest {
         every { Sentry.captureException(any(), any<ScopeCallback>()) } returns SentryId.EMPTY_ID
 
         coEvery { triggerRepository.getById(42L) } returns scheduledTrigger
-        coEvery { habitRepository.getEligibleHabits(any(), any()) } throws RuntimeException("boom")
+        coEvery { habitRepository.getEligibleHabits(any()) } throws RuntimeException("boom")
 
         pipeline.execute(42L)
 


### PR DESCRIPTION
## Summary

This PR ships two behaviour changes to the Un-Reminder trigger/scheduling logic:

**1. Trigger outcome cooldowns**
- **COMPLETED**: habit is excluded for the rest of the day (eligibility cutoff = midnight of current day in local timezone). A habit you mark complete won't re-trigger until tomorrow.
- **DISMISSED / FIRED**: 3-hour cooldown before the habit becomes eligible again. This replaces the old single `excludeRecentMinutes` parameter with two distinct cutoffs (`completedCutoff`, `dismissedCutoff`) in `HabitDao.getEligibleHabits`.
- `HabitRepository` now computes both cutoffs internally and no longer exposes `excludeRecentMinutes`.

**2. Pool size increased to 50**
- `RefillWorker` now generates `n = VariationRepository.POOL_SIZE` (50) variations per fill instead of the previous hardcoded `n = 20`.
- Initial pool fill and refill (triggered when pool drops below 5) both use the same constant.

**Tests**
- `HabitRepositoryTest` updated to match the new 5-argument DAO mock signature (was 4 args).

**README**
- Pool lifecycle documented (initial fill = 50, refill when < 5).
- Trigger outcome behavior documented.
- Stale "Gemma 3 1B" acceptance-criteria reference removed.
- `autofill-descriptions` vs `pool-generation` clarified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)