### PR TITLE
feat: per-habit daily trigger limit (N times/day)

### DIFF
--- a/app/schemas/net.interstellarai.unreminder.data.db.AppDatabase/8.json
+++ b/app/schemas/net.interstellarai.unreminder.data.db.AppDatabase/8.json
@@ -1,0 +1,516 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "77d27bdd615f65216ce00f0f527a67bf",
+    "entities": [
+      {
+        "tableName": "habits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `dedication_level` INTEGER NOT NULL, `description_ladder` TEXT NOT NULL, `auto_adjust_level` INTEGER NOT NULL, `daily_limit` INTEGER NOT NULL, `active` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dedicationLevel",
+            "columnName": "dedication_level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "descriptionLadder",
+            "columnName": "description_ladder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAdjustLevel",
+            "columnName": "auto_adjust_level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dailyLimit",
+            "columnName": "daily_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "windows",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `start_time` INTEGER NOT NULL, `end_time` INTEGER NOT NULL, `days_of_week_bitmask` INTEGER NOT NULL, `frequency_per_day` INTEGER NOT NULL, `active` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "end_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "daysOfWeekBitmask",
+            "columnName": "days_of_week_bitmask",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frequencyPerDay",
+            "columnName": "frequency_per_day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "triggers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `window_id` INTEGER, `habit_id` INTEGER, `scheduled_at` INTEGER NOT NULL, `fired_at` INTEGER, `status` TEXT NOT NULL, `generated_prompt` TEXT, `source` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "windowId",
+            "columnName": "window_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "scheduledAt",
+            "columnName": "scheduled_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firedAt",
+            "columnName": "fired_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generatedPrompt",
+            "columnName": "generated_prompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "locations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `lat` REAL NOT NULL, `lng` REAL NOT NULL, `radius_m` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lat",
+            "columnName": "lat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lng",
+            "columnName": "lng",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "radiusM",
+            "columnName": "radius_m",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "habit_location",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`habit_id` INTEGER NOT NULL, `location_id` INTEGER NOT NULL, PRIMARY KEY(`habit_id`, `location_id`), FOREIGN KEY(`habit_id`) REFERENCES `habits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`location_id`) REFERENCES `locations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationId",
+            "columnName": "location_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "habit_id",
+            "location_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_habit_location_location_id",
+            "unique": false,
+            "columnNames": [
+              "location_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_habit_location_location_id` ON `${TABLE_NAME}` (`location_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "habits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "habit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "locations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "location_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "habit_window",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`habit_id` INTEGER NOT NULL, `window_id` INTEGER NOT NULL, PRIMARY KEY(`habit_id`, `window_id`), FOREIGN KEY(`habit_id`) REFERENCES `habits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`window_id`) REFERENCES `windows`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "windowId",
+            "columnName": "window_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "habit_id",
+            "window_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_habit_window_window_id",
+            "unique": false,
+            "columnNames": [
+              "window_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_habit_window_window_id` ON `${TABLE_NAME}` (`window_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "habits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "habit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "windows",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "window_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pending_feedback",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `screenshot_path` TEXT, `description` TEXT NOT NULL, `queued_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "screenshotPath",
+            "columnName": "screenshot_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queued_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "variations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `habit_id` INTEGER NOT NULL, `text` TEXT NOT NULL, `prompt_fingerprint` TEXT NOT NULL, `generated_at` INTEGER NOT NULL, `consumed_at` INTEGER, FOREIGN KEY(`habit_id`) REFERENCES `habits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptFingerprint",
+            "columnName": "prompt_fingerprint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generatedAt",
+            "columnName": "generated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "consumedAt",
+            "columnName": "consumed_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_variations_habit_id",
+            "unique": false,
+            "columnNames": [
+              "habit_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_variations_habit_id` ON `${TABLE_NAME}` (`habit_id`)"
+          },
+          {
+            "name": "index_variations_habit_id_prompt_fingerprint_text",
+            "unique": true,
+            "columnNames": [
+              "habit_id",
+              "prompt_fingerprint",
+              "text"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_variations_habit_id_prompt_fingerprint_text` ON `${TABLE_NAME}` (`habit_id`, `prompt_fingerprint`, `text`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "habits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "habit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "habit_level_descriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`habit_id` INTEGER NOT NULL, `level` INTEGER NOT NULL, `description` TEXT NOT NULL, PRIMARY KEY(`habit_id`, `level`), FOREIGN KEY(`habit_id`) REFERENCES `habits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "habit_id",
+            "level"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_habit_level_descriptions_habit_id",
+            "unique": false,
+            "columnNames": [
+              "habit_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_habit_level_descriptions_habit_id` ON `${TABLE_NAME}` (`habit_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "habits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "habit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '77d27bdd615f65216ce00f0f527a67bf')"
+    ]
+  }
+}

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/AppDatabase.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/AppDatabase.kt
@@ -16,7 +16,7 @@ import androidx.room.TypeConverters
         VariationEntity::class,
         HabitLevelDescriptionEntity::class
     ],
-    version = 7,
+    version = 8,
     exportSchema = true
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/HabitDao.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/HabitDao.kt
@@ -71,11 +71,19 @@ interface HabitDao {
             AND (status = 'DISMISSED' OR status = 'FIRED')
             AND fired_at > :dismissedCutoff
         )
+        AND (
+            SELECT COUNT(*) FROM triggers
+            WHERE habit_id = h.id
+            AND fired_at IS NOT NULL
+            AND fired_at >= :startOfDayCutoff
+            AND (status = 'COMPLETED' OR status = 'DISMISSED' OR status = 'FIRED')
+        ) < h.daily_limit
     """)
     suspend fun getEligibleHabits(
         locationIds: List<Long>,
         completedCutoff: Long,
         dismissedCutoff: Long,
+        startOfDayCutoff: Long,
         currentSecondOfDay: Int,
         dayOfWeekBit: Int
     ): List<HabitEntity>

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/HabitEntity.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/HabitEntity.kt
@@ -16,6 +16,8 @@ data class HabitEntity(
     val descriptionLadder: List<String> = List(6) { "" },
     @ColumnInfo(name = "auto_adjust_level")
     val autoAdjustLevel: Boolean = true,
+    @ColumnInfo(name = "daily_limit")
+    val dailyLimit: Int = 1,
     val active: Boolean = true,
     @ColumnInfo(name = "created_at")
     val createdAt: Instant = Instant.now(),

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/Migration7To8.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/Migration7To8.kt
@@ -1,0 +1,10 @@
+package net.interstellarai.unreminder.data.db
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_7_8 = object : Migration(7, 8) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `habits` ADD COLUMN `daily_limit` INTEGER NOT NULL DEFAULT 1")
+    }
+}

--- a/app/src/main/java/net/interstellarai/unreminder/data/repository/HabitRepository.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/repository/HabitRepository.kt
@@ -44,12 +44,22 @@ class HabitRepository @Inject constructor(
             .toEpochMilli()
         // DISMISSED or FIRED-but-not-responded: 3-hour cooldown.
         val dismissedCutoff = Instant.now().minusSeconds(3 * 3600L).toEpochMilli()
+        // Per-habit daily cap boundary: same epoch as completedCutoff today, kept as a
+        // distinct named param so the SQL stays self-documenting if cooldown semantics diverge.
+        val startOfDayCutoff = completedCutoff
         // Room crashes if IN-clause receives an empty list. Use an impossible ID (-1) so the
         // clause is syntactically valid but never matches any real habit row.
         val ids = if (currentLocationIds.isEmpty()) listOf(-1L) else currentLocationIds.toList()
         val currentSecondOfDay = LocalTime.now().toSecondOfDay()
         val dayOfWeekBit = 1 shl (LocalDate.now().dayOfWeek.value - 1)
-        return habitDao.getEligibleHabits(ids, completedCutoff, dismissedCutoff, currentSecondOfDay, dayOfWeekBit)
+        return habitDao.getEligibleHabits(
+            ids,
+            completedCutoff,
+            dismissedCutoff,
+            startOfDayCutoff,
+            currentSecondOfDay,
+            dayOfWeekBit
+        )
     }
 
     suspend fun getLocationIds(habitId: Long): List<Long> =

--- a/app/src/main/java/net/interstellarai/unreminder/di/AppModule.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/di/AppModule.kt
@@ -16,6 +16,7 @@ import net.interstellarai.unreminder.data.db.MIGRATION_3_4
 import net.interstellarai.unreminder.data.db.MIGRATION_4_5
 import net.interstellarai.unreminder.data.db.MIGRATION_5_6
 import net.interstellarai.unreminder.data.db.MIGRATION_6_7
+import net.interstellarai.unreminder.data.db.MIGRATION_7_8
 import net.interstellarai.unreminder.data.db.HabitLevelDescriptionDao
 import net.interstellarai.unreminder.data.db.HabitWindowCrossRefDao
 import net.interstellarai.unreminder.data.db.PendingFeedbackDao
@@ -49,7 +50,7 @@ object AppModule {
             context,
             AppDatabase::class.java,
             "unreminder.db"
-        ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7).build()
+        ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8).build()
     }
 
     @Provides

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
@@ -214,6 +214,37 @@ fun HabitEditScreen(
 
                 Spacer(Modifier.height(Dimens.lg))
 
+                MonoSectionLabel("daily limit")
+                Spacer(Modifier.height(Dimens.sm))
+                val limitOptions = listOf(1, 2, 3, 5, 10)
+                var limitMenuExpanded by remember { mutableStateOf(false) }
+                Box {
+                    Text(
+                        "${uiState.dailyLimit}× / day",
+                        style = SansBody,
+                        color = MaterialTheme.colorScheme.onBackground,
+                        modifier = Modifier
+                            .clickable { limitMenuExpanded = true }
+                            .padding(vertical = Dimens.sm),
+                    )
+                    DropdownMenu(
+                        expanded = limitMenuExpanded,
+                        onDismissRequest = { limitMenuExpanded = false },
+                    ) {
+                        limitOptions.forEach { n ->
+                            DropdownMenuItem(
+                                text = { Text("${n}× / day", style = SansBody) },
+                                onClick = {
+                                    viewModel.updateDailyLimit(n)
+                                    limitMenuExpanded = false
+                                },
+                            )
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(Dimens.lg))
+
                 MonoSectionLabel("description ladder")
                 Spacer(Modifier.height(Dimens.sm))
 

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
@@ -38,6 +38,7 @@ data class HabitEditUiState(
     val descriptionLadder: List<String> = List(6) { "" },
     val dedicationLevel: Int = 2,
     val autoAdjustLevel: Boolean = true,
+    val dailyLimit: Int = 1,
     val selectedLocationIds: Set<Long> = emptySet(),
     val selectedWindowIds: Set<Long> = emptySet(),
     val active: Boolean = true,
@@ -115,6 +116,7 @@ class HabitEditViewModel @Inject constructor(
                     descriptionLadder = habit.descriptionLadder,
                     dedicationLevel = habit.dedicationLevel,
                     autoAdjustLevel = habit.autoAdjustLevel,
+                    dailyLimit = habit.dailyLimit,
                     selectedLocationIds = locationIds,
                     selectedWindowIds = windowIds,
                     active = habit.active
@@ -137,6 +139,7 @@ class HabitEditViewModel @Inject constructor(
     }
     fun updateDedicationLevel(level: Int) { _uiState.value = _uiState.value.copy(dedicationLevel = level) }
     fun updateAutoAdjustLevel(enabled: Boolean) { _uiState.value = _uiState.value.copy(autoAdjustLevel = enabled) }
+    fun updateDailyLimit(limit: Int) { _uiState.value = _uiState.value.copy(dailyLimit = limit) }
 
     fun toggleLocation(locationId: Long) {
         val current = _uiState.value.selectedLocationIds
@@ -174,6 +177,7 @@ class HabitEditViewModel @Inject constructor(
                             descriptionLadder = state.descriptionLadder,
                             dedicationLevel = state.dedicationLevel,
                             autoAdjustLevel = state.autoAdjustLevel,
+                            dailyLimit = state.dailyLimit,
                             active = state.active
                         )
                     )
@@ -185,6 +189,7 @@ class HabitEditViewModel @Inject constructor(
                             descriptionLadder = state.descriptionLadder,
                             dedicationLevel = state.dedicationLevel,
                             autoAdjustLevel = state.autoAdjustLevel,
+                            dailyLimit = state.dailyLimit,
                             active = state.active
                         )
                     )

--- a/app/src/test/java/net/interstellarai/unreminder/data/db/HabitDaoEligibleTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/db/HabitDaoEligibleTest.kt
@@ -1,0 +1,134 @@
+package net.interstellarai.unreminder.data.db
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.runTest
+import net.interstellarai.unreminder.domain.model.TriggerStatus
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+@RunWith(RobolectricTestRunner::class)
+class HabitDaoEligibleTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var habitDao: HabitDao
+    private lateinit var triggerDao: TriggerDao
+
+    private val midnightMillis: Long = LocalDate.now()
+        .atStartOfDay(ZoneId.systemDefault())
+        .toInstant()
+        .toEpochMilli()
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java
+        ).allowMainThreadQueries().build()
+        habitDao = db.habitDao()
+        triggerDao = db.triggerDao()
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    /**
+     * Calls the DAO with cutoffs aligned to midnight so that ONLY the new
+     * daily-limit clause can exclude a habit. The completed/dismissed cooldowns
+     * use strict-greater-than against the same epoch, so a trigger fired at
+     * exactly midnight is not excluded by them — that isolates the new clause.
+     */
+    private suspend fun queryEligible(): List<HabitEntity> = habitDao.getEligibleHabits(
+        locationIds = listOf(-1L),
+        completedCutoff = midnightMillis,
+        dismissedCutoff = midnightMillis,
+        startOfDayCutoff = midnightMillis,
+        currentSecondOfDay = 0,
+        dayOfWeekBit = 1
+    )
+
+    private suspend fun insertHabit(name: String, dailyLimit: Int = 1): Long =
+        habitDao.insert(HabitEntity(name = name, dailyLimit = dailyLimit))
+
+    private suspend fun insertTrigger(habitId: Long, status: TriggerStatus, firedAt: Instant?) {
+        triggerDao.insert(
+            TriggerEntity(
+                habitId = habitId,
+                scheduledAt = Instant.ofEpochMilli(midnightMillis),
+                firedAt = firedAt,
+                status = status
+            )
+        )
+    }
+
+    @Test
+    fun `dailyLimit 1 with no triggers today is eligible`() = runTest {
+        insertHabit("h1", dailyLimit = 1)
+
+        val eligible = queryEligible()
+
+        assertEquals(1, eligible.size)
+        assertEquals("h1", eligible[0].name)
+    }
+
+    @Test
+    fun `dailyLimit 1 with one COMPLETED trigger today is excluded`() = runTest {
+        val id = insertHabit("h2", dailyLimit = 1)
+        insertTrigger(id, TriggerStatus.COMPLETED, Instant.ofEpochMilli(midnightMillis))
+
+        val eligible = queryEligible()
+
+        assertTrue(eligible.none { it.id == id })
+    }
+
+    @Test
+    fun `dailyLimit 2 with one DISMISSED trigger today is eligible`() = runTest {
+        val id = insertHabit("h3", dailyLimit = 2)
+        insertTrigger(id, TriggerStatus.DISMISSED, Instant.ofEpochMilli(midnightMillis))
+
+        val eligible = queryEligible()
+
+        assertTrue(eligible.any { it.id == id })
+    }
+
+    @Test
+    fun `dailyLimit 2 with two FIRED triggers today is excluded`() = runTest {
+        val id = insertHabit("h4", dailyLimit = 2)
+        insertTrigger(id, TriggerStatus.FIRED, Instant.ofEpochMilli(midnightMillis))
+        insertTrigger(id, TriggerStatus.FIRED, Instant.ofEpochMilli(midnightMillis + 1))
+
+        val eligible = queryEligible()
+
+        assertTrue(eligible.none { it.id == id })
+    }
+
+    @Test
+    fun `dailyLimit 1 with one COMPLETED trigger from yesterday is eligible`() = runTest {
+        val id = insertHabit("h5", dailyLimit = 1)
+        // 1ms before today's local midnight = yesterday
+        insertTrigger(id, TriggerStatus.COMPLETED, Instant.ofEpochMilli(midnightMillis - 1))
+
+        val eligible = queryEligible()
+
+        assertTrue(eligible.any { it.id == id })
+    }
+
+    @Test
+    fun `dailyLimit 1 with one SCHEDULED trigger today is eligible`() = runTest {
+        val id = insertHabit("h6", dailyLimit = 1)
+        // SCHEDULED triggers have firedAt = null and must not count toward the cap
+        insertTrigger(id, TriggerStatus.SCHEDULED, firedAt = null)
+
+        val eligible = queryEligible()
+
+        assertTrue(eligible.any { it.id == id })
+    }
+}

--- a/app/src/test/java/net/interstellarai/unreminder/data/db/Migration7To8Test.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/db/Migration7To8Test.kt
@@ -1,0 +1,58 @@
+package net.interstellarai.unreminder.data.db
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class Migration7To8Test {
+
+    private fun createV7Database(): SupportSQLiteDatabase {
+        val config = SupportSQLiteOpenHelper.Configuration.builder(RuntimeEnvironment.getApplication())
+            .name(null) // in-memory
+            .callback(object : SupportSQLiteOpenHelper.Callback(7) {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS `habits` (" +
+                        "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "`name` TEXT NOT NULL, " +
+                        "`dedication_level` INTEGER NOT NULL DEFAULT 2, " +
+                        "`description_ladder` TEXT NOT NULL DEFAULT '[]', " +
+                        "`auto_adjust_level` INTEGER NOT NULL DEFAULT 1, " +
+                        "`active` INTEGER NOT NULL DEFAULT 1, " +
+                        "`created_at` INTEGER NOT NULL DEFAULT 0, " +
+                        "`updated_at` INTEGER NOT NULL DEFAULT 0)"
+                    )
+                }
+
+                override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {}
+            })
+            .build()
+
+        return FrameworkSQLiteOpenHelperFactory().create(config).writableDatabase
+    }
+
+    @Test
+    fun `MIGRATION_7_8 adds daily_limit column with default 1`() {
+        val db = createV7Database()
+
+        db.execSQL(
+            "INSERT INTO habits (name, dedication_level, description_ladder, auto_adjust_level, active, created_at, updated_at) " +
+            "VALUES ('meditate', 2, '[]', 1, 1, 0, 0)"
+        )
+
+        MIGRATION_7_8.migrate(db)
+
+        val cursor = db.query("SELECT daily_limit FROM habits WHERE name = 'meditate'")
+        cursor.moveToFirst()
+        assertEquals(1, cursor.getInt(0))
+        cursor.close()
+
+        db.close()
+    }
+}

--- a/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitRepositoryTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitRepositoryTest.kt
@@ -27,11 +27,11 @@ class HabitRepositoryTest {
 
     @Test
     fun `getEligibleHabits with empty set uses sentinel -1L`() = runTest {
-        coEvery { habitDao.getEligibleHabits(listOf(-1L), any(), any(), any(), any()) } returns emptyList()
+        coEvery { habitDao.getEligibleHabits(listOf(-1L), any(), any(), any(), any(), any()) } returns emptyList()
 
         repo.getEligibleHabits(emptySet())
 
-        coVerify { habitDao.getEligibleHabits(listOf(-1L), any(), any(), any(), any()) }
+        coVerify { habitDao.getEligibleHabits(listOf(-1L), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -45,10 +45,10 @@ class HabitRepositoryTest {
 
     @Test
     fun `getEligibleHabits with non-empty set passes ids directly`() = runTest {
-        coEvery { habitDao.getEligibleHabits(listOf(1L, 2L), any(), any(), any(), any()) } returns emptyList()
+        coEvery { habitDao.getEligibleHabits(listOf(1L, 2L), any(), any(), any(), any(), any()) } returns emptyList()
 
         repo.getEligibleHabits(setOf(1L, 2L))
 
-        coVerify { habitDao.getEligibleHabits(listOf(1L, 2L), any(), any(), any(), any()) }
+        coVerify { habitDao.getEligibleHabits(listOf(1L, 2L), any(), any(), any(), any(), any()) }
     }
 }


### PR DESCRIPTION
## Summary

Adds a configurable per-habit `dailyLimit` so users can cap how many times a single habit can fire per local calendar day. Default is `1` for all existing rows (backward-compatible). Users can pick `1×`, `2×`, `3×`, `5×`, or `10×` per day from a dropdown on the habit edit screen.

Fixes #211

## Changes

### Data layer
- **`HabitEntity`**: new `@ColumnInfo("daily_limit") val dailyLimit: Int = 1` field
- **`AppDatabase`**: bumped `version = 7` → `version = 8`
- **`Migration7To8.kt`** (new): one-line `ALTER TABLE habits ADD COLUMN daily_limit INTEGER NOT NULL DEFAULT 1`
- **`AppModule`**: `MIGRATION_7_8` wired into the `.addMigrations(...)` chain
- **`HabitDao.getEligibleHabits`**: new `startOfDayCutoff: Long` parameter and a correlated-subquery exclusion clause:
  ```sql
  AND (SELECT COUNT(*) FROM triggers
       WHERE habit_id = h.id
         AND fired_at IS NOT NULL
         AND fired_at >= :startOfDayCutoff
         AND status IN ('COMPLETED','DISMISSED','FIRED')
      ) < h.daily_limit
  ```
- **`HabitRepository`**: computes `startOfDayCutoff` (same local-midnight epoch-millis used for `completedCutoff`) and passes it through

### UI layer
- **`HabitEditViewModel`**: `dailyLimit: Int = 1` on `HabitEditUiState`; `loadHabit` / `updateDailyLimit(n)` / `save()` plumbing
- **`HabitEditScreen`**: new "daily limit" section after the dedication block — `DropdownMenu` with options `[1, 2, 3, 5, 10]`, formatted as `Nx / day`

### Schema & tests
- **`app/schemas/.../8.json`** (new, KSP-generated): committed alongside the entity/version bump
- **`Migration7To8Test`** (new): asserts the migration adds `daily_limit` with default `1`
- **`HabitDaoEligibleTest`** (new): 6 scenarios — limit met / not met, status filter (`SCHEDULED`/`fired_at IS NULL` ignored), yesterday boundary
- **`HabitRepositoryTest`**: existing mocks updated for the new 6th DAO param

## Validation evidence

All `./gradlew` checks ran on commit `6fa58df`:

| Check | Command | Result |
|-------|---------|--------|
| Compile | `./gradlew :app:compileDebugKotlin` | PASS |
| Lint | `./gradlew :app:lintDebug` | PASS (BUILD SUCCESSFUL in 47s) |
| Unit tests | `./gradlew :app:testDebugUnitTest` | PASS — 269 tests / 40 classes / 0 failures / 0 errors / 0 skipped |
| Build | `./gradlew :app:assembleDebug` | PASS — `app/schemas/.../8.json` regenerated |

New / changed test classes for #211:

| Class | Tests |
|-------|------|
| `Migration7To8Test` | 1 |
| `HabitDaoEligibleTest` | 6 |
| `HabitRepositoryTest` | 3 (mocks updated for 6th DAO param) |
| `HabitEditViewModelTest` | 32 (existing; covers new `dailyLimit` plumbing path) |

There is no `ktlint` / `detekt` / `spotless` plugin in the build, so no formatter step applies. The `worker/` Cloudflare-Worker module is untouched by this change.

## Behavior notes

- **Existing users**: every habit gets `daily_limit = 1` on migration. For the common case where `COMPLETED` is the only consumed status, this is identical to today's behavior (the existing `COMPLETED`-until-midnight cooldown already produced that effect). Where it diverges: a habit previously fired 3× a day with the first two `DISMISSED`ed will now fire only 1× until the user bumps the limit — this is the intended product behavior per #211.
- **`>=` vs `>`**: `startOfDayCutoff` uses `>=` (a trigger fired exactly at midnight counts as today); the existing cooldown clauses use `>` because they're "ago" cutoffs.
- **Status set**: `('COMPLETED','DISMISSED','FIRED')` mirrors the union already considered "consumed" by the two existing cooldown clauses. `SCHEDULED` triggers (fired_at NULL) correctly do not count.
- **`dailyLimit = 0`** is unreachable from the UI; if it ever occurred, `(COUNT(*)) < 0` is always false → habit never eligible. Acceptable; no `CHECK` constraint added.

## Out of scope

- Custom limit values beyond the `[1, 2, 3, 5, 10]` presets
- Index on `triggers(habit_id, fired_at)` — flagged as a follow-up if daily trigger volume grows
- Per-window or per-location daily limits
- Worker-side enforcement (exclusion is entirely in the Android query path)
- Localized strings (codebase uses hardcoded English throughout this screen)

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — PASS
- [x] `./gradlew :app:lintDebug` — PASS
- [x] `./gradlew :app:testDebugUnitTest` — 269/269 PASS
- [x] `./gradlew :app:assembleDebug` — PASS, schema `8.json` regenerated
- [ ] Manual smoke: install debug APK over a v7 install, open a habit, confirm default `1× / day`, change to `2× / day`, save, reopen — value persists. (Not run in CI; reviewer to confirm before merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)