### PR TITLE
Fix: opaque feedback screenshot + scrollable feedback form

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/ui/feedback/FeedbackScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/feedback/FeedbackScreen.kt
@@ -122,131 +122,148 @@ fun FeedbackScreen(
             modifier = Modifier
                 .padding(padding)
                 .imePadding()
-                .padding(16.dp)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
+            // Image + annotation toolbar live outside verticalScroll so the
+            // annotation Canvas's drag gestures cannot starve a parent scroll
+            // (#114).
             if (screenshotBitmap != null) {
-                val aspectRatio = screenshotBitmap.width.toFloat() / screenshotBitmap.height.toFloat()
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 300.dp)
-                        .aspectRatio(aspectRatio)
-                        .clipToBounds()
-                        .onSizeChanged { canvasSize = it }
+                Column(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    Image(
-                        bitmap = screenshotBitmap.asImageBitmap(),
-                        contentDescription = "Screenshot",
-                        modifier = Modifier.fillMaxSize(),
-                        contentScale = ContentScale.Fit
-                    )
-                    Canvas(
+                    val aspectRatio = screenshotBitmap.width.toFloat() / screenshotBitmap.height.toFloat()
+                    Box(
                         modifier = Modifier
-                            .fillMaxSize()
-                            .pointerInput(Unit) {
-                                detectDragGestures(
-                                    onDragStart = { offset ->
-                                        currentPath = Path().apply { moveTo(offset.x, offset.y) }
-                                    },
-                                    onDrag = { change, _ ->
-                                        change.consume()
-                                        currentPath?.lineTo(change.position.x, change.position.y)
-                                        // Create a new Path instance to trigger Compose recomposition —
-                                        // Path has no structural equality, so mutating in place is
-                                        // invisible to state tracking and the canvas would not redraw.
-                                        currentPath = currentPath?.let { Path().apply { addPath(it) } }
-                                    },
-                                    onDragEnd = {
-                                        currentPath?.let { strokes.add(StrokePath(it, currentColor)) }
-                                        currentPath = null
-                                    }
-                                )
-                            }
+                            .fillMaxWidth()
+                            .heightIn(max = 300.dp)
+                            .aspectRatio(aspectRatio)
+                            .clipToBounds()
+                            .onSizeChanged { canvasSize = it }
                     ) {
-                        for (stroke in strokes) {
-                            drawPath(stroke.path, stroke.color, style = Stroke(width = 6f))
-                        }
-                        currentPath?.let {
-                            drawPath(it, currentColor, style = Stroke(width = 6f))
-                        }
-                    }
-                }
-
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    listOf(AnnotationRed, AnnotationYellow, AnnotationGreen).forEach { color ->
-                        Box(
-                            modifier = Modifier
-                                .size(36.dp)
-                                .clip(CircleShape)
-                                .background(color)
-                                .then(
-                                    if (currentColor == color)
-                                        Modifier
-                                            .border(3.dp, Color.Black, CircleShape)
-                                            .padding(2.dp)
-                                            .border(3.dp, Color.White, CircleShape)
-                                    else Modifier
-                                )
-                                .clickable { currentColor = color }
+                        Image(
+                            bitmap = screenshotBitmap.asImageBitmap(),
+                            contentDescription = "Screenshot",
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Fit
                         )
+                        Canvas(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .pointerInput(Unit) {
+                                    detectDragGestures(
+                                        onDragStart = { offset ->
+                                            currentPath = Path().apply { moveTo(offset.x, offset.y) }
+                                        },
+                                        onDrag = { change, _ ->
+                                            change.consume()
+                                            currentPath?.lineTo(change.position.x, change.position.y)
+                                            // Create a new Path instance to trigger Compose recomposition —
+                                            // Path has no structural equality, so mutating in place is
+                                            // invisible to state tracking and the canvas would not redraw.
+                                            currentPath = currentPath?.let { Path().apply { addPath(it) } }
+                                        },
+                                        onDragEnd = {
+                                            currentPath?.let { strokes.add(StrokePath(it, currentColor)) }
+                                            currentPath = null
+                                        }
+                                    )
+                                }
+                        ) {
+                            for (stroke in strokes) {
+                                drawPath(stroke.path, stroke.color, style = Stroke(width = 6f))
+                            }
+                            currentPath?.let {
+                                drawPath(it, currentColor, style = Stroke(width = 6f))
+                            }
+                        }
                     }
 
-                    Spacer(Modifier.weight(1f))
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        listOf(AnnotationRed, AnnotationYellow, AnnotationGreen).forEach { color ->
+                            Box(
+                                modifier = Modifier
+                                    .size(36.dp)
+                                    .clip(CircleShape)
+                                    .background(color)
+                                    .then(
+                                        if (currentColor == color)
+                                            Modifier
+                                                .border(3.dp, Color.Black, CircleShape)
+                                                .padding(2.dp)
+                                                .border(3.dp, Color.White, CircleShape)
+                                        else Modifier
+                                    )
+                                    .clickable { currentColor = color }
+                            )
+                        }
 
-                    TextButton(onClick = { strokes.clear() }) {
-                        Text("Clear All")
+                        Spacer(Modifier.weight(1f))
+
+                        TextButton(onClick = { strokes.clear() }) {
+                            Text("Clear All")
+                        }
                     }
                 }
             }
 
-            OutlinedTextField(
-                value = uiState.description,
-                onValueChange = { viewModel.updateDescription(it) },
-                label = { Text("What happened?") },
-                modifier = Modifier.fillMaxWidth(),
-                minLines = 3
-            )
-
-            Button(
-                onClick = {
-                    val bmpSnapshot = screenshotBitmap
-                    val strokesSnapshot = strokes.toList()
-                    val canvasSizeSnapshot = canvasSize
-                    coroutineScope.launch(Dispatchers.Default) {
-                        val annotationBitmap = if (bmpSnapshot != null && canvasSizeSnapshot.width > 0) {
-                            val annBitmap = Bitmap.createBitmap(bmpSnapshot.width, bmpSnapshot.height, Bitmap.Config.ARGB_8888)
-                            val canvas = android.graphics.Canvas(annBitmap)
-                            val scaleX = bmpSnapshot.width.toFloat() / canvasSizeSnapshot.width
-                            val scaleY = bmpSnapshot.height.toFloat() / canvasSizeSnapshot.height
-                            canvas.scale(scaleX, scaleY)
-                            val paint = android.graphics.Paint().apply {
-                                style = android.graphics.Paint.Style.STROKE
-                                strokeWidth = 6f
-                                isAntiAlias = true
-                            }
-                            for (stroke in strokesSnapshot) {
-                                paint.color = stroke.color.toArgb()
-                                canvas.drawPath(stroke.path.asAndroidPath(), paint)
-                            }
-                            annBitmap
-                        } else {
-                            Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
-                        }
-                        viewModel.submit(annotationBitmap)
-                    }
-                },
-                modifier = Modifier.fillMaxWidth(),
-                enabled = !uiState.isSubmitting
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp)
+                    .padding(
+                        top = if (screenshotBitmap == null) 12.dp else 0.dp,
+                        bottom = 16.dp
+                    ),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                if (uiState.isSubmitting) {
-                    CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
-                } else {
-                    Text("Send")
+                OutlinedTextField(
+                    value = uiState.description,
+                    onValueChange = { viewModel.updateDescription(it) },
+                    label = { Text("What happened?") },
+                    modifier = Modifier.fillMaxWidth(),
+                    minLines = 3
+                )
+
+                Button(
+                    onClick = {
+                        val bmpSnapshot = screenshotBitmap
+                        val strokesSnapshot = strokes.toList()
+                        val canvasSizeSnapshot = canvasSize
+                        coroutineScope.launch(Dispatchers.Default) {
+                            val annotationBitmap = if (bmpSnapshot != null && canvasSizeSnapshot.width > 0) {
+                                val annBitmap = Bitmap.createBitmap(bmpSnapshot.width, bmpSnapshot.height, Bitmap.Config.ARGB_8888)
+                                val canvas = android.graphics.Canvas(annBitmap)
+                                val scaleX = bmpSnapshot.width.toFloat() / canvasSizeSnapshot.width
+                                val scaleY = bmpSnapshot.height.toFloat() / canvasSizeSnapshot.height
+                                canvas.scale(scaleX, scaleY)
+                                val paint = android.graphics.Paint().apply {
+                                    style = android.graphics.Paint.Style.STROKE
+                                    strokeWidth = 6f
+                                    isAntiAlias = true
+                                }
+                                for (stroke in strokesSnapshot) {
+                                    paint.color = stroke.color.toArgb()
+                                    canvas.drawPath(stroke.path.asAndroidPath(), paint)
+                                }
+                                annBitmap
+                            } else {
+                                Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+                            }
+                            viewModel.submit(annotationBitmap)
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !uiState.isSubmitting
+                ) {
+                    if (uiState.isSubmitting) {
+                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                    } else {
+                        Text("Send")
+                    }
                 }
             }
         }

--- a/app/src/main/java/net/interstellarai/unreminder/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/navigation/NavGraph.kt
@@ -85,7 +85,15 @@ fun NavGraph(
         feedbackScreenshot = null  // clear stale state before capture
         try {
             val bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
-            view.draw(Canvas(bitmap))
+            val canvas = Canvas(bitmap)
+            // Pre-fill with theme background so transparent regions (system bar
+            // insets under edge-to-edge rendering) don't leak through as black /
+            // checkerboard in the captured screenshot.
+            val isNight = (activity.resources.configuration.uiMode and
+                android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
+                android.content.res.Configuration.UI_MODE_NIGHT_YES
+            canvas.drawColor(if (isNight) 0xFF171C14.toInt() else 0xFFE8EBD9.toInt())
+            view.draw(canvas)
             feedbackScreenshot = bitmap
         } catch (_: Exception) {
             // capture failed, navigate with null screenshot


### PR DESCRIPTION
## Summary

Fixes the feedback screenshot display and scrolling issue reported in #114. The image preview was showing with a transparent/black background, and the form could not be scrolled when the keyboard was open.

**Root cause**: The screenshot bitmap was being drawn with a transparent background, and the image section was inside the vertically-scrollable container, which prevented the scroll gesture from reaching the text fields.

## Changes

- **NavGraph.kt**: Pre-fill the captured bitmap with the opaque theme background color before returning it to the feedback screen. This ensures the preview always has a solid background that matches the current theme (light or dark).
- **FeedbackScreen.kt**: Restructure the layout to move the image section outside the `verticalScroll` container. The image now stays pinned at the top while the feedback text field and other form content remain scrollable below.

## Validation

- ✅ Kotlin compilation: `./gradlew :app:compileDebugKotlin` passes with no errors
- ✅ Both modified files compile successfully
- ⚠️ Full build blocked by pre-existing JDK toolchain issue (unrelated to this fix, reproduces on main)
- ⏳ Manual device verification still required (feedback screen opaque preview, scroll behavior, annotation drawing)

## Testing

The Kotlin compiler validates the layout restructure and bitmap-fill changes. Manual on-device testing is needed to confirm:
1. Feedback preview has no transparent/black bands
2. Dark mode fills preview with dark background (not white)
3. Text fields scroll freely with keyboard open; image stays pinned
4. Annotation drawing still works
5. Submitted feedback has opaque background in attachment

Fixes #114
