### PR TITLE
feat: adaptive check interval — 15-30 min normal, 60-90 min post-notification

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/worker/RandomIntervalWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/worker/RandomIntervalWorker.kt
@@ -39,12 +39,26 @@ class RandomIntervalWorker @AssistedInject constructor(
 
     companion object {
         const val WORK_NAME = "random_interval"
-        const val MIN_DELAY_MINUTES = 60L
-        const val MAX_DELAY_MINUTES = 180L
+        const val MIN_DELAY_MINUTES = 15L
+        const val MAX_DELAY_MINUTES = 30L
+        private const val MIN_POST_NOTIF_MINUTES = 60L
+        private const val MAX_POST_NOTIF_MINUTES = 90L
         private const val TAG = "RandomIntervalWorker"
 
         fun enqueueNext(workManager: WorkManager) {
             val delay = Random.nextLong(MIN_DELAY_MINUTES, MAX_DELAY_MINUTES)
+            val request = OneTimeWorkRequestBuilder<RandomIntervalWorker>()
+                .setInitialDelay(delay, TimeUnit.MINUTES)
+                .build()
+            workManager.enqueueUniqueWork(
+                WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                request
+            )
+        }
+
+        fun enqueueNextAfterFire(workManager: WorkManager) {
+            val delay = Random.nextLong(MIN_POST_NOTIF_MINUTES, MAX_POST_NOTIF_MINUTES)
             val request = OneTimeWorkRequestBuilder<RandomIntervalWorker>()
                 .setInitialDelay(delay, TimeUnit.MINUTES)
                 .build()
@@ -74,6 +88,7 @@ class RandomIntervalWorker @AssistedInject constructor(
     override suspend fun doWork(): Result {
         var step = "init"
         var triggerId: Long? = null
+        var fired = false
         try {
             step = "windowQuery"
             val activeWindows = windowRepository.getActiveWindows()
@@ -111,6 +126,7 @@ class RandomIntervalWorker @AssistedInject constructor(
 
             step = "pipeline"
             triggerPipeline.execute(triggerId)
+            fired = triggerRepository.getById(triggerId)?.status == TriggerStatus.FIRED
         } catch (e: CancellationException) {
             // Intentionally not calling scheduleNext here — WorkManager may not be
             // in a safe state to accept new work during coroutine cancellation.
@@ -127,9 +143,11 @@ class RandomIntervalWorker @AssistedInject constructor(
             triggerId?.let { triggerRepository.updateOutcome(it, TriggerStatus.DISMISSED) }
         }
 
-        scheduleNext()
+        scheduleNext(fired)
         return Result.success()
     }
 
-    private fun scheduleNext() = enqueueNext(workManager)
+    private fun scheduleNext(fired: Boolean = false) {
+        if (fired) enqueueNextAfterFire(workManager) else enqueueNext(workManager)
+    }
 }


### PR DESCRIPTION
## Summary

- Reduces normal notification check interval from 60–180 min to **15–30 min**, making habit reminders more responsive.
- Adds a post-notification back-off: after a notification is actually shown (`TriggerStatus.FIRED`), the next check is delayed **60–90 min** to avoid immediate re-triggering.
- Adds `enqueueNextAfterFire(workManager)` companion function with the longer interval constants.
- `enqueueInitial` automatically picks up the new 15–30 min normal range (shared constants).

## Changes

Only `RandomIntervalWorker.kt` is modified:
- Updated `MIN_DELAY_MINUTES = 15L`, `MAX_DELAY_MINUTES = 30L`
- Added `MIN_POST_NOTIF_MINUTES = 60L`, `MAX_POST_NOTIF_MINUTES = 90L`
- Added `enqueueNextAfterFire()` companion function
- Added `fired` local var in `doWork()`, set after `triggerPipeline.execute()` by querying trigger status
- `scheduleNext(fired: Boolean)` branches to the appropriate enqueue function

## Test plan

- [ ] Verify normal (no notification fired) path schedules next work in 15–30 min range
- [ ] Verify post-notification path schedules next work in 60–90 min range
- [ ] Confirm `enqueueInitial` uses 15–30 min range
- [ ] Confirm `CancellationException` path is unchanged (no `scheduleNext` call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)