### PR TITLE
fix(worker): reject empty strings in validateVariants + log missing SENTRY_DSN

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -24,6 +24,9 @@ app.post('/v1/habit-fields', habitFieldsHandler)
 app.post('/v1/preview', previewHandler)
 
 export default withSentry(
-  (env: Env) => ({ dsn: env.SENTRY_DSN ?? '' }),
+  (env: Env) => {
+    if (!env.SENTRY_DSN) console.warn('[un-reminder-worker] SENTRY_DSN not set — errors will not be reported to Sentry')
+    return { dsn: env.SENTRY_DSN ?? '' }
+  },
   { fetch: app.fetch }
 )

--- a/worker/src/routes/generateBatch.ts
+++ b/worker/src/routes/generateBatch.ts
@@ -21,7 +21,7 @@ function buildPrompt(habitTitle: string, habitTags: string[], locationName: stri
 
 function validateVariants(parsed: unknown): string[] | null {
   if (!Array.isArray(parsed)) return null
-  if (!parsed.every((s) => typeof s === 'string')) return null
+  if (!parsed.every((s) => typeof s === 'string' && s.trim() !== '')) return null
   return parsed as string[]
 }
 

--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -297,6 +297,26 @@ describe('un-reminder-worker', () => {
     expect(res.status).toBe(502)
   })
 
+  // ---- Empty-string rejection test ----
+
+  it('returns 502 when LLM returns empty strings in variants array', async () => {
+    mockRequestySuccess(['', '', ''])
+    mockRequestySuccess(['', '', ''])
+
+    const req = makeRequest('/v1/generate/batch', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-UR-Secret': SECRET,
+      },
+      body: validBody(3),
+    })
+    const ctx = createExecutionContext()
+    const res = await app.fetch(req, testEnv(), ctx)
+    await waitOnExecutionContext(ctx)
+    expect(res.status).toBe(502)
+  })
+
   // ---- Retry-then-succeed test ----
 
   it('returns 200 when first call is malformed but retry succeeds', async () => {


### PR DESCRIPTION
## Summary

- **Bug fix**: `validateVariants` in `generateBatch.ts` only checked `typeof s === 'string'`, so an LLM response of `["", "", ...]` would pass validation, get stored in the notification pool, and produce blank push notifications. Added `&& s.trim() !== ''` to match the same guard used in `habitFields.ts`.
- **Observability**: Added a `console.warn` in `src/index.ts` at startup when `SENTRY_DSN` is unset. Without this, operators have no signal that all Sentry error reporting is silently disabled — the warning is immediately visible in CF Worker logs.
- **Test**: Added one new test case that queues two all-empty-string responses and asserts the endpoint returns 502 (retry-exhausted), confirming the fix is exercised.

## Test plan

- [ ] All 57 existing tests still pass (`npm test` in `worker/`)
- [ ] New test `returns 502 when LLM returns empty strings in variants array` is green
- [ ] Deploy to staging and confirm the SENTRY_DSN warning appears in CF logs when the secret is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)