### PR TITLE
fix: persist and reactively update geofence location state to fix false 'not available' badge (#245)

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/geofence/GeofenceManager.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/geofence/GeofenceManager.kt
@@ -9,6 +9,9 @@ import net.interstellarai.unreminder.data.repository.LocationRepository
 import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.GeofencingRequest
 import com.google.android.gms.location.LocationServices
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -19,18 +22,38 @@ class GeofenceManager @Inject constructor(
 ) {
     companion object {
         private const val TAG = "GeofenceManager"
+        private const val PREFS_NAME = "geofence_prefs"
+        private const val KEY_LOCATION_IDS = "current_location_ids"
     }
 
+    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val locationIdLock = Any()
 
-    var currentLocationIds: Set<Long> = emptySet()
-        get() = synchronized(locationIdLock) { field }
-        private set
+    private val _currentLocationIds = MutableStateFlow<Set<Long>>(restoreLocationIds())
+    val currentLocationIds: StateFlow<Set<Long>> = _currentLocationIds.asStateFlow()
 
     private val geofencingClient = LocationServices.getGeofencingClient(context)
 
-    fun addLocationId(id: Long) = synchronized(locationIdLock) { currentLocationIds = currentLocationIds + id }
-    fun removeLocationId(id: Long) = synchronized(locationIdLock) { currentLocationIds = currentLocationIds - id }
+    private fun restoreLocationIds(): Set<Long> {
+        val stored = prefs.getStringSet(KEY_LOCATION_IDS, emptySet()) ?: emptySet()
+        return stored.mapNotNull { it.toLongOrNull() }.toSet()
+    }
+
+    private fun persistLocationIds(ids: Set<Long>) {
+        prefs.edit().putStringSet(KEY_LOCATION_IDS, ids.map { it.toString() }.toSet()).apply()
+    }
+
+    fun addLocationId(id: Long) = synchronized(locationIdLock) {
+        val updated = _currentLocationIds.value + id
+        _currentLocationIds.value = updated
+        persistLocationIds(updated)
+    }
+
+    fun removeLocationId(id: Long) = synchronized(locationIdLock) {
+        val updated = _currentLocationIds.value - id
+        _currentLocationIds.value = updated
+        persistLocationIds(updated)
+    }
 
     fun registerGeofence(id: Long, name: String, lat: Double, lng: Double, radiusM: Float) {
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)

--- a/app/src/main/java/net/interstellarai/unreminder/service/trigger/TriggerPipeline.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/trigger/TriggerPipeline.kt
@@ -64,7 +64,7 @@ class TriggerPipeline @Inject constructor(
         }
         if (trigger.status != TriggerStatus.SCHEDULED) return
 
-        val locationIds = geofenceManager.currentLocationIds
+        val locationIds = geofenceManager.currentLocationIds.value
 
         try {
             val eligibleHabits = habitRepository.getEligibleHabits(locationIds)

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModel.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.collect
 import java.io.IOException
 import java.time.Instant
 import java.time.LocalDate
@@ -117,6 +118,31 @@ class HabitEditViewModel @Inject constructor(
 
     private var existingHabit: HabitEntity? = null
 
+    // Holds the most-recently-loaded habit data for reactive availability recomputation.
+    private data class LoadedHabitData(
+        val habit: HabitEntity,
+        val locationIds: Set<Long>,
+        val windowIds: Set<Long>,
+    )
+    private val _loadedHabit = MutableStateFlow<LoadedHabitData?>(null)
+
+    init {
+        // Reactively recompute availability whenever the loaded habit OR the current geofence set changes.
+        viewModelScope.launch {
+            geofenceManager.currentLocationIds.collect { _ ->
+                val loaded = _loadedHabit.value ?: return@collect
+                val availability = try {
+                    computeAvailability(loaded.habit, loaded.locationIds, loaded.windowIds)
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    Log.w(TAG, "reactive availability recompute failed for habit ${loaded.habit.id} — hiding badge", e)
+                    AvailabilityStatus.NewHabit
+                }
+                _uiState.value = _uiState.value.copy(availabilityStatus = availability)
+            }
+        }
+    }
+
     fun loadHabit(id: Long) {
         viewModelScope.launch {
             _habitId.value = id
@@ -150,6 +176,8 @@ class HabitEditViewModel @Inject constructor(
                     active = habit.active,
                     availabilityStatus = availability
                 )
+                // Publish loaded data so the reactive collector can recompute on location changes.
+                _loadedHabit.value = LoadedHabitData(habit, locationIds, windowIds)
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
                 Log.e(TAG, "loadHabit: failed to load habit $id", e)
@@ -364,7 +392,7 @@ class HabitEditViewModel @Inject constructor(
         // --- Location ---
         // Habit has location restrictions AND current location not in them.
         if (locationIds.isNotEmpty()) {
-            val currentIds = geofenceManager.currentLocationIds
+            val currentIds = geofenceManager.currentLocationIds.value
             if (currentIds.none { it in locationIds }) {
                 reasons += UnavailableReason.LOCATION
             }

--- a/app/src/main/java/net/interstellarai/unreminder/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/settings/SettingsViewModel.kt
@@ -78,7 +78,7 @@ class SettingsViewModel @Inject constructor(
 
     fun testTriggerNow() {
         viewModelScope.launch {
-            val locationIds = geofenceManager.currentLocationIds
+            val locationIds = geofenceManager.currentLocationIds.value
             val eligible = habitRepository.getEligibleHabits(locationIds)
             if (eligible.isEmpty()) {
                 _uiState.value = _uiState.value.copy(testTriggeredEmpty = true)

--- a/app/src/main/java/net/interstellarai/unreminder/worker/RandomIntervalWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/worker/RandomIntervalWorker.kt
@@ -93,7 +93,7 @@ class RandomIntervalWorker @AssistedInject constructor(
             }
 
             step = "habitQuery"
-            val eligibleHabits = habitRepository.getEligibleHabits(geofenceManager.currentLocationIds)
+            val eligibleHabits = habitRepository.getEligibleHabits(geofenceManager.currentLocationIds.value)
             if (eligibleHabits.isEmpty()) {
                 Log.d(TAG, "No eligible habits, skipping")
                 scheduleNext()

--- a/app/src/test/java/net/interstellarai/unreminder/service/trigger/TriggerPipelineTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/trigger/TriggerPipelineTest.kt
@@ -23,6 +23,8 @@ import io.mockk.verify
 import io.sentry.Sentry
 import io.sentry.ScopeCallback
 import io.sentry.protocol.SentryId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -79,7 +81,7 @@ class TriggerPipelineTest {
             levelDescriptionRepository = levelDescriptionRepository,
         )
 
-        every { geofenceManager.currentLocationIds } returns setOf(1L)
+        every { geofenceManager.currentLocationIds } returns MutableStateFlow(setOf(1L)).asStateFlow()
         coEvery { locationRepository.getByIds(any()) } returns emptyList()
         coEvery { triggerRepository.getLastFiredForHabit(any()) } returns null
     }

--- a/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModelTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/ui/habit/HabitEditViewModelTest.kt
@@ -28,6 +28,8 @@ import io.sentry.ScopeCallback
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -60,6 +62,9 @@ class HabitEditViewModelTest {
     private val mockTriggerRepository: TriggerRepository = mockk(relaxed = true)
     private lateinit var viewModel: HabitEditViewModel
 
+    // Backing flow for geofenceManager.currentLocationIds — tests mutate this directly.
+    private val currentLocationIdsFlow = MutableStateFlow<Set<Long>>(emptySet())
+
     private val testLadder = listOf("3 deep breaths", "", "", "20-minute guided meditation", "", "")
 
     private val testHabit = HabitEntity(
@@ -73,10 +78,11 @@ class HabitEditViewModelTest {
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
+        currentLocationIdsFlow.value = emptySet()
         every { mockLocationRepository.getAll() } returns flowOf(emptyList())
         every { mockWindowRepository.getAll() } returns flowOf(emptyList())
         every { mockPromptGenerator.aiStatus } returns MutableStateFlow<AiStatus>(AiStatus.Ready)
-        every { mockGeofenceManager.currentLocationIds } returns emptySet()
+        every { mockGeofenceManager.currentLocationIds } returns currentLocationIdsFlow.asStateFlow()
         coEvery { mockTriggerRepository.countCompletedSince(any(), any()) } returns 0
         coEvery { mockTriggerRepository.countNonScheduledSince(any(), any()) } returns 0
         coEvery { mockTriggerRepository.getLastFiredOrDismissedForHabit(any()) } returns null
@@ -600,7 +606,7 @@ class HabitEditViewModelTest {
         coEvery { mockHabitRepository.getById(testHabit.id) } returns flowOf(testHabit)
         coEvery { mockHabitRepository.getLocationIds(testHabit.id) } returns listOf(1L, 2L)
         coEvery { mockHabitRepository.getWindowIds(testHabit.id) } returns emptyList()
-        every { mockGeofenceManager.currentLocationIds } returns setOf(99L)
+        currentLocationIdsFlow.value = setOf(99L)
 
         viewModel.loadHabit(testHabit.id)
         advanceUntilIdle()
@@ -614,9 +620,30 @@ class HabitEditViewModelTest {
         coEvery { mockHabitRepository.getById(testHabit.id) } returns flowOf(testHabit)
         coEvery { mockHabitRepository.getLocationIds(testHabit.id) } returns listOf(1L, 2L)
         coEvery { mockHabitRepository.getWindowIds(testHabit.id) } returns emptyList()
-        every { mockGeofenceManager.currentLocationIds } returns setOf(2L, 99L)
+        currentLocationIdsFlow.value = setOf(2L, 99L)
 
         viewModel.loadHabit(testHabit.id)
+        advanceUntilIdle()
+
+        assertEquals(AvailabilityStatus.Available, viewModel.uiState.value.availabilityStatus)
+    }
+
+    @Test
+    fun `availability updates reactively when geofence location changes after habit is loaded`() = runTest(testDispatcher) {
+        coEvery { mockHabitRepository.getById(testHabit.id) } returns flowOf(testHabit)
+        coEvery { mockHabitRepository.getLocationIds(testHabit.id) } returns listOf(1L, 2L)
+        coEvery { mockHabitRepository.getWindowIds(testHabit.id) } returns emptyList()
+        // Start with wrong location — badge shows LOCATION
+        currentLocationIdsFlow.value = setOf(99L)
+
+        viewModel.loadHabit(testHabit.id)
+        advanceUntilIdle()
+
+        val before = viewModel.uiState.value.availabilityStatus as AvailabilityStatus.Unavailable
+        assertTrue(UnavailableReason.LOCATION in before.reasons)
+
+        // Simulate INITIAL_TRIGGER_ENTER firing — now at a matching location
+        currentLocationIdsFlow.value = setOf(2L)
         advanceUntilIdle()
 
         assertEquals(AvailabilityStatus.Available, viewModel.uiState.value.availabilityStatus)

--- a/app/src/test/java/net/interstellarai/unreminder/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/ui/settings/SettingsViewModelTest.kt
@@ -14,6 +14,8 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -37,6 +39,7 @@ class SettingsViewModelTest {
     private lateinit var viewModel: SettingsViewModel
 
     private val testDispatcher = StandardTestDispatcher()
+    private val currentLocationIdsFlow = MutableStateFlow<Set<Long>>(emptySet())
 
     @Before
     fun setup() {
@@ -47,8 +50,9 @@ class SettingsViewModelTest {
         geofenceManager = mockk(relaxed = true)
         context = mockk(relaxed = true)
         every { context.getSystemService(Context.ALARM_SERVICE) } returns mockk<AlarmManager>(relaxed = true)
+        currentLocationIdsFlow.value = emptySet()
         // Default: at least one eligible habit so the pre-existing tests still exercise the pipeline path.
-        every { geofenceManager.currentLocationIds } returns emptySet()
+        every { geofenceManager.currentLocationIds } returns currentLocationIdsFlow.asStateFlow()
         coEvery { habitRepository.getEligibleHabits(any()) } returns listOf(
             HabitEntity(id = 1L, name = "habit")
         )
@@ -98,7 +102,7 @@ class SettingsViewModelTest {
 
     @Test
     fun `testTriggerNow sets testTriggeredEmpty and skips pipeline when no eligible habits`() = runTest {
-        every { geofenceManager.currentLocationIds } returns emptySet()
+        currentLocationIdsFlow.value = emptySet()
         coEvery { habitRepository.getEligibleHabits(any()) } returns emptyList()
 
         viewModel.testTriggerNow()
@@ -112,7 +116,7 @@ class SettingsViewModelTest {
 
     @Test
     fun `testTriggerNow fires pipeline when at least one eligible habit`() = runTest {
-        every { geofenceManager.currentLocationIds } returns setOf(7L)
+        currentLocationIdsFlow.value = setOf(7L)
         coEvery { habitRepository.getEligibleHabits(setOf(7L)) } returns listOf(
             HabitEntity(id = 1L, name = "habit")
         )
@@ -139,7 +143,7 @@ class SettingsViewModelTest {
 
     @Test
     fun `clearTestTriggeredEmpty resets testTriggeredEmpty to false`() = runTest {
-        every { geofenceManager.currentLocationIds } returns emptySet()
+        currentLocationIdsFlow.value = emptySet()
         coEvery { habitRepository.getEligibleHabits(any()) } returns emptyList()
         viewModel.testTriggerNow()
         advanceUntilIdle()

--- a/app/src/test/java/net/interstellarai/unreminder/worker/RandomIntervalWorkerTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/worker/RandomIntervalWorkerTest.kt
@@ -17,6 +17,8 @@ import io.sentry.Sentry
 import io.sentry.ScopeCallback
 import io.sentry.protocol.SentryId
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.runTest
 import net.interstellarai.unreminder.data.db.TriggerEntity
 import net.interstellarai.unreminder.data.db.WindowEntity
@@ -46,6 +48,7 @@ class RandomIntervalWorkerTest {
 
     @Before
     fun setup() {
+        every { mockGeofenceManager.currentLocationIds } returns MutableStateFlow<Set<Long>>(emptySet()).asStateFlow()
         worker = RandomIntervalWorker(
             mockContext,
             mockWorkerParams,


### PR DESCRIPTION
Fixes #245

## Root cause

`GeofenceManager.currentLocationIds` was an in-memory `var` that reset to `emptySet()` on every process restart. `HabitEditViewModel.computeAvailability()` read it synchronously at screen load, before Android's async `INITIAL_TRIGGER_ENTER` geofence event could fire. Even when the event eventually fired, the already-rendered habit screen never recomputed.

## Changes

### Part 1 — Persist location state (`GeofenceManager.kt`)

- Changed `currentLocationIds` from a plain `var Set<Long>` to a `MutableStateFlow<Set<Long>>`, exposed as `StateFlow<Set<Long>>`
- On construction, restores the set from `SharedPreferences("geofence_prefs")` (key `current_location_ids`, stored as `Set<String>`)
- `addLocationId` / `removeLocationId` update the flow **and** write back to SharedPreferences via `.apply()` (non-blocking, safe on main thread)
- Existing `synchronized(locationIdLock)` lock kept for thread safety around the read-modify-write

### Part 2 — Reactive availability in `HabitEditViewModel.kt`

- Added `_loadedHabit: MutableStateFlow<LoadedHabitData?>` to hold the currently-loaded habit/locationIds/windowIds
- `init {}` launches a permanent `geofenceManager.currentLocationIds.collect { }` coroutine in `viewModelScope`; on each emission it recomputes availability from the cached habit data and updates `_uiState`
- `loadHabit()` sets `_loadedHabit` after loading so the reactive collector has data to work with
- `computeAvailability()` reads `.value` from the `StateFlow` (snapshot read, not suspension)

### Call-site fixes

Four other callers of `currentLocationIds` updated to use `.value`:
- `TriggerPipeline.kt`
- `RandomIntervalWorker.kt`
- `SettingsViewModel.kt`

### Tests

- `HabitEditViewModelTest`: stubs now use `MutableStateFlow` + `asStateFlow()`; two location-overlap tests updated accordingly; new test `availability updates reactively when geofence location changes after habit is loaded` covers the reactive path
- `SettingsViewModelTest`, `TriggerPipelineTest`, `RandomIntervalWorkerTest`: stubs updated to return `StateFlow`

## Test plan

- [ ] Kotlin compilation (`compileDebugKotlin`) passes — confirmed
- [ ] `compileDebugUnitTestKotlin` passes — confirmed
- [ ] New reactive test `availability updates reactively when geofence location changes after habit is loaded` exercises the full flow
- [ ] Note: `hiltJavaCompileDebug` fails in CI due to a pre-existing Java 25 toolchain incompatibility on this dev machine (confirmed present on `main` before this branch)
- [ ] Manual: open a location-restricted habit while physically inside the geofence — badge should show "available" immediately on load instead of showing "not available · location"

🤖 Generated with [Claude Code](https://claude.com/claude-code)