### PR TITLE
fix(geofence): require ACCESS_BACKGROUND_LOCATION on Android 10+

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/geofence/GeofenceManager.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/geofence/GeofenceManager.kt
@@ -62,8 +62,10 @@ class GeofenceManager @Inject constructor(
     fun registerGeofence(id: Long, name: String, lat: Double, lng: Double, radiusM: Float) {
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
             != PackageManager.PERMISSION_GRANTED
+            || ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+            != PackageManager.PERMISSION_GRANTED
         ) {
-            Log.w(TAG, "Missing location permission, cannot register geofence")
+            Log.w(TAG, "Missing required location permissions, cannot register geofence")
             return
         }
 


### PR DESCRIPTION
## Problem

On Android 10+, geofences only fire when the app is in the background if it holds `ACCESS_BACKGROUND_LOCATION` in addition to `ACCESS_FINE_LOCATION`. Without this permission, `addGeofences()` returns success but the OS silently drops all transition events — geofences appear registered but never trigger.

## Fix

Added `ACCESS_BACKGROUND_LOCATION` to the permission guard in `registerGeofence()`. Both permissions are now checked together; if either is missing the method returns early with a log warning instead of registering a fence that will never deliver events.

The change is minimal and targeted: no new UI, no API changes, one extra `checkSelfPermission` call and an updated log message.