### PR TITLE
Fix: hide SCHEDULED triggers from recent triggers list

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/data/db/TriggerDao.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/TriggerDao.kt
@@ -15,6 +15,8 @@ interface TriggerDao {
     @Update
     suspend fun update(trigger: TriggerEntity)
 
+    // != 'SCHEDULED' (not IN whitelist) so legacy DB rows with status 'COMPLETED_FULL' or
+    // 'COMPLETED_LOW_FLOOR' (see Converters.toTriggerStatus) also pass through.
     @Query("SELECT * FROM triggers WHERE status != 'SCHEDULED' ORDER BY scheduled_at DESC LIMIT :limit")
     fun getRecentTriggers(limit: Int = 20): Flow<List<TriggerEntity>>
 

--- a/app/src/main/java/net/interstellarai/unreminder/data/db/TriggerDao.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/data/db/TriggerDao.kt
@@ -15,7 +15,7 @@ interface TriggerDao {
     @Update
     suspend fun update(trigger: TriggerEntity)
 
-    @Query("SELECT * FROM triggers ORDER BY scheduled_at DESC LIMIT :limit")
+    @Query("SELECT * FROM triggers WHERE status != 'SCHEDULED' ORDER BY scheduled_at DESC LIMIT :limit")
     fun getRecentTriggers(limit: Int = 20): Flow<List<TriggerEntity>>
 
     @Query("SELECT * FROM triggers WHERE status = 'SCHEDULED' AND scheduled_at >= :fromMillis AND scheduled_at < :toMillis")

--- a/app/src/test/java/net/interstellarai/unreminder/data/db/TriggerDaoRecentTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/db/TriggerDaoRecentTest.kt
@@ -93,5 +93,9 @@ class TriggerDaoRecentTest {
 
         assertEquals(3, results.size)
         assertTrue(results.none { it.status == TriggerStatus.SCHEDULED })
+        // Verify ORDER BY scheduled_at DESC: DISMISSED (now-10s) → COMPLETED (now-20s) → FIRED (now-30s)
+        assertEquals(TriggerStatus.DISMISSED, results[0].status)
+        assertEquals(TriggerStatus.COMPLETED, results[1].status)
+        assertEquals(TriggerStatus.FIRED, results[2].status)
     }
 }

--- a/app/src/test/java/net/interstellarai/unreminder/data/db/TriggerDaoRecentTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/data/db/TriggerDaoRecentTest.kt
@@ -1,0 +1,97 @@
+package net.interstellarai.unreminder.data.db
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import net.interstellarai.unreminder.domain.model.TriggerStatus
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+class TriggerDaoRecentTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var triggerDao: TriggerDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java
+        ).allowMainThreadQueries().build()
+        triggerDao = db.triggerDao()
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    @Test
+    fun `getRecentTriggers excludes SCHEDULED triggers`() = runTest {
+        val now = Instant.now()
+        triggerDao.insert(
+            TriggerEntity(scheduledAt = now, status = TriggerStatus.SCHEDULED)
+        )
+        triggerDao.insert(
+            TriggerEntity(
+                habitId = 1,
+                scheduledAt = now.minusSeconds(60),
+                firedAt = now.minusSeconds(30),
+                status = TriggerStatus.FIRED,
+                generatedPrompt = "Do the thing"
+            )
+        )
+
+        val results = triggerDao.getRecentTriggers(20).first()
+
+        assertEquals(1, results.size)
+        assertEquals(TriggerStatus.FIRED, results[0].status)
+        assertEquals("Do the thing", results[0].generatedPrompt)
+    }
+
+    @Test
+    fun `getRecentTriggers includes COMPLETED DISMISSED and FIRED`() = runTest {
+        val now = Instant.now()
+        triggerDao.insert(
+            TriggerEntity(
+                habitId = 1,
+                scheduledAt = now.minusSeconds(30),
+                firedAt = now.minusSeconds(20),
+                status = TriggerStatus.FIRED,
+                generatedPrompt = "p1"
+            )
+        )
+        triggerDao.insert(
+            TriggerEntity(
+                habitId = 2,
+                scheduledAt = now.minusSeconds(20),
+                firedAt = now.minusSeconds(10),
+                status = TriggerStatus.COMPLETED,
+                generatedPrompt = "p2"
+            )
+        )
+        triggerDao.insert(
+            TriggerEntity(
+                habitId = 3,
+                scheduledAt = now.minusSeconds(10),
+                firedAt = now,
+                status = TriggerStatus.DISMISSED,
+                generatedPrompt = "p3"
+            )
+        )
+        triggerDao.insert(
+            TriggerEntity(scheduledAt = now.plusSeconds(60), status = TriggerStatus.SCHEDULED)
+        )
+
+        val results = triggerDao.getRecentTriggers(20).first()
+
+        assertEquals(3, results.size)
+        assertTrue(results.none { it.status == TriggerStatus.SCHEDULED })
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the issue where stale SCHEDULED triggers appear in the "recent triggers" history list without any notification text. These triggers accumulate when the RandomIntervalWorker is killed between inserting the trigger record and executing the pipeline. While the TriggerWatchdogWorker cleans them up every 24 hours, the list shows blank rows until then.

**Root cause**: `getRecentTriggers` returned all triggers regardless of status, including SCHEDULED ones which have never been fired and thus have `generatedPrompt = null`. The TriggerRow UI correctly skips rendering the text block when the prompt is null, leaving blank rows.

**Solution**: Filter out SCHEDULED triggers from the query since the "what happened" history should only surface past events (FIRED, DISMISSED, COMPLETED). The next trigger's scheduled time is already visible in the screen header via WorkManager info.

## Changes

| File | Change |
|------|--------|
| `app/src/main/java/net/interstellarai/unreminder/data/db/TriggerDao.kt` | Updated `getRecentTriggers()` query to exclude SCHEDULED triggers with `WHERE status != 'SCHEDULED'` |
| `app/src/test/java/net/interstellarai/unreminder/data/db/TriggerDaoRecentTest.kt` | Added new Robolectric DAO test with 2 cases: excludes SCHEDULED and includes COMPLETED/DISMISSED/FIRED |

## Validation

- ✅ Type check (Kotlin compile): PASS
- ✅ Tests: 312 passed (including 2 new DAO tests)
- ✅ Lint: 0 errors, no new warnings
- ✅ Build: DEBUG APK assembled successfully

## Testing Strategy

The new test `TriggerDaoRecentTest` verifies:
1. `getRecentTriggers excludes SCHEDULED triggers` — inserted a SCHEDULED trigger and a FIRED trigger, verified only the FIRED one is returned
2. `getRecentTriggers includes COMPLETED DISMISSED and FIRED` — ensures the negation filter doesn't accidentally exclude other statuses

Follows the existing pattern in the codebase (e.g., `HabitDaoEligibleTest`) using Robolectric for in-memory Room testing.

Fixes #112
