### PR TITLE
Add optional name field for "when" windows

### DIFF
--- a/app/schemas/net.interstellarai.unreminder.data.db.AppDatabase/10.json
+++ b/app/schemas/net.interstellarai.unreminder.data.db.AppDatabase/10.json
@@ -1,0 +1,529 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "e53747c58b47a8ed7617e0f45ae43dd9",
+    "entities": [
+      {
+        "tableName": "habits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `dedication_level` INTEGER NOT NULL, `description_ladder` TEXT NOT NULL, `auto_adjust_level` INTEGER NOT NULL, `daily_limit` INTEGER NOT NULL, `cooldown_minutes` INTEGER NOT NULL DEFAULT 180, `active` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dedicationLevel",
+            "columnName": "dedication_level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "descriptionLadder",
+            "columnName": "description_ladder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAdjustLevel",
+            "columnName": "auto_adjust_level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dailyLimit",
+            "columnName": "daily_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cooldownMinutes",
+            "columnName": "cooldown_minutes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "180"
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "windows",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `end_time` INTEGER NOT NULL, `days_of_week_bitmask` INTEGER NOT NULL, `frequency_per_day` INTEGER NOT NULL, `active` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "end_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "daysOfWeekBitmask",
+            "columnName": "days_of_week_bitmask",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frequencyPerDay",
+            "columnName": "frequency_per_day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "triggers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `window_id` INTEGER, `habit_id` INTEGER, `scheduled_at` INTEGER NOT NULL, `fired_at` INTEGER, `status` TEXT NOT NULL, `generated_prompt` TEXT, `source` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "windowId",
+            "columnName": "window_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "scheduledAt",
+            "columnName": "scheduled_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firedAt",
+            "columnName": "fired_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generatedPrompt",
+            "columnName": "generated_prompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "locations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `lat` REAL NOT NULL, `lng` REAL NOT NULL, `radius_m` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lat",
+            "columnName": "lat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lng",
+            "columnName": "lng",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "radiusM",
+            "columnName": "radius_m",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "habit_location",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`habit_id` INTEGER NOT NULL, `location_id` INTEGER NOT NULL, PRIMARY KEY(`habit_id`, `location_id`), FOREIGN KEY(`habit_id`) REFERENCES `habits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`location_id`) REFERENCES `locations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationId",
+            "columnName": "location_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "habit_id",
+            "location_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_habit_location_location_id",
+            "unique": false,
+            "columnNames": [
+              "location_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_habit_location_location_id` ON `${TABLE_NAME}` (`location_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "habits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "habit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "locations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "location_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "habit_window",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`habit_id` INTEGER NOT NULL, `window_id` INTEGER NOT NULL, PRIMARY KEY(`habit_id`, `window_id`), FOREIGN KEY(`habit_id`) REFERENCES `habits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`window_id`) REFERENCES `windows`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "windowId",
+            "columnName": "window_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "habit_id",
+            "window_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_habit_window_window_id",
+            "unique": false,
+            "columnNames": [
+              "window_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_habit_window_window_id` ON `${TABLE_NAME}` (`window_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "habits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "habit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "windows",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "window_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pending_feedback",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `screenshot_path` TEXT, `description` TEXT NOT NULL, `queued_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "screenshotPath",
+            "columnName": "screenshot_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queued_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "variations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `habit_id` INTEGER NOT NULL, `text` TEXT NOT NULL, `prompt_fingerprint` TEXT NOT NULL, `generated_at` INTEGER NOT NULL, `consumed_at` INTEGER, FOREIGN KEY(`habit_id`) REFERENCES `habits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptFingerprint",
+            "columnName": "prompt_fingerprint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generatedAt",
+            "columnName": "generated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "consumedAt",
+            "columnName": "consumed_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_variations_habit_id",
+            "unique": false,
+            "columnNames": [
+              "habit_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_variations_habit_id` ON `${TABLE_NAME}` (`habit_id`)"
+          },
+          {
+            "name": "index_variations_habit_id_prompt_fingerprint_text",
+            "unique": true,
+            "columnNames": [
+              "habit_id",
+              "prompt_fingerprint",
+              "text"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_variations_habit_id_prompt_fingerprint_text` ON `${TABLE_NAME}` (`habit_id`, `prompt_fingerprint`, `text`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "habits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "habit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "habit_level_descriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`habit_id` INTEGER NOT NULL, `level` INTEGER NOT NULL, `description` TEXT NOT NULL, PRIMARY KEY(`habit_id`, `level`), FOREIGN KEY(`habit_id`) REFERENCES `habits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "habitId",
+            "columnName": "habit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "habit_id",
+            "level"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_habit_level_descriptions_habit_id",
+            "unique": false,
+            "columnNames": [
+              "habit_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_habit_level_descriptions_habit_id` ON `${TABLE_NAME}` (`habit_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "habits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "habit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e53747c58b47a8ed7617e0f45ae43dd9')"
+    ]
+  }
+}

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/AppDatabase.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/AppDatabase.kt
@@ -16,7 +16,7 @@ import androidx.room.TypeConverters
         VariationEntity::class,
         HabitLevelDescriptionEntity::class
     ],
-    version = 9,
+    version = 10,
     exportSchema = true
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/Migration9To10.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/Migration9To10.kt
@@ -1,0 +1,10 @@
+package net.interstellarai.unreminder.data.db
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_9_10 = object : Migration(9, 10) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `windows` ADD COLUMN `name` TEXT NOT NULL DEFAULT ''")
+    }
+}

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/WindowEntity.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/WindowEntity.kt
@@ -9,6 +9,7 @@ import java.time.LocalTime
 data class WindowEntity(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,
+    val name: String = "",
     @ColumnInfo(name = "start_time")
     val startTime: LocalTime,
     @ColumnInfo(name = "end_time")

--- a/app/src/main/java/net/interstellarai/unreminder/di/AppModule.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/di/AppModule.kt
@@ -18,6 +18,7 @@ import net.interstellarai.unreminder.data.db.MIGRATION_5_6
 import net.interstellarai.unreminder.data.db.MIGRATION_6_7
 import net.interstellarai.unreminder.data.db.MIGRATION_7_8
 import net.interstellarai.unreminder.data.db.MIGRATION_8_9
+import net.interstellarai.unreminder.data.db.MIGRATION_9_10
 import net.interstellarai.unreminder.data.db.HabitLevelDescriptionDao
 import net.interstellarai.unreminder.data.db.HabitWindowCrossRefDao
 import net.interstellarai.unreminder.data.db.PendingFeedbackDao
@@ -51,7 +52,7 @@ object AppModule {
             context,
             AppDatabase::class.java,
             "unreminder.db"
-        ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9).build()
+        ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10).build()
     }
 
     @Provides

