### PR TITLE
Fix: highlight current locations in Locations view

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/ui/location/LocationScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/location/LocationScreen.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -29,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import net.interstellarai.unreminder.ui.theme.Dimens
 import net.interstellarai.unreminder.ui.theme.MonoLabelTiny
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -92,17 +95,16 @@ fun LocationScreen(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Column(modifier = Modifier.weight(1f)) {
-                            if (isCurrent) {
-                                Row(verticalAlignment = Alignment.CenterVertically) {
-                                    Text(loc.name, style = MaterialTheme.typography.titleMedium)
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(loc.name, style = MaterialTheme.typography.titleMedium)
+                                if (isCurrent) {
+                                    Spacer(Modifier.width(Dimens.sm))
                                     Text(
-                                        "  · current",
+                                        "· current",
                                         style = MonoLabelTiny,
-                                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.45f),
+                                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.45f),
                                     )
                                 }
-                            } else {
-                                Text(loc.name, style = MaterialTheme.typography.titleMedium)
                             }
                             Text(
                                 "%.4f, %.4f — radius ${loc.radiusM.toInt()} m".format(loc.lat, loc.lng),

--- a/app/src/main/java/net/interstellarai/unreminder/ui/location/LocationScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/location/LocationScreen.kt
@@ -1,5 +1,6 @@
 package net.interstellarai.unreminder.ui.location
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,6 +13,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -27,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import net.interstellarai.unreminder.ui.theme.MonoLabelTiny
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -65,17 +68,44 @@ fun LocationScreen(
                     style = MaterialTheme.typography.bodyMedium
                 )
             }
-            items(locations) { loc ->
-                Card(modifier = Modifier.fillMaxWidth()) {
+            items(locations) { row ->
+                val loc = row.location
+                val isCurrent = row.isCurrent
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = if (isCurrent) {
+                        CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer
+                        )
+                    } else {
+                        CardDefaults.cardColors()
+                    },
+                    border = if (isCurrent) {
+                        BorderStroke(1.5.dp, MaterialTheme.colorScheme.primary)
+                    } else {
+                        null
+                    },
+                ) {
                     Row(
                         modifier = Modifier.padding(16.dp),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Column(modifier = Modifier.weight(1f)) {
-                            Text(loc.name, style = MaterialTheme.typography.titleMedium)
+                            if (isCurrent) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Text(loc.name, style = MaterialTheme.typography.titleMedium)
+                                    Text(
+                                        "  · current",
+                                        style = MonoLabelTiny,
+                                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.45f),
+                                    )
+                                }
+                            } else {
+                                Text(loc.name, style = MaterialTheme.typography.titleMedium)
+                            }
                             Text(
-                                "%.4f, %.4f \u2014 radius ${loc.radiusM.toInt()} m".format(loc.lat, loc.lng),
+                                "%.4f, %.4f — radius ${loc.radiusM.toInt()} m".format(loc.lat, loc.lng),
                                 style = MaterialTheme.typography.bodySmall
                             )
                         }

--- a/app/src/main/java/net/interstellarai/unreminder/ui/location/LocationViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/location/LocationViewModel.kt
@@ -9,9 +9,15 @@ import net.interstellarai.unreminder.service.geofence.GeofenceManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+data class LocationRow(
+    val location: LocationEntity,
+    val isCurrent: Boolean
+)
 
 @HiltViewModel
 class LocationViewModel @Inject constructor(
@@ -23,8 +29,12 @@ class LocationViewModel @Inject constructor(
         private const val TAG = "LocationViewModel"
     }
 
-    val locations: StateFlow<List<LocationEntity>> = locationRepository.getAll()
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+    val locations: StateFlow<List<LocationRow>> = combine(
+        locationRepository.getAll(),
+        geofenceManager.currentLocationIds
+    ) { locations, currentIds ->
+        locations.map { LocationRow(it, it.id in currentIds) }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     fun deleteLocation(location: LocationEntity) {
         viewModelScope.launch {

--- a/app/src/test/java/net/interstellarai/unreminder/ui/location/LocationViewModelTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/ui/location/LocationViewModelTest.kt
@@ -9,12 +9,17 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -24,14 +29,17 @@ class LocationViewModelTest {
     private lateinit var locationRepository: LocationRepository
     private lateinit var geofenceManager: GeofenceManager
     private lateinit var viewModel: LocationViewModel
-    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testDispatcher = StandardTestDispatcher()
+    private val locationsFlow = MutableStateFlow<List<LocationEntity>>(emptyList())
+    private val currentIdsFlow = MutableStateFlow<Set<Long>>(emptySet())
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         locationRepository = mockk(relaxUnitFun = true)
         geofenceManager = mockk(relaxUnitFun = true)
-        every { locationRepository.getAll() } returns flowOf(emptyList())
+        every { locationRepository.getAll() } returns locationsFlow
+        every { geofenceManager.currentLocationIds } returns currentIdsFlow
         viewModel = LocationViewModel(locationRepository, geofenceManager)
     }
 
@@ -41,14 +49,61 @@ class LocationViewModelTest {
     }
 
     @Test
-    fun `deleteLocation calls delete on repository and removeGeofence by id`() = runTest {
+    fun `deleteLocation calls delete on repository and removeGeofence by id`() = runTest(testDispatcher) {
         val location = LocationEntity(id = 42L, name = "Home", lat = 51.5, lng = -0.1, radiusM = 100f)
         coEvery { locationRepository.delete(location) } returns Unit
         coEvery { geofenceManager.removeGeofence(42L) } returns Unit
 
         viewModel.deleteLocation(location)
+        advanceUntilIdle()
 
         coVerify { locationRepository.delete(location) }
         coVerify { geofenceManager.removeGeofence(42L) }
+    }
+
+    @Test
+    fun `locations exposes empty list when no data`() = runTest(testDispatcher) {
+        backgroundScope.launch { viewModel.locations.collect {} }
+        advanceUntilIdle()
+
+        assertEquals(emptyList<LocationRow>(), viewModel.locations.value)
+    }
+
+    @Test
+    fun `locations marks isCurrent=true when id matches currentLocationIds`() = runTest(testDispatcher) {
+        val home = LocationEntity(id = 1L, name = "Home", lat = 51.5, lng = -0.1, radiusM = 100f)
+        val office = LocationEntity(id = 2L, name = "Office", lat = 51.5, lng = -0.09, radiusM = 100f)
+        locationsFlow.value = listOf(home, office)
+        currentIdsFlow.value = setOf(1L)
+
+        backgroundScope.launch { viewModel.locations.collect {} }
+        advanceUntilIdle()
+
+        val rows = viewModel.locations.value
+        assertEquals(2, rows.size)
+        assertEquals(home, rows[0].location)
+        assertTrue(rows[0].isCurrent)
+        assertEquals(office, rows[1].location)
+        assertFalse(rows[1].isCurrent)
+    }
+
+    @Test
+    fun `locations updates reactively when currentLocationIds changes`() = runTest(testDispatcher) {
+        val home = LocationEntity(id = 1L, name = "Home", lat = 51.5, lng = -0.1, radiusM = 100f)
+        val office = LocationEntity(id = 2L, name = "Office", lat = 51.5, lng = -0.09, radiusM = 100f)
+        locationsFlow.value = listOf(home, office)
+        currentIdsFlow.value = setOf(1L)
+
+        backgroundScope.launch { viewModel.locations.collect {} }
+        advanceUntilIdle()
+
+        assertTrue(viewModel.locations.value[0].isCurrent)
+        assertFalse(viewModel.locations.value[1].isCurrent)
+
+        currentIdsFlow.value = setOf(2L)
+        advanceUntilIdle()
+
+        assertFalse(viewModel.locations.value[0].isCurrent)
+        assertTrue(viewModel.locations.value[1].isCurrent)
     }
 }

--- a/app/src/test/java/net/interstellarai/unreminder/ui/location/LocationViewModelTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/ui/location/LocationViewModelTest.kt
@@ -7,6 +7,8 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -105,5 +107,41 @@ class LocationViewModelTest {
 
         assertFalse(viewModel.locations.value[0].isCurrent)
         assertTrue(viewModel.locations.value[1].isCurrent)
+    }
+
+    @Test
+    fun `locations marks all isCurrent=false when currentLocationIds becomes empty`() = runTest(testDispatcher) {
+        val home = LocationEntity(id = 1L, name = "Home", lat = 51.5, lng = -0.1, radiusM = 100f)
+        val office = LocationEntity(id = 2L, name = "Office", lat = 51.5, lng = -0.09, radiusM = 100f)
+        locationsFlow.value = listOf(home, office)
+        currentIdsFlow.value = setOf(1L)
+
+        backgroundScope.launch { viewModel.locations.collect {} }
+        advanceUntilIdle()
+        assertTrue(viewModel.locations.value[0].isCurrent)
+
+        currentIdsFlow.value = emptySet()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.locations.value[0].isCurrent)
+        assertFalse(viewModel.locations.value[1].isCurrent)
+    }
+
+    @Test
+    fun `deleteLocation swallows repository failure and skips removeGeofence`() = runTest(testDispatcher) {
+        mockkStatic(android.util.Log::class)
+        every { android.util.Log.e(any<String>(), any<String>(), any<Throwable>()) } returns 0
+        try {
+            val location = LocationEntity(id = 7L, name = "Home", lat = 51.5, lng = -0.1, radiusM = 100f)
+            coEvery { locationRepository.delete(location) } throws RuntimeException("db down")
+
+            viewModel.deleteLocation(location)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { locationRepository.delete(location) }
+            coVerify(exactly = 0) { geofenceManager.removeGeofence(any()) }
+        } finally {
+            unmockkStatic(android.util.Log::class)
+        }
     }
 }


### PR DESCRIPTION
## Summary

In the Locations screen, every saved location rendered with identical styling — there was no way to confirm which geofence(s) the app currently considered the user inside. The data already existed in `GeofenceManager.currentLocationIds` but was never surfaced to the UI. This change consumes that `StateFlow` from `LocationViewModel`, joins it with the persisted location list, and renders a visually-distinct card style + "· current" tag for matching rows. Updates reactively as the user crosses fence boundaries while the screen is open.

Fixes #241

## Changes

- **`LocationViewModel.kt`**: Add `LocationRow(location, isCurrent)` data class. Replace `locations: StateFlow<List<LocationEntity>>` with `StateFlow<List<LocationRow>>` produced by `combine(locationRepository.getAll(), geofenceManager.currentLocationIds)`, mirroring the pattern in `RecentTriggersViewModel`. `deleteLocation` is preserved as-is.
- **`LocationScreen.kt`**: Render `LocationRow` instead of `LocationEntity`. When `isCurrent`, the Card uses `MaterialTheme.colorScheme.primaryContainer` as its container color, a `BorderStroke(1.5.dp, primary)` border, and renders a "· current" tag in `MonoLabelTiny` style next to the name.
- **`LocationViewModelTest.kt`**: Stub `geofenceManager.currentLocationIds` in `setup()` (otherwise the new `combine` would crash on construction). Switched to `StandardTestDispatcher` + `MutableStateFlow` inputs to match the project's `combine`-flow test pattern. Added three tests for empty / matching / reactive-change scenarios; the existing `deleteLocation` test still passes.

No new files. No DI changes. No migrations. Only edits to three files in `ui/location`.

## Validation

| Check | Command | Result |
|-------|---------|--------|
| Type check | `./gradlew :app:compileDebugKotlin` | PASS |
| Lint | `./gradlew :app:lintDebug` | PASS — 0 errors, 0 fatal warnings |
| Unit tests | `./gradlew :app:testDebugUnitTest` | PASS — 313/313 |
| Debug build | `./gradlew :app:assembleDebug` | PASS — `app-debug.apk` produced |

`LocationViewModelTest` (4 tests, 0 failures):
- `deleteLocation calls delete on repository and removeGeofence by id` (existing)
- `locations exposes empty list when no data` (new)
- `locations marks isCurrent=true when id matches currentLocationIds` (new)
- `locations updates reactively when currentLocationIds changes` (new)

## Out of Scope

Per the plan in `artifacts/runs/de22dcf190318f7d1e20c345f52743c0/plan.md`:

- No re-sorting current locations to the top (would change list order users are used to).
- No tap-to-recenter / map navigation behavior on highlighted rows.
- No animation on `isCurrent` transition — reactive recomposition is sufficient.
- No empty-state copy change for "you're not currently in any location".

## Test plan

- [ ] Open Locations screen with the device inside one or more geofences — confirm matching rows show the sage-tinted background, sage border, and "· current" tag.
- [ ] Open Locations screen with the device outside all geofences — confirm all cards use the unchanged default style.
- [ ] With the screen open, walk into / out of a fence boundary — confirm the highlight updates without leaving the screen.
- [ ] Toggle dark mode — confirm `primaryContainer` and `primary` resolve to dark variants and remain readable.
- [ ] Delete a location the user is currently inside — confirm the row disappears (`deleteLocation` already calls `geofenceManager.removeGeofence`).