### PR TITLE
fix: RefillWorker parse errors retry + scheduler REPLACE policy

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillScheduler.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillScheduler.kt
@@ -27,7 +27,7 @@ class RefillScheduler @Inject constructor(
             .build()
         WorkManager.getInstance(context).enqueueUniqueWork(
             "${RefillWorker.WORK_NAME}-$habitId",
-            ExistingWorkPolicy.KEEP,
+            ExistingWorkPolicy.REPLACE,
             request,
         )
     }

--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
@@ -16,6 +16,7 @@ import net.interstellarai.unreminder.data.repository.WorkerSettingsRepository
 import io.sentry.Sentry
 import java.io.IOException
 import java.time.Instant
+import org.json.JSONException
 
 @HiltWorker
 class RefillWorker @AssistedInject constructor(
@@ -100,6 +101,21 @@ class RefillWorker @AssistedInject constructor(
         } catch (e: IOException) {
             Log.w(TAG, "IO error for habit $habitId, will retry", e)
             Result.retry()
+        } catch (e: JSONException) {
+            Log.w(TAG, "JSON parse error for habit $habitId, will retry", e)
+            Result.retry()
+        } catch (e: RuntimeException) {
+            if (e.cause is JSONException) {
+                Log.w(TAG, "JSON parse error (wrapped) for habit $habitId, will retry", e)
+                Result.retry()
+            } else {
+                Log.e(TAG, "Unexpected error for habit $habitId", e)
+                Sentry.captureException(e) { scope ->
+                    scope.setTag("component", "refill-worker")
+                    scope.setTag("habit_id", habitId.toString())
+                }
+                Result.failure()
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Unexpected error for habit $habitId", e)
             Sentry.captureException(e) { scope ->

--- a/app/src/test/java/net/interstellarai/unreminder/service/worker/RefillWorkerTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/worker/RefillWorkerTest.kt
@@ -22,6 +22,7 @@ import net.interstellarai.unreminder.data.db.VariationEntity
 import net.interstellarai.unreminder.data.repository.HabitRepository
 import net.interstellarai.unreminder.data.repository.VariationRepository
 import net.interstellarai.unreminder.data.repository.WorkerSettingsRepository
+import org.json.JSONException
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -182,6 +183,30 @@ class RefillWorkerTest {
 
         val worker = createWorker()
         assertEquals(Result.failure(), worker.doWork())
+    }
+
+    @Test
+    fun `doWork returns retry on JSONException`() = runTest {
+        val habit = HabitEntity(id = 1L, name = "Meditate")
+        coEvery { mockHabitRepository.getByIdOnce(1L) } returns habit
+        coEvery {
+            mockProxyClient.generateBatch(any(), any(), any(), any(), any(), any(), any())
+        } throws JSONException("Value at 0 is null")
+
+        val worker = createWorker()
+        assertEquals(Result.retry(), worker.doWork())
+    }
+
+    @Test
+    fun `doWork returns retry on RuntimeException wrapping JSONException`() = runTest {
+        val habit = HabitEntity(id = 1L, name = "Meditate")
+        coEvery { mockHabitRepository.getByIdOnce(1L) } returns habit
+        coEvery {
+            mockProxyClient.generateBatch(any(), any(), any(), any(), any(), any(), any())
+        } throws RuntimeException("json error", JSONException("Unexpected token"))
+
+        val worker = createWorker()
+        assertEquals(Result.retry(), worker.doWork())
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **JSONException now retries instead of permanently failing**: `RefillWorker` previously caught all non-IO exceptions in a generic `Exception` block that returned `Result.failure()`. This meant a `JSONException` from a malformed/truncated response permanently stopped WorkManager from retrying that habit's refill job, leaving the pool empty forever. Two new catch blocks — one for `org.json.JSONException` directly and one for `RuntimeException` whose cause is a `JSONException` — now return `Result.retry()` with the same log pattern as the `IOException` handler.

- **REPLACE policy resets backoff when pool hits zero**: `RefillScheduler` previously used `ExistingWorkPolicy.KEEP`, so if a stuck-in-backoff job existed for a habit, any new `enqueueForHabit()` call from `TriggerPipeline` was silently dropped. Changed to `ExistingWorkPolicy.REPLACE` so that when the pool empties and a new refill is requested, the backoff-stuck job is cancelled and a fresh one starts immediately. Duplicate insertions are safe — the DB uses an `IGNORE` conflict strategy.

- **Together these two changes ensure the pool recovers**: Previously, a single malformed response could permanently break a habit's pool. Now both transient parse failures and re-enqueue-while-backing-off scenarios self-heal.

## Test plan

- [ ] Existing `RefillWorkerTest` suite passes (all pre-existing tests unchanged)
- [ ] New test `doWork returns retry on JSONException` — verifies `JSONException` maps to `Result.retry()`
- [ ] New test `doWork returns retry on RuntimeException wrapping JSONException` — verifies wrapped `JSONException` also maps to `Result.retry()`
- [ ] Manually verify: trigger a habit refill with a mocked malformed JSON response and confirm WorkManager retries rather than permanently stopping

🤖 Generated with [Claude Code](https://claude.com/claude-code)