--- a/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/habit/HabitEditScreen.kt
@@ -952,4 +952,5 @@ private fun AvailabilityStatusRow(
 }
 
 private fun WindowEntity.label(): String =
-    "${startTime.format(DateTimeFormatter.ofPattern("HH:mm"))}\u2013${endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}"
+    if (name.isNotBlank()) name
+    else "${startTime.format(DateTimeFormatter.ofPattern("HH:mm"))}\u2013${endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}"

--- a/app/src/main/java/net/interstellarai/unreminder/ui/window/WindowEditScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/window/WindowEditScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -21,6 +23,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberTimePickerState
@@ -29,9 +33,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import net.interstellarai.unreminder.ui.theme.Dimens
+import net.interstellarai.unreminder.ui.theme.DisplayLarge
+import net.interstellarai.unreminder.ui.theme.MonoSectionLabel
 import java.time.DayOfWeek
 import java.time.format.TextStyle
 import java.util.Locale
@@ -94,6 +102,16 @@ fun WindowEditScreen(
                 .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
+            Column {
+                MonoSectionLabel("window name")
+                Spacer(Modifier.height(Dimens.sm))
+                UnderlinedDisplayField(
+                    value = uiState.name,
+                    onValueChange = viewModel::updateName,
+                    placeholder = "e.g. morning",
+                )
+            }
+
             Text("Start Time", style = MaterialTheme.typography.titleSmall)
             TimePicker(state = startTimeState)
 
@@ -132,4 +150,32 @@ fun WindowEditScreen(
             }
         }
     }
+}
+
+@Composable
+private fun UnderlinedDisplayField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+) {
+    TextField(
+        value = value,
+        onValueChange = onValueChange,
+        textStyle = DisplayLarge.copy(color = MaterialTheme.colorScheme.onBackground),
+        placeholder = {
+            Text(
+                placeholder,
+                style = DisplayLarge.copy(color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.35f)),
+            )
+        },
+        colors = TextFieldDefaults.colors(
+            focusedContainerColor = Color.Transparent,
+            unfocusedContainerColor = Color.Transparent,
+            focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+            unfocusedIndicatorColor = MaterialTheme.colorScheme.primary,
+            cursorColor = MaterialTheme.colorScheme.primary,
+        ),
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
 }

--- a/app/src/main/java/net/interstellarai/unreminder/ui/window/WindowEditViewModel.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/window/WindowEditViewModel.kt
@@ -21,6 +21,7 @@ data class WindowEditUiState(
     val daysOfWeekBitmask: Int = 0b1111111, // all days
     val frequencyPerDay: Int = 1,
     val active: Boolean = true,
+    val name: String = "",
     val isSaved: Boolean = false
 )
 
@@ -46,7 +47,8 @@ class WindowEditViewModel @Inject constructor(
                     endMinute = window.endTime.minute,
                     daysOfWeekBitmask = window.daysOfWeekBitmask,
                     frequencyPerDay = window.frequencyPerDay,
-                    active = window.active
+                    active = window.active,
+                    name = window.name
                 )
             }
         }
@@ -74,6 +76,10 @@ class WindowEditViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(active = active)
     }
 
+    fun updateName(name: String) {
+        _uiState.value = _uiState.value.copy(name = name)
+    }
+
     fun save() {
         viewModelScope.launch {
             val state = _uiState.value
@@ -88,7 +94,8 @@ class WindowEditViewModel @Inject constructor(
                         endTime = endTime,
                         daysOfWeekBitmask = state.daysOfWeekBitmask,
                         frequencyPerDay = state.frequencyPerDay,
-                        active = state.active
+                        active = state.active,
+                        name = state.name
                     )
                 )
             } else {
@@ -98,7 +105,8 @@ class WindowEditViewModel @Inject constructor(
                         endTime = endTime,
                         daysOfWeekBitmask = state.daysOfWeekBitmask,
                         frequencyPerDay = state.frequencyPerDay,
-                        active = state.active
+                        active = state.active,
+                        name = state.name
                     )
                 )
             }

--- a/app/src/main/java/net/interstellarai/unreminder/ui/window/WindowListScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/window/WindowListScreen.kt
@@ -127,6 +127,7 @@ fun WindowListScreen(
                 ) {
                     items(windows, key = { it.id }) { window ->
                         WindowRow(
+                            name = window.name,
                             timeText = "${window.startTime} \u2013 ${window.endTime}",
                             frequency = window.frequencyPerDay,
                             daysBitmask = window.daysOfWeekBitmask,
@@ -173,6 +174,7 @@ private fun WindowListHeader(onNavigateToFeedback: () -> Unit) {
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun WindowRow(
+    name: String,
     timeText: String,
     frequency: Int,
     daysBitmask: Int,
@@ -201,6 +203,14 @@ private fun WindowRow(
         }
         Spacer(Modifier.size(Dimens.md + 2.dp))
         Column(modifier = Modifier.weight(1f)) {
+            if (name.isNotBlank()) {
+                Text(
+                    text = name,
+                    style = MonoLabel,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = alpha),
+                )
+                Spacer(Modifier.height(Dimens.xs))
+            }
             Text(
                 text = timeText,
                 style = DisplaySmall.copy(

--- a/app/src/test/java/net/interstellarai/unreminder/data/db/Migration9To10Test.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/db/Migration9To10Test.kt
@@ -1,0 +1,56 @@
+package net.interstellarai.unreminder.data.db
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class Migration9To10Test {
+
+    private fun createV9Database(): SupportSQLiteDatabase {
+        val config = SupportSQLiteOpenHelper.Configuration.builder(RuntimeEnvironment.getApplication())
+            .name(null) // in-memory
+            .callback(object : SupportSQLiteOpenHelper.Callback(9) {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS `windows` (" +
+                        "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "`start_time` INTEGER NOT NULL, " +
+                        "`end_time` INTEGER NOT NULL, " +
+                        "`days_of_week_bitmask` INTEGER NOT NULL, " +
+                        "`frequency_per_day` INTEGER NOT NULL, " +
+                        "`active` INTEGER NOT NULL)"
+                    )
+                }
+
+                override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {}
+            })
+            .build()
+
+        return FrameworkSQLiteOpenHelperFactory().create(config).writableDatabase
+    }
+
+    @Test
+    fun `MIGRATION_9_10 adds name column with default empty string`() {
+        val db = createV9Database()
+
+        db.execSQL(
+            "INSERT INTO windows (start_time, end_time, days_of_week_bitmask, frequency_per_day, active) " +
+            "VALUES (32400, 61200, 127, 1, 1)"
+        )
+
+        MIGRATION_9_10.migrate(db)
+
+        val cursor = db.query("SELECT name FROM windows LIMIT 1")
+        cursor.moveToFirst()
+        assertEquals("", cursor.getString(0))
+        cursor.close()
+
+        db.close()
+    }
+}


### PR DESCRIPTION
## Summary

Add optional `name` field to "when" (time) windows, allowing users to label and identify windows by custom names instead of relying solely on time ranges.

## Changes

- **Database**: Added `name: String = ""` field to `WindowEntity` with migration (Migration_9_10)
- **UI**: Added name input field to window editor and displays name above time range in list
- **ViewModel**: Threaded `name` field through `WindowEditViewModel`
- **Label Logic**: Updated `WindowEntity.label()` to prefer custom name over time range display
- **Tests**: Added Robolectric migration test for database schema change

## Validation

✅ Type checking: `compileDebugKotlin` passes  
✅ Linting: No errors or warnings  
✅ Unit tests: All pass, including new `Migration9To10Test`  
✅ Database schema: Room generates `10.json` with `name TEXT NOT NULL` column  

## Files Changed

- `WindowEntity.kt` — Add `name` field
- `AppDatabase.kt` — Bump version to 10
- `Migration9To10.kt` — New migration
- `AppModule.kt` — Register migration
- `WindowEditViewModel.kt` — Thread `name` through
- `WindowEditScreen.kt` — Add name input field
- `WindowListScreen.kt` — Display name in window rows
- `HabitEditScreen.kt` — Update label logic
- `Migration9To10Test.kt` — New test

Fixes #113
