### PR TITLE
fix(location): re-register geofences on app launch + show current location in UI

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/UnReminderApp.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/UnReminderApp.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import androidx.work.WorkManager
+import net.interstellarai.unreminder.service.geofence.GeofenceManager
 import net.interstellarai.unreminder.service.notification.NotificationHelper
 import net.interstellarai.unreminder.service.sentry.applyOptions
 import net.interstellarai.unreminder.service.sentry.shouldInitSentry
@@ -12,6 +13,10 @@ import net.interstellarai.unreminder.worker.RandomIntervalWorker
 import net.interstellarai.unreminder.worker.TriggerWatchdogWorker
 import dagger.hilt.android.HiltAndroidApp
 import io.sentry.android.core.SentryAndroid
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -22,6 +27,9 @@ class UnReminderApp : Application(), Configuration.Provider {
 
     @Inject
     lateinit var notificationHelper: NotificationHelper
+
+    @Inject
+    lateinit var geofenceManager: GeofenceManager
 
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
@@ -39,6 +47,12 @@ class UnReminderApp : Application(), Configuration.Provider {
         // Self-heal (KEEP, 24h periodic): re-enqueues the chain if it ever falls into a
         // terminal state, and reaps stale SCHEDULED rows.
         TriggerWatchdogWorker.enqueue(this)
+        // Re-register all geofences on every launch. Android clears geofences on app update,
+        // force-stop, or data clear; re-registering with INITIAL_TRIGGER_ENTER ensures
+        // currentLocationIds is accurate even without a device reboot.
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            geofenceManager.registerAllFromDb()
+        }
     }
 
     private fun initSentry() {


### PR DESCRIPTION
## Summary

- **Bug 1 (already landed from main pull)**: `LocationViewModel` now combines `locationRepository.getAll()` with `geofenceManager.currentLocationIds` into a `LocationRow` list (with `isCurrent: Boolean`). `LocationScreen` shows a `"· current"` label using `MonoLabelTiny` style and highlights the card with a primary-colored border and `primaryContainer` background when the user is physically inside that location.

- **Bug 2 (this PR)**: `GeofenceManager.registerAllFromDb()` is now called in `UnReminderApp.onCreate()` via a fire-and-forget `CoroutineScope(SupervisorJob() + Dispatchers.IO)`. Previously it was only called from `BootReschedulerWorker`, which means geofences were lost after every app update, force-stop, or data clear. Re-registering on launch with `INITIAL_TRIGGER_ENTER` causes the Android geofencing system to immediately fire an `ENTER` event when the user is already inside a geofence, populating `currentLocationIds` without requiring a device reboot.

## Test plan

- [ ] Compile passes: `./gradlew compileDebugKotlin` — BUILD SUCCESSFUL
- [ ] `LocationViewModelTest` (6 tests) all pass including new reactive tests for `isCurrent` flag
- [ ] Pre-existing `MapPickerViewModelTest` failure confirmed to exist on `main` before these changes — not introduced here
- [ ] On device: force-stop app, re-open while inside a saved geofence → location card shows "· current" highlight immediately after re-launch (previously required reboot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)