### PR TITLE
fix: capture RefillWorker retry errors in Sentry for visibility

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
@@ -83,6 +83,11 @@ class RefillWorker @AssistedInject constructor(
         } catch (e: WorkerError) {
             if (e.isServerError()) {
                 Log.w(TAG, "Server error ${e.code} for habit $habitId, will retry", e)
+                Sentry.captureException(e) { scope ->
+                    scope.setTag("component", "refill-worker")
+                    scope.setTag("habit_id", habitId.toString())
+                    scope.setTag("error_code", e.code.toString())
+                }
                 Result.retry()
             } else {
                 Log.w(TAG, "Client error ${e.code} for habit $habitId", e)
@@ -90,13 +95,25 @@ class RefillWorker @AssistedInject constructor(
             }
         } catch (e: IOException) {
             Log.w(TAG, "IO error for habit $habitId, will retry", e)
+            Sentry.captureException(e) { scope ->
+                scope.setTag("component", "refill-worker")
+                scope.setTag("habit_id", habitId.toString())
+            }
             Result.retry()
         } catch (e: JSONException) {
             Log.w(TAG, "JSON parse error for habit $habitId, will retry", e)
+            Sentry.captureException(e) { scope ->
+                scope.setTag("component", "refill-worker")
+                scope.setTag("habit_id", habitId.toString())
+            }
             Result.retry()
         } catch (e: RuntimeException) {
             if (e.cause is JSONException) {
                 Log.w(TAG, "JSON parse error (wrapped) for habit $habitId, will retry", e)
+                Sentry.captureException(e) { scope ->
+                    scope.setTag("component", "refill-worker")
+                    scope.setTag("habit_id", habitId.toString())
+                }
                 Result.retry()
             } else {
                 reportUnexpected(e, habitId)


### PR DESCRIPTION
## Problem

`RefillWorker` retries silently on 502s, `IOException`, `JSONException`, and wrapped `JSONException` (via `RuntimeException`). When the worker backed off and retried, nothing surfaced in Sentry — making it impossible to tell whether pool-empty incidents were caused by transient network blips, a flaky CF Worker deployment, or a repeated parse failure on the LLM response.

## Changes

Added `Sentry.captureException` (with tags `component=refill-worker`, `habit_id`, and `error_code` where applicable) before each `Result.retry()` call in the four retry paths:

- `WorkerError` (server error branch) — tagged with `error_code` so 502 vs 503 is distinguishable
- `IOException` — network-level failures now visible
- `JSONException` — direct parse failures now visible
- `RuntimeException { cause is JSONException }` — wrapped parse failures now visible

The existing log lines are preserved. The `SpendCapExceededException`, `WorkerAuthException`, and fallthrough `Exception` paths are unchanged (they already call `reportUnexpected` or `Result.failure()` which was already captured).

## Why this matters

Silent retries mean pools can stay empty with no alertable signal. These events in Sentry allow us to set an alert threshold and distinguish "one-off blip" from "CF Worker is down" within minutes rather than hours.