### PR TITLE
feat: per-habit notification cooldown (default 3h, configurable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ A repeatable thing the user wants to do. Each habit has:
   If the habit is already at level 0, 3 consecutive `DISMISSED` triggers set it to `active = false`
   (auto-paused). The user can re-activate it from the habit editor.
   (see [Trigger Logic §5](#5-trigger-logic)).
+- `daily_limit` — integer; default 1. Maximum number of `COMPLETED`/`FIRED` triggers per local day before
+  the habit is excluded from selection. User-configurable in the Habit editor.
+- `cooldown_minutes` — integer minutes; default 180 (= 3 h). After a `DISMISSED` or unanswered `FIRED`
+  trigger, the habit is excluded from selection until this many minutes have passed. `0` disables this
+  exclusion. User-configurable in the Habit editor (presets 1h · 2h · 3h · 6h · 12h · None).
 - `created_at`, `updated_at`.
 
 Per-level descriptive text is stored separately in `HabitLevelDescriptionEntity` (`habit_level_descriptions`
@@ -197,7 +202,7 @@ updated by geofence `ENTER`/`EXIT` callbacks. Empty set means no known location.
      `location_id` matching a geofence the user is currently inside.
    - Has an active time window covering the current day and time (or no window association).
    - **Not completed today**: any habit with a `COMPLETED` trigger fired after midnight is excluded for the rest of the day.
-   - **Not on cooldown**: any habit with a `DISMISSED` or unanswered `FIRED` trigger in the last 3 hours is excluded.
+   - **Not on cooldown**: any habit with a `DISMISSED` or unanswered `FIRED` trigger inside its `cooldown_minutes` window (default 180 min, configurable per habit in the editor; `0` disables this exclusion entirely) is excluded.
 3. Pick **one** habit by weighted-random selection from the eligible set, biased toward habits
    not recently prompted. Weight formula: `1 + min(minutesSince, 1440) / 120`, where
    `minutesSince` is minutes since the habit was last fired (cap: 1440 min = 24 h). A habit
@@ -206,7 +211,7 @@ updated by geofence `ENTER`/`EXIT` callbacks. Empty set means no known location.
 5. Post the notification with the generated text. Action buttons: **Did it**, **Dismiss**.
 6. Record the trigger row with the generated prompt and the outcome when the user responds.
    - **Did it (COMPLETED):** the habit is excluded from the rest of today's triggers (step 2 above). When `auto_adjust_level` is true, consecutive completions promote `dedication_level` (up to max 5).
-   - **Dismiss (DISMISSED):** a 3-hour cooldown applies before this habit is eligible again. When `auto_adjust_level` is true: 3 consecutive `DISMISSED` triggers demote `dedication_level` by 1; at level 0, 3 consecutive dismissals auto-pause the habit (`active = false`). The user can re-activate via the habit editor.
+   - **Dismiss (DISMISSED):** a per-habit cooldown (default 3 h, configurable via `cooldownMinutes` in the Habit editor — presets 1h · 2h · 3h · 6h · 12h · None, where None=`0` disables the cooldown) applies before this habit is eligible again. When `auto_adjust_level` is true: 3 consecutive `DISMISSED` triggers demote `dedication_level` by 1; at level 0, 3 consecutive dismissals auto-pause the habit (`active = false`). The user can re-activate via the habit editor.
 
 ### Variation pool (cloud-generated)
 
@@ -241,7 +246,8 @@ Generates a sample notification via the worker's `/v1/preview` endpoint. Shown i
 1. **Home screen** — list of habits. FAB → add habit. Tap habit → edit. BugReport icon in header → Feedback screen.
 2. **Habit editor** — name, dedication level progress bar (0–5), auto-adjust toggle, 6-level
    description fields (level 0 = minimum/low-floor, level 5 = full version; current level highlighted),
-   location chips (multi-select from saved locations; no selection = "Anywhere"), active toggle.
+   location chips (multi-select from saved locations; no selection = "Anywhere"), active toggle,
+   daily-limit dropdown (1–10/day, default 1), cooldown dropdown (1h · 2h · 3h · 6h · 12h · None, default 3h).
    AI-assist row: **✦ autofill** ("Autofill descriptions" — populates all 6 description-ladder levels (0–5)
    from the habit name via cloud AI; enabled when name ≥ 2 chars) · **↻ resample** / **Preview** (generates
    a live sample notification text via cloud AI; enabled when at least one level description is non-blank).
@@ -277,8 +283,8 @@ Generates a sample notification via the worker's `/v1/preview` endpoint. Shown i
 ## 8. Database Schema (Room)
 
 ```kotlin
-// DB version 7
-@Entity Habit(id, name, dedication_level/*Int 0-5*/, auto_adjust_level/*Boolean*/, active, created_at, updated_at)
+// DB version 9
+@Entity Habit(id, name, dedication_level/*Int 0-5*/, auto_adjust_level/*Boolean*/, daily_limit/*Int, default 1*/, cooldown_minutes/*Int, default 180*/, active, created_at, updated_at)
 @Entity HabitLevelDescriptionEntity(habit_id → Habit.id CASCADE, level/*0-5*/, description)  // per-level text
 @Entity Window(id, start_time, end_time, days_of_week_bitmask, frequency_per_day, active)
 @Entity Location(id, name /* user-defined, e.g. "Home", "Gym", "Office" */, lat, lng, radius_m)

--- a/app/schemas/net.interstellarai.unreminder.data.db.AppDatabase/9.json
+++ b/app/schemas/net.interstellarai.unreminder.data.db.AppDatabase/9.json
@@ -1,0 +1,523 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "faf42771c29496a5c88ad55ad9c4eb69",
+    "entities": [
+      {
+        "tableName": "habits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `dedication_level` INTEGER NOT NULL, `description_ladder` TEXT NOT NULL, `auto_adjust_level` INTEGER NOT NULL, `daily_limit` INTEGER NOT NULL, `cooldown_minutes` INTEGER NOT NULL DEFAULT 180, `active` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dedicationLevel",
+            "columnName": "dedication_level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "descriptionLadder",
+            "columnName": "description_ladder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAdjustLevel",
+            "columnName": "auto_adjust_level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dailyLimit",
+            "columnName": "daily_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cooldownMinutes",
+            "columnName": "cooldown_minutes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "180"
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "windows",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `start_time` INTEGER NOT NULL, `end_time` INTEGER NOT NULL, `days_of_week_bitmask` INTEGER NOT NULL, `frequency_per_day` INTEGER NOT NULL, `active` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "end_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "daysOfWeekBitmask",
+            "columnName": "days_of_week_bitmask",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frequencyPerDay",
+            "columnName": "frequency_per_day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "triggers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `window_id` INTEGER, `habit_id` INTEGER, `scheduled_at` INTEGER NOT NULL, `fired_at` INTEGER, `status` TEXT NOT NULL, `generated_prompt` TEXT, `source` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "windowId",
+            "columnName": "window_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "scheduledAt",
+            "columnName": "scheduled_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firedAt",
+            "columnName": "fired_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generatedPrompt",
+            "columnName": "generated_prompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "locations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `lat` REAL NOT NULL, `lng` REAL NOT NULL, `radius_m` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lat",
+            "columnName": "lat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lng",
+            "columnName": "lng",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "radiusM",
+            "columnName": "radius_m",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "habit_location",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`habit_id` INTEGER NOT NULL, `location_id` INTEGER NOT NULL, PRIMARY KEY(`habit_id`, `location_id`), FOREIGN KEY(`habit_id`) REFERENCES `habits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`location_id`) REFERENCES `locations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationId",
+            "columnName": "location_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "habit_id",
+            "location_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_habit_location_location_id",
+            "unique": false,
+            "columnNames": [
+              "location_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_habit_location_location_id` ON `${TABLE_NAME}` (`location_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "habits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "habit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "locations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "location_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "habit_window",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`habit_id` INTEGER NOT NULL, `window_id` INTEGER NOT NULL, PRIMARY KEY(`habit_id`, `window_id`), FOREIGN KEY(`habit_id`) REFERENCES `habits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`window_id`) REFERENCES `windows`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "windowId",
+            "columnName": "window_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "habit_id",
+            "window_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_habit_window_window_id",
+            "unique": false,
+            "columnNames": [
+              "window_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_habit_window_window_id` ON `${TABLE_NAME}` (`window_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "habits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "habit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "windows",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "window_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pending_feedback",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `screenshot_path` TEXT, `description` TEXT NOT NULL, `queued_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "screenshotPath",
+            "columnName": "screenshot_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queued_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "variations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `habit_id` INTEGER NOT NULL, `text` TEXT NOT NULL, `prompt_fingerprint` TEXT NOT NULL, `generated_at` INTEGER NOT NULL, `consumed_at` INTEGER, FOREIGN KEY(`habit_id`) REFERENCES `habits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptFingerprint",
+            "columnName": "prompt_fingerprint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generatedAt",
+            "columnName": "generated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "consumedAt",
+            "columnName": "consumed_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_variations_habit_id",
+            "unique": false,
+            "columnNames": [
+              "habit_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_variations_habit_id` ON `${TABLE_NAME}` (`habit_id`)"
+          },
+          {
+            "name": "index_variations_habit_id_prompt_fingerprint_text",
+            "unique": true,
+            "columnNames": [
+              "habit_id",
+              "prompt_fingerprint",
+              "text"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_variations_habit_id_prompt_fingerprint_text` ON `${TABLE_NAME}` (`habit_id`, `prompt_fingerprint`, `text`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "habits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "habit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "habit_level_descriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`habit_id` INTEGER NOT NULL, `level` INTEGER NOT NULL, `description` TEXT NOT NULL, PRIMARY KEY(`habit_id`, `level`), FOREIGN KEY(`habit_id`) REFERENCES `habits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "habit_id",
+            "level"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_habit_level_descriptions_habit_id",
+            "unique": false,
+            "columnNames": [
+              "habit_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_habit_level_descriptions_habit_id` ON `${TABLE_NAME}` (`habit_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "habits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "habit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'faf42771c29496a5c88ad55ad9c4eb69')"
+    ]
+  }
+}

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/AppDatabase.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/AppDatabase.kt
@@ -16,7 +16,7 @@ import androidx.room.TypeConverters
         VariationEntity::class,
         HabitLevelDescriptionEntity::class
     ],
-    version = 8,
+    version = 9,
     exportSchema = true
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/HabitDao.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/HabitDao.kt
@@ -69,7 +69,8 @@ interface HabitDao {
             WHERE habit_id IS NOT NULL
             AND fired_at IS NOT NULL
             AND (status = 'DISMISSED' OR status = 'FIRED')
-            AND fired_at > :dismissedCutoff
+            AND fired_at > (:nowEpochMillis - h.cooldown_minutes * 60 * 1000)
+            AND h.cooldown_minutes > 0
         )
         AND (
             SELECT COUNT(*) FROM triggers
@@ -82,7 +83,7 @@ interface HabitDao {
     suspend fun getEligibleHabits(
         locationIds: List<Long>,
         completedCutoff: Long,
-        dismissedCutoff: Long,
+        nowEpochMillis: Long,
         startOfDayCutoff: Long,
         currentSecondOfDay: Int,
         dayOfWeekBit: Int

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/HabitEntity.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/HabitEntity.kt
@@ -18,6 +18,8 @@ data class HabitEntity(
     val autoAdjustLevel: Boolean = true,
     @ColumnInfo(name = "daily_limit")
     val dailyLimit: Int = 1,
+    @ColumnInfo(name = "cooldown_minutes", defaultValue = "180")
+    val cooldownMinutes: Int = 180,
     val active: Boolean = true,
     @ColumnInfo(name = "created_at")
     val createdAt: Instant = Instant.now(),

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/Migration8To9.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/Migration8To9.kt
@@ -1,0 +1,10 @@
+package net.interstellarai.unreminder.data.db
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_8_9 = object : Migration(8, 9) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `habits` ADD COLUMN `cooldown_minutes` INTEGER NOT NULL DEFAULT 180")
+    }
+}

--- a/app/src/main/java/net/interstellarai/unreminder/data/repository/HabitRepository.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/repository/HabitRepository.kt
@@ -42,8 +42,8 @@ class HabitRepository @Inject constructor(
             .atStartOfDay(ZoneId.systemDefault())
             .toInstant()
             .toEpochMilli()
-        // DISMISSED or FIRED-but-not-responded: 3-hour cooldown.
-        val dismissedCutoff = Instant.now().minusSeconds(3 * 3600L).toEpochMilli()
+        // "now" is passed so the DAO can correlate per-habit cooldown_minutes (see HabitDao.kt).
+        val nowEpochMillis = Instant.now().toEpochMilli()
         // Per-habit daily cap boundary: same epoch as completedCutoff today, kept as a
         // distinct named param so the SQL stays self-documenting if cooldown semantics diverge.
         val startOfDayCutoff = completedCutoff
@@ -55,7 +55,7 @@ class HabitRepository @Inject constructor(
         return habitDao.getEligibleHabits(
             ids,
             completedCutoff,
-            dismissedCutoff,
+            nowEpochMillis,
             startOfDayCutoff,
             currentSecondOfDay,
             dayOfWeekBit

--- a/app/src/main/java/net/interstellarai/unreminder/di/AppModule.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/di/AppModule.kt
@@ -17,6 +17,7 @@ import net.interstellarai.unreminder.data.db.MIGRATION_4_5
 import net.interstellarai.unreminder.data.db.MIGRATION_5_6
 import net.interstellarai.unreminder.data.db.MIGRATION_6_7
 import net.interstellarai.unreminder.data.db.MIGRATION_7_8
+import net.interstellarai.unreminder.data.db.MIGRATION_8_9
 import net.interstellarai.unreminder.data.db.HabitLevelDescriptionDao
 import net.interstellarai.unreminder.data.db.HabitWindowCrossRefDao
 import net.interstellarai.unreminder.data.db.PendingFeedbackDao
@@ -50,7 +51,7 @@ object AppModule {
             context,
             AppDatabase::class.java,
             "unreminder.db"
-        ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8).build()
+        ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9).build()
     }
 
     @Provides

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
@@ -245,6 +245,46 @@ fun HabitEditScreen(
 
                 Spacer(Modifier.height(Dimens.lg))
 
+                MonoSectionLabel("cooldown")
+                Spacer(Modifier.height(Dimens.sm))
+                val cooldownOptions = listOf(
+                    60 to "1 hour",
+                    120 to "2 hours",
+                    180 to "3 hours",
+                    360 to "6 hours",
+                    720 to "12 hours",
+                    0 to "None",
+                )
+                var cooldownMenuExpanded by remember { mutableStateOf(false) }
+                val cooldownLabel = cooldownOptions.firstOrNull { it.first == uiState.cooldownMinutes }?.second
+                    ?: "${uiState.cooldownMinutes} min"
+                Box {
+                    Text(
+                        cooldownLabel,
+                        style = SansBody,
+                        color = MaterialTheme.colorScheme.onBackground,
+                        modifier = Modifier
+                            .clickable { cooldownMenuExpanded = true }
+                            .padding(vertical = Dimens.sm),
+                    )
+                    DropdownMenu(
+                        expanded = cooldownMenuExpanded,
+                        onDismissRequest = { cooldownMenuExpanded = false },
+                    ) {
+                        cooldownOptions.forEach { (mins, label) ->
+                            DropdownMenuItem(
+                                text = { Text(label, style = SansBody) },
+                                onClick = {
+                                    viewModel.updateCooldownMinutes(mins)
+                                    cooldownMenuExpanded = false
+                                },
+                            )
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(Dimens.lg))
+
                 MonoSectionLabel("description ladder")
                 Spacer(Modifier.height(Dimens.sm))
 

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
@@ -39,6 +39,7 @@ data class HabitEditUiState(
     val dedicationLevel: Int = 2,
     val autoAdjustLevel: Boolean = true,
     val dailyLimit: Int = 1,
+    val cooldownMinutes: Int = 180,
     val selectedLocationIds: Set<Long> = emptySet(),
     val selectedWindowIds: Set<Long> = emptySet(),
     val active: Boolean = true,
@@ -117,6 +118,7 @@ class HabitEditViewModel @Inject constructor(
                     dedicationLevel = habit.dedicationLevel,
                     autoAdjustLevel = habit.autoAdjustLevel,
                     dailyLimit = habit.dailyLimit,
+                    cooldownMinutes = habit.cooldownMinutes,
                     selectedLocationIds = locationIds,
                     selectedWindowIds = windowIds,
                     active = habit.active
@@ -140,6 +142,7 @@ class HabitEditViewModel @Inject constructor(
     fun updateDedicationLevel(level: Int) { _uiState.value = _uiState.value.copy(dedicationLevel = level) }
     fun updateAutoAdjustLevel(enabled: Boolean) { _uiState.value = _uiState.value.copy(autoAdjustLevel = enabled) }
     fun updateDailyLimit(limit: Int) { _uiState.value = _uiState.value.copy(dailyLimit = limit) }
+    fun updateCooldownMinutes(minutes: Int) { _uiState.value = _uiState.value.copy(cooldownMinutes = minutes) }
 
     fun toggleLocation(locationId: Long) {
         val current = _uiState.value.selectedLocationIds
@@ -178,6 +181,7 @@ class HabitEditViewModel @Inject constructor(
                             dedicationLevel = state.dedicationLevel,
                             autoAdjustLevel = state.autoAdjustLevel,
                             dailyLimit = state.dailyLimit,
+                            cooldownMinutes = state.cooldownMinutes,
                             active = state.active
                         )
                     )
@@ -190,6 +194,7 @@ class HabitEditViewModel @Inject constructor(
                             dedicationLevel = state.dedicationLevel,
                             autoAdjustLevel = state.autoAdjustLevel,
                             dailyLimit = state.dailyLimit,
+                            cooldownMinutes = state.cooldownMinutes,
                             active = state.active
                         )
                     )

--- a/app/src/test/java/net/interstellarai/unreminder/data/db/HabitDaoEligibleTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/db/HabitDaoEligibleTest.kt
@@ -11,6 +11,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -59,7 +60,7 @@ class HabitDaoEligibleTest {
         locationIds = listOf(-1L),
         completedCutoff = midnightMillis,
         nowEpochMillis = nowMillis,
-        startOfDayCutoff = midnightMillis - 1,
+        startOfDayCutoff = midnightMillis,
         currentSecondOfDay = 0,
         dayOfWeekBit = 1
     )
@@ -144,7 +145,7 @@ class HabitDaoEligibleTest {
 
     @Test
     fun `cooldown 180 with DISMISSED 2h ago is excluded`() = runTest {
-        val twoHoursAgo = Instant.now().minus(java.time.Duration.ofHours(2)).toEpochMilli()
+        val twoHoursAgo = Instant.now().minus(Duration.ofHours(2)).toEpochMilli()
         val now = Instant.now().toEpochMilli()
         val id = insertHabit("hCooldown180Excluded", cooldownMinutes = 180, dailyLimit = 999)
         insertTrigger(id, TriggerStatus.DISMISSED, Instant.ofEpochMilli(twoHoursAgo))
@@ -156,7 +157,7 @@ class HabitDaoEligibleTest {
 
     @Test
     fun `cooldown 180 with DISMISSED 4h ago is eligible`() = runTest {
-        val fourHoursAgo = Instant.now().minus(java.time.Duration.ofHours(4)).toEpochMilli()
+        val fourHoursAgo = Instant.now().minus(Duration.ofHours(4)).toEpochMilli()
         val now = Instant.now().toEpochMilli()
         val id = insertHabit("hCooldown180Eligible", cooldownMinutes = 180, dailyLimit = 999)
         insertTrigger(id, TriggerStatus.DISMISSED, Instant.ofEpochMilli(fourHoursAgo))
@@ -188,5 +189,31 @@ class HabitDaoEligibleTest {
         val eligible = queryEligibleAt(now)
 
         assertTrue(eligible.none { it.id == id })
+    }
+
+    @Test
+    fun `cooldown 0 with FIRED 1 minute ago is eligible`() = runTest {
+        val oneMinAgo = Instant.now().minusSeconds(60).toEpochMilli()
+        val now = Instant.now().toEpochMilli()
+        val id = insertHabit("hCooldown0Fired", cooldownMinutes = 0, dailyLimit = 999)
+        insertTrigger(id, TriggerStatus.FIRED, Instant.ofEpochMilli(oneMinAgo))
+
+        val eligible = queryEligibleAt(now)
+
+        assertTrue(eligible.any { it.id == id })
+    }
+
+    @Test
+    fun `cooldown 180 with DISMISSED exactly at boundary is eligible`() = runTest {
+        // SQL uses strict `fired_at > (now - cooldown_minutes * 60 * 1000)`,
+        // so a trigger fired exactly at the boundary is eligible (not excluded).
+        val now = Instant.now().toEpochMilli()
+        val exactlyAtBoundary = now - 180L * 60L * 1000L
+        val id = insertHabit("hCooldownBoundary", cooldownMinutes = 180, dailyLimit = 999)
+        insertTrigger(id, TriggerStatus.DISMISSED, Instant.ofEpochMilli(exactlyAtBoundary))
+
+        val eligible = queryEligibleAt(now)
+
+        assertTrue(eligible.any { it.id == id })
     }
 }

--- a/app/src/test/java/net/interstellarai/unreminder/data/db/HabitDaoEligibleTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/db/HabitDaoEligibleTest.kt
@@ -49,14 +49,23 @@ class HabitDaoEligibleTest {
     private suspend fun queryEligible(): List<HabitEntity> = habitDao.getEligibleHabits(
         locationIds = listOf(-1L),
         completedCutoff = midnightMillis,
-        dismissedCutoff = midnightMillis,
+        nowEpochMillis = midnightMillis,
         startOfDayCutoff = midnightMillis,
         currentSecondOfDay = 0,
         dayOfWeekBit = 1
     )
 
-    private suspend fun insertHabit(name: String, dailyLimit: Int = 1): Long =
-        habitDao.insert(HabitEntity(name = name, dailyLimit = dailyLimit))
+    private suspend fun queryEligibleAt(nowMillis: Long): List<HabitEntity> = habitDao.getEligibleHabits(
+        locationIds = listOf(-1L),
+        completedCutoff = midnightMillis,
+        nowEpochMillis = nowMillis,
+        startOfDayCutoff = midnightMillis - 1,
+        currentSecondOfDay = 0,
+        dayOfWeekBit = 1
+    )
+
+    private suspend fun insertHabit(name: String, dailyLimit: Int = 1, cooldownMinutes: Int = 180): Long =
+        habitDao.insert(HabitEntity(name = name, dailyLimit = dailyLimit, cooldownMinutes = cooldownMinutes))
 
     private suspend fun insertTrigger(habitId: Long, status: TriggerStatus, firedAt: Instant?) {
         triggerDao.insert(
@@ -91,7 +100,8 @@ class HabitDaoEligibleTest {
 
     @Test
     fun `dailyLimit 2 with one DISMISSED trigger today is eligible`() = runTest {
-        val id = insertHabit("h3", dailyLimit = 2)
+        // cooldownMinutes = 0 isolates the daily-limit clause from the new per-row cooldown branch.
+        val id = insertHabit("h3", dailyLimit = 2, cooldownMinutes = 0)
         insertTrigger(id, TriggerStatus.DISMISSED, Instant.ofEpochMilli(midnightMillis))
 
         val eligible = queryEligible()
@@ -130,5 +140,53 @@ class HabitDaoEligibleTest {
         val eligible = queryEligible()
 
         assertTrue(eligible.any { it.id == id })
+    }
+
+    @Test
+    fun `cooldown 180 with DISMISSED 2h ago is excluded`() = runTest {
+        val twoHoursAgo = Instant.now().minus(java.time.Duration.ofHours(2)).toEpochMilli()
+        val now = Instant.now().toEpochMilli()
+        val id = insertHabit("hCooldown180Excluded", cooldownMinutes = 180, dailyLimit = 999)
+        insertTrigger(id, TriggerStatus.DISMISSED, Instant.ofEpochMilli(twoHoursAgo))
+
+        val eligible = queryEligibleAt(now)
+
+        assertTrue(eligible.none { it.id == id })
+    }
+
+    @Test
+    fun `cooldown 180 with DISMISSED 4h ago is eligible`() = runTest {
+        val fourHoursAgo = Instant.now().minus(java.time.Duration.ofHours(4)).toEpochMilli()
+        val now = Instant.now().toEpochMilli()
+        val id = insertHabit("hCooldown180Eligible", cooldownMinutes = 180, dailyLimit = 999)
+        insertTrigger(id, TriggerStatus.DISMISSED, Instant.ofEpochMilli(fourHoursAgo))
+
+        val eligible = queryEligibleAt(now)
+
+        assertTrue(eligible.any { it.id == id })
+    }
+
+    @Test
+    fun `cooldown 0 with DISMISSED 1 minute ago is eligible`() = runTest {
+        val oneMinAgo = Instant.now().minusSeconds(60).toEpochMilli()
+        val now = Instant.now().toEpochMilli()
+        val id = insertHabit("hCooldown0", cooldownMinutes = 0, dailyLimit = 999)
+        insertTrigger(id, TriggerStatus.DISMISSED, Instant.ofEpochMilli(oneMinAgo))
+
+        val eligible = queryEligibleAt(now)
+
+        assertTrue(eligible.any { it.id == id })
+    }
+
+    @Test
+    fun `cooldown 60 with FIRED 30 minutes ago is excluded`() = runTest {
+        val thirtyMinAgo = Instant.now().minusSeconds(30 * 60).toEpochMilli()
+        val now = Instant.now().toEpochMilli()
+        val id = insertHabit("hCooldown60", cooldownMinutes = 60, dailyLimit = 999)
+        insertTrigger(id, TriggerStatus.FIRED, Instant.ofEpochMilli(thirtyMinAgo))
+
+        val eligible = queryEligibleAt(now)
+
+        assertTrue(eligible.none { it.id == id })
     }
 }

--- a/app/src/test/java/net/interstellarai/unreminder/data/db/Migration8To9Test.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/db/Migration8To9Test.kt
@@ -1,0 +1,59 @@
+package net.interstellarai.unreminder.data.db
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class Migration8To9Test {
+
+    private fun createV8Database(): SupportSQLiteDatabase {
+        val config = SupportSQLiteOpenHelper.Configuration.builder(RuntimeEnvironment.getApplication())
+            .name(null) // in-memory
+            .callback(object : SupportSQLiteOpenHelper.Callback(8) {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS `habits` (" +
+                        "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "`name` TEXT NOT NULL, " +
+                        "`dedication_level` INTEGER NOT NULL DEFAULT 2, " +
+                        "`description_ladder` TEXT NOT NULL DEFAULT '[]', " +
+                        "`auto_adjust_level` INTEGER NOT NULL DEFAULT 1, " +
+                        "`daily_limit` INTEGER NOT NULL DEFAULT 1, " +
+                        "`active` INTEGER NOT NULL DEFAULT 1, " +
+                        "`created_at` INTEGER NOT NULL DEFAULT 0, " +
+                        "`updated_at` INTEGER NOT NULL DEFAULT 0)"
+                    )
+                }
+
+                override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {}
+            })
+            .build()
+
+        return FrameworkSQLiteOpenHelperFactory().create(config).writableDatabase
+    }
+
+    @Test
+    fun `MIGRATION_8_9 adds cooldown_minutes column with default 180`() {
+        val db = createV8Database()
+
+        db.execSQL(
+            "INSERT INTO habits (name, dedication_level, description_ladder, auto_adjust_level, daily_limit, active, created_at, updated_at) " +
+            "VALUES ('meditate', 2, '[]', 1, 1, 1, 0, 0)"
+        )
+
+        MIGRATION_8_9.migrate(db)
+
+        val cursor = db.query("SELECT cooldown_minutes FROM habits WHERE name = 'meditate'")
+        cursor.moveToFirst()
+        assertEquals(180, cursor.getInt(0))
+        cursor.close()
+
+        db.close()
+    }
+}

--- a/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitRepositoryTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/repository/HabitRepositoryTest.kt
@@ -6,9 +6,12 @@ import net.interstellarai.unreminder.data.db.HabitWindowCrossRefDao
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.time.Instant
 
 class HabitRepositoryTest {
 
@@ -50,5 +53,22 @@ class HabitRepositoryTest {
         repo.getEligibleHabits(setOf(1L, 2L))
 
         coVerify { habitDao.getEligibleHabits(listOf(1L, 2L), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `getEligibleHabits passes nowEpochMillis (not pre-subtracted by 3h) as third arg`() = runTest {
+        val captured = slot<Long>()
+        coEvery {
+            habitDao.getEligibleHabits(any(), any(), capture(captured), any(), any(), any())
+        } returns emptyList()
+
+        val before = Instant.now().toEpochMilli()
+        repo.getEligibleHabits(emptySet())
+        val after = Instant.now().toEpochMilli()
+
+        assertTrue(captured.captured >= before - 1000)
+        assertTrue(captured.captured <= after + 1000)
+        val threeHoursMillis = 3 * 3600 * 1000L
+        assertTrue(captured.captured > before - threeHoursMillis + 60_000)
     }
 }


### PR DESCRIPTION
## Summary

Adds a configurable per-habit notification cooldown that replaces the global hardcoded 3-hour cap on DISMISSED/FIRED triggers. Users can now choose presets (1h · 2h · 3h · 6h · 12h · None) per habit from the edit screen; existing habits keep current 3h behaviour via the migration default.

Fixes #212

## Changes

**Schema (v8 → v9):**
- `HabitEntity.cooldownMinutes: Int = 180` with `@ColumnInfo(name = "cooldown_minutes", defaultValue = "180")`
- `Migration8To9.kt`: `ALTER TABLE habits ADD COLUMN cooldown_minutes INTEGER NOT NULL DEFAULT 180`
- `AppDatabase` version 8 → 9; `MIGRATION_8_9` wired into `AppModule`
- Generated `app/schemas/.../9.json`

**Eligibility query:**
- `HabitDao.getEligibleHabits` — DISMISSED/FIRED `NOT IN` subquery now uses a per-row correlated cutoff `:nowEpochMillis - h.cooldown_minutes * 60 * 1000` with an inner `h.cooldown_minutes > 0` guard (so `0` means "no cooldown")
- Third DAO arg renamed `dismissedCutoff` → `nowEpochMillis`

**Repository:**
- `HabitRepository.getEligibleHabits` no longer subtracts 3h; passes `Instant.now().toEpochMilli()` to the DAO

**UI:**
- `HabitEditViewModel.HabitEditUiState` gains `cooldownMinutes`; threaded through `loadHabit`, both `save()` branches, plus `updateCooldownMinutes` setter
- `HabitEditScreen` — new "cooldown" `DropdownMenu` mirroring the existing daily-limit pattern (NOT `ExposedDropdownMenuBox`); presets `1h · 2h · 3h · 6h · 12h · None`

## Validation

| Check | Command | Result |
|-------|---------|--------|
| Type / KSP compile | `./gradlew :app:compileDebugKotlin :app:kspDebugKotlin` | PASS |
| Unit tests | `./gradlew :app:testDebugUnitTest` | PASS — **289 tests, 0 failed, 0 ignored** (13.9s) |
| Debug APK | `./gradlew :app:assembleDebug` | PASS |

New / updated test coverage:
- `Migration8To9Test` (Robolectric) — asserts `cooldown_minutes` exists with default 180 after v8→v9
- `HabitDaoEligibleTest` — cooldown 180 with DISMISSED 2h ago excluded; 4h ago eligible; cooldown 0 ("None") never excluded; cooldown 60 with FIRED 30 min ago excluded
- `HabitRepositoryTest` — `slot<Long>()` capture asserts third DAO arg is `~Instant.now()`, NOT pre-subtracted by 3h

Schema export verified: `9.json` contains `"columnName": "cooldown_minutes"` with `"defaultValue": "180"`.

## Notes

One pre-existing daily-limit test (`dailyLimit 2 with one DISMISSED trigger today is eligible`) had to set `cooldownMinutes = 0` on its habit to keep isolating the daily-limit clause it was originally written for — under the new SQL with default 180, a DISMISSED trigger AT midnight falls inside the 3h cooldown window. This is a correct behaviour change, not a regression; documented in the implementation report.

## Test plan

- [ ] Clean install on a fresh emulator: create a habit, fire + dismiss a notification, confirm it stays excluded for ~3h (default-preserving behaviour)
- [ ] Open habit edit screen: verify "cooldown" dropdown shows "3 hours" by default, lists `1h · 2h · 3h · 6h · 12h · None`, and persists across save/reopen
- [ ] Per-habit divergence: habit A cooldown 60min, habit B cooldown 360min — both dismissed; after 90 min, A re-fires, B does not
- [ ] "None" preset: set cooldown to None, dismiss a trigger, confirm habit becomes eligible immediately on next eligibility check
- [ ] Upgrade path: install build at v8 with one habit, dismiss a notification, upgrade to v9; confirm habit remains on cooldown for ~3h (migration default applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)