### PR TITLE
fix: upload R8 mapping and embed native debug symbols in AAB

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: net.interstellarai.unreminder
           releaseFiles: app/build/outputs/bundle/release/*.aab
+          mappingFile: app/build/outputs/mapping/release/mapping.txt
           track: internal
           status: draft
           releaseName: ${{ env.VERSION_NAME }}
@@ -142,6 +143,7 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: net.interstellarai.unreminder
           releaseFiles: app/build/outputs/bundle/release/*.aab
+          mappingFile: app/build/outputs/mapping/release/mapping.txt
           track: production
           status: completed
           releaseName: ${{ env.VERSION_NAME }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Resolves two Google Play Console warnings emitted on every AAB upload:

1. *"There is no deobfuscation file associated with this App Bundle…"* — R8 mapping was being generated but never delivered to Play.
2. *"This App Bundle contains native code, and you've not uploaded debug symbols…"* — Sentry's transitive `libsentry.so` / `libsentry-android.so` shipped stripped, with no `debugSymbolLevel` configured.

Two surgical edits — no new tooling, no Sentry plugin changes.

## Changes

- **`app/build.gradle.kts`** — added `ndk { debugSymbolLevel = "FULL" }` inside `buildTypes.release`. AGP 4.1+ embeds native debug symbols inside the AAB itself; Play Console picks them up server-side.
- **`.github/workflows/release.yml`** — added `mappingFile: app/build/outputs/mapping/release/mapping.txt` to both `r0adkll/upload-google-play@v1` invocations (internal-track and production-track).

Total: 5 insertions across 2 files.

## Why not Sentry

The existing `sentry { }` block intentionally keeps mapping/native-symbol uploads off (only Source Context goes to Sentry, gated on `SENTRY_AUTH_TOKEN`). This PR is scoped strictly to the Play Console warnings; re-enabling Sentry-side uploads is a separate scope decision and is left untouched.

## Validation

| Check | Result |
|-------|--------|
| `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` | pass |
| `grep -c 'mappingFile: app/build/outputs/mapping/release/mapping.txt' .github/workflows/release.yml` | `2` |
| `./gradlew :app:tasks --quiet` (config parse, AGP 8.13.2 accepts the new `ndk` block) | pass |
| `./gradlew help --task :app:bundleRelease` | resolves |

`./gradlew :app:bundleRelease` was not run locally due to a pre-existing Java-toolchain mismatch (`module-info.class wrong version 65.0/61.0`) that reproduces on `HEAD~1` without these changes — it is environmental, not change-related. CI uses `actions/setup-java@v4` with `java-version: 21` and runs `bundleRelease` cleanly. The new `ndk` block is consumed at AGP's merge/strip/package phases (`mergeReleaseNativeDebugMetadata`), downstream of the local Hilt failure point, so config-parse coverage is sufficient pre-merge.

## Test Plan

- [x] Workflow YAML parses
- [x] Both upload steps reference `mappingFile`
- [x] Gradle config evaluates with the new `ndk` block
- [ ] Post-merge: confirm next internal-track release in Play Console no longer surfaces the deobfuscation-file or debug-symbols warnings
- [ ] Post-merge (optional): trigger a Java + native crash and verify Android Vitals stack traces are deobfuscated and symbolicated

Fixes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)