### PR TITLE
fix: refill threshold 20 + OkHttp timeouts to keep variation pool full

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Notification texts are pre-generated in batches by the Cloudflare Worker (`/v1/g
 
 **Pool lifecycle:**
 - **Initial fill:** saving a new habit immediately enqueues `RefillWorker`, which calls `/v1/generate/batch` with `n = POOL_SIZE` (50) and stores the results. The pool starts at up to 50 unused variations.
-- **Refill:** when the unused count drops below `REFILL_THRESHOLD` (5), `TriggerPipeline` enqueues another `RefillWorker` run after each notification fire. Consumed variations are pruned before each batch is inserted, so the pool stays near the 50-variation target.
+- **Refill:** when the unused count drops below `REFILL_THRESHOLD` (20 — a 40% buffer over `POOL_SIZE = 50`, sized to outlast multiple WorkManager backoff cycles when refills fail), `TriggerPipeline` enqueues another `RefillWorker` run after each notification fire. Consumed variations are pruned before each batch is inserted, so the pool stays near the 50-variation target.
 - **Prompt change:** if a habit's name or description ladder changes on save, the entire pool is cleared and a fresh 50-variation refill is enqueued.
 
 ### Fallback

--- a/app/src/main/java/net/interstellarai/unreminder/data/repository/VariationRepository.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/repository/VariationRepository.kt
@@ -15,7 +15,10 @@ class VariationRepository @Inject constructor(
 ) {
     companion object {
         const val POOL_SIZE = 50
-        const val REFILL_THRESHOLD = 5
+        // Trigger refill at 40% pool depletion. Was 5 when POOL_SIZE = 20 (25% buffer);
+        // #205 raised the pool to 50 and left this at 5 (10% buffer) — too thin to
+        // survive WorkManager exponential backoff when refills fail (Sentry #181, #193).
+        const val REFILL_THRESHOLD = 20
     }
 
     /**

--- a/app/src/main/java/net/interstellarai/unreminder/di/ServiceModule.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/di/ServiceModule.kt
@@ -14,6 +14,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -36,7 +37,12 @@ object ServiceModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder().build()
+    fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .callTimeout(90, TimeUnit.SECONDS)
+        .build()
 
     @Provides
     @Singleton

--- a/app/src/test/java/net/interstellarai/unreminder/data/repository/VariationRepositoryTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/repository/VariationRepositoryTest.kt
@@ -73,11 +73,11 @@ class VariationRepositoryTest {
         assertFalse(repository.needsRefill(1L, threshold = 5))
     }
 
-    @Test fun `needsRefill uses default threshold of 5`() = runTest {
-        coEvery { mockDao.countUnused(1L) } returns 4
+    @Test fun `needsRefill uses default threshold of 20`() = runTest {
+        coEvery { mockDao.countUnused(1L) } returns 19
         assertTrue(repository.needsRefill(1L))
 
-        coEvery { mockDao.countUnused(1L) } returns 5
+        coEvery { mockDao.countUnused(1L) } returns 20
         assertFalse(repository.needsRefill(1L))
     }
 


### PR DESCRIPTION
## Summary

Fixes the queued-notifications-empty regression (`pool empty for habit N` Sentry alerts, edit screen showing `0 / 0`) by addressing the two root causes left after PR #209:

1. **Capacity buffer collapse** — `REFILL_THRESHOLD` was 5 over a `POOL_SIZE` of 50 (a 10% safety buffer). PR #205 tripled the pool but left the threshold alone, halving the historical 25% buffer right when WorkManager backoff windows mattered most. Raised to **20** (40% buffer) so the pool can outlast multiple exponential-backoff cycles when refills fail.
2. **Missing HTTP timeouts** — the shared `OkHttpClient` used the 10 s default for connect/read/write, well below LLM-batch tail latency (Sentry #181 `SocketTimeoutException`). Added explicit `connectTimeout=15s`, `readTimeout=60s`, `writeTimeout=30s`, `callTimeout=90s` so a single slow batch no longer cascades into worker backoff that drains the pool.

Companion to PR #209 (parse-error retry + `ExistingWorkPolicy.REPLACE`), which shipped the orthogonal half of the fix.

## Changes

| File | Change |
|------|--------|
| `app/src/main/java/net/interstellarai/unreminder/data/repository/VariationRepository.kt` | `REFILL_THRESHOLD` 5 → 20 with rationale comment |
| `app/src/main/java/net/interstellarai/unreminder/di/ServiceModule.kt` | Configure connect / read / write / call timeouts on the shared `OkHttpClient`; add `java.util.concurrent.TimeUnit` import |
| `app/src/test/java/net/interstellarai/unreminder/data/repository/VariationRepositoryTest.kt` | Default-threshold test now asserts `count=19` → `true`, `count=20` → `false` |
| `README.md` | Pool-lifecycle doc: `(5)` → `(20 — a 40% buffer over POOL_SIZE = 50, sized to outlast multiple WorkManager backoff cycles when refills fail)` |

Total: 4 files, +15 / -6.

## Root cause walkthrough

1. Edit screen shows `0 / 0`; Sentry fires `pool empty for habit 1` (#192, #201).
2. `TriggerPipeline.resolvePrompt` got `null` from `pickRandomUnused` (`TriggerPipeline.kt:108-130`).
3. `dao.getUnusedForHabit(habitId, POOL_SIZE)` returned empty (`VariationRepository.kt:28-40`).
4. `RefillWorker` did not top up between `count<5` and `count=0` — pool was consumed faster than refills could complete.
5. Refills were retrying with WorkManager exponential backoff (correct policy) while normal triggers consumed the remaining 5-variant buffer; failures driven by Sentry #181 (`SocketTimeoutException`) and #193 (worker 502).
6. **Root cause 1** — `REFILL_THRESHOLD = 5` is only a 10% buffer of the 50-variant pool; commit `acf8cca` (#205) tripled the pool and halved the relative buffer.
7. **Root cause 2** — shared `OkHttpClient` uses default 10 s read/connect timeouts, well below LLM tail latency for a 50-variant batch.

Detailed trace and Sentry mapping in `investigation.md` (workflow `f243b453352a37b114330872cea97e03`).

## Validation

| Check | Result |
|-------|--------|
| `./gradlew :app:assembleDebug` | ✅ BUILD SUCCESSFUL |
| `./gradlew :app:lintDebug` | ✅ BUILD SUCCESSFUL — no new findings |
| `./gradlew :app:testDebugUnitTest --tests VariationRepositoryTest` | ✅ 8 / 8 pass (covers the rewritten default-threshold test) |
| `./gradlew :app:testDebugUnitTest` (full suite) | ⚠️ 245 / 283 — all 38 failures are pre-existing baseline (`android.util.Log` native-link errors on this workstation). Reverted to `HEAD~1` and reproduced 40 failures; the fix removes 2 by updating the default-threshold assertions. **Zero new failures.** |
| Format | n/a — no `spotless` / `ktlint` configured |

### Test plan

- [x] Unit tests for `VariationRepositoryTest` (default + parameterised threshold cases)
- [x] Compile + lint with new OkHttp builder chain
- [ ] On-device manual: install debug APK, fire ~30 triggers on a fresh habit, confirm pool survives a worker outage (deferred — no Android device in this run)
- [ ] 24 h Sentry soak post-merge: confirm `pool empty for habit N` no longer fires (the success metric, not a pre-merge gate)

## Edge cases & risks

- `OkHttpClient` is shared with `GitHubApiService` (feedback uploads). Generous timeouts apply there too — acceptable; feedback submission is async / rare and a longer timeout is *more* lenient than the default.
- `callTimeout(90s)` hard-caps any single `RefillWorker` HTTP attempt — desired, so the worker slot frees for the next backoff retry instead of blocking forever.
- Threshold of 20 means refills are enqueued ~3× more often than at 5; combined with `ExistingWorkPolicy.REPLACE` (PR #209), an in-flight refill can be cancelled. Trade-off was accepted by #209; the alternative is the previous `KEEP` policy that re-introduces the bug.

## Out of scope

Tracked separately, not touched in this PR:

- UX status surfacing in `HabitEditScreen` (fix-direction #3 from the issue body) — needs `WorkInfo` plumbing.
- Worker-side robustness for Sentry #193 (server 502) and #195 / #180 (autofill `descriptionLadder` shape).
- `BackoffPolicy` tuning, `runAttemptCount` cap on `RefillWorker` retries, walking the full `cause` chain in `RefillWorker`'s catch blocks.

Fixes #207