### PR TITLE
Fix: retry HTTP errors in callRequestyWithSchemaRetry

### DIFF
--- a/worker/bun.lock
+++ b/worker/bun.lock
@@ -1,0 +1,195 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "un-reminder-worker",
+      "dependencies": {
+        "@sentry/cloudflare": "^10.0",
+        "hono": "^4.12.0",
+      },
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.14.7",
+        "@cloudflare/workers-types": "^4.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.4",
+        "wrangler": "^4.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, ""],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0" } }, ""],
+
+    "@cloudflare/vitest-pool-workers": ["@cloudflare/vitest-pool-workers@0.14.7", "", { "dependencies": { "cjs-module-lexer": "^1.2.3", "esbuild": "0.27.3", "miniflare": "4.20260415.0", "wrangler": "4.83.0", "zod": "^3.25.76" }, "peerDependencies": { "@vitest/runner": "^4.1.0", "@vitest/snapshot": "^4.1.0", "vitest": "^4.1.0" } }, "sha512-6LooO25358uPn/7U3LUg5f5pLULncDTShGuOf00TyEn3VIBW2otq92dTNf8ScIR3gV9QDztXNfChc4mqPCSBEA=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260415.1", "", { "os": "linux", "cpu": "x64" }, ""],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260420.1", "", {}, ""],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, ""],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, ""],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, ""],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, ""],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, ""],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, ""],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, ""],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, ""],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, ""],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, ""],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.126.0", "", {}, ""],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, ""],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, ""],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, ""],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.16", "", { "os": "linux", "cpu": "x64" }, ""],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.16", "", {}, ""],
+
+    "@sentry/cloudflare": ["@sentry/cloudflare@10.51.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@sentry/core": "10.51.0" }, "peerDependencies": { "@cloudflare/workers-types": "^4.x" } }, "sha512-oDv2i70q25QPG9zN2GbdtkAjxBdvwHjZL+2aAuilDsagz+jUMq89EXrdh3RPdqnSlaTOqMJovIRDJVbTvpOCsg=="],
+
+    "@sentry/core": ["@sentry/core@10.51.0", "", {}, "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, ""],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, ""],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, ""],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, ""],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, ""],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, ""],
+
+    "@vitest/expect": ["@vitest/expect@4.1.4", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, ""],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.4", "", { "dependencies": { "@vitest/spy": "4.1.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw"] }, ""],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.4", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, ""],
+
+    "@vitest/runner": ["@vitest/runner@4.1.4", "", { "dependencies": { "@vitest/utils": "4.1.4", "pathe": "^2.0.3" } }, ""],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "@vitest/utils": "4.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, ""],
+
+    "@vitest/spy": ["@vitest/spy@4.1.4", "", {}, ""],
+
+    "@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, ""],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, ""],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, ""],
+
+    "chai": ["chai@6.2.2", "", {}, ""],
+
+    "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, ""],
+
+    "cookie": ["cookie@1.1.1", "", {}, ""],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, ""],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, ""],
+
+    "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, ""],
+
+    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/linux-x64": "0.27.3" }, "bin": "bin/esbuild" }, ""],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, ""],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, ""],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, ""],
+
+    "hono": ["hono@4.12.14", "", {}, ""],
+
+    "kleur": ["kleur@4.1.5", "", {}, ""],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-linux-x64-gnu": "1.32.0" } }, ""],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, ""],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, ""],
+
+    "miniflare": ["miniflare@4.20260415.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260415.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": "bootstrap.js" }, ""],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, ""],
+
+    "obug": ["obug@2.1.1", "", {}, ""],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, ""],
+
+    "pathe": ["pathe@2.0.3", "", {}, ""],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, ""],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, ""],
+
+    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, ""],
+
+    "rolldown": ["rolldown@1.0.0-rc.16", "", { "dependencies": { "@oxc-project/types": "=0.126.0", "@rolldown/pluginutils": "1.0.0-rc.16" }, "optionalDependencies": { "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16" }, "bin": "bin/cli.mjs" }, ""],
+
+    "semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, ""],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5" } }, ""],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, ""],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, ""],
+
+    "stackback": ["stackback@0.0.2", "", {}, ""],
+
+    "std-env": ["std-env@4.1.0", "", {}, ""],
+
+    "supports-color": ["supports-color@10.2.2", "", {}, ""],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, ""],
+
+    "tinyexec": ["tinyexec@1.1.1", "", {}, ""],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, ""],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, ""],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, ""],
+
+    "undici": ["undici@7.24.8", "", {}, ""],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, ""],
+
+    "vite": ["vite@8.0.9", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.16", "tinyglobby": "^0.2.16" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, ""],
+
+    "vitest": ["vitest@4.1.4", "", { "dependencies": { "@vitest/expect": "4.1.4", "@vitest/mocker": "4.1.4", "@vitest/pretty-format": "4.1.4", "@vitest/runner": "4.1.4", "@vitest/snapshot": "4.1.4", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.4", "@vitest/browser-preview": "4.1.4", "@vitest/browser-webdriverio": "4.1.4", "@vitest/coverage-istanbul": "4.1.4", "@vitest/coverage-v8": "4.1.4", "@vitest/ui": "4.1.4", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": "vitest.mjs" }, ""],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": "cli.js" }, ""],
+
+    "workerd": ["workerd@1.20260415.1", "", { "optionalDependencies": { "@cloudflare/workerd-linux-64": "1.20260415.1" }, "bin": "bin/workerd" }, ""],
+
+    "wrangler": ["wrangler@4.83.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260415.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260415.1" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260415.1" }, "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, ""],
+
+    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, ""],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, ""],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, ""],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+  }
+}

--- a/worker/src/lib/requesty.test.ts
+++ b/worker/src/lib/requesty.test.ts
@@ -166,7 +166,7 @@ describe('callRequestyWithSchemaRetry', () => {
   })
 
   it('returns null on HTTP error after retrying both attempts', async () => {
-    const sentryCapture = vi.spyOn(Sentry, 'captureException').mockImplementation(() => ({} as ReturnType<typeof Sentry.captureException>))
+    const sentryCapture = vi.spyOn(Sentry, 'captureException').mockReturnValue({} as ReturnType<typeof Sentry.captureException>)
 
     mockFetchResponses(
       { status: 500, body: 'Internal Server Error' },

--- a/worker/src/lib/requesty.test.ts
+++ b/worker/src/lib/requesty.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
+import * as Sentry from '@sentry/cloudflare'
 import { callRequesty, callRequestyWithSchemaRetry } from './requesty'
 
 const originalFetch = globalThis.fetch
@@ -165,6 +166,8 @@ describe('callRequestyWithSchemaRetry', () => {
   })
 
   it('returns null on HTTP error after retrying both attempts', async () => {
+    const sentryCapture = vi.spyOn(Sentry, 'captureException').mockImplementation(() => ({} as ReturnType<typeof Sentry.captureException>))
+
     mockFetchResponses(
       { status: 500, body: 'Internal Server Error' },
       { status: 500, body: 'Internal Server Error' },
@@ -176,6 +179,9 @@ describe('callRequestyWithSchemaRetry', () => {
     )
     expect(result).toBeNull()
     expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+    // Sentry must only fire on the final failure, not the first attempt
+    expect(sentryCapture).toHaveBeenCalledTimes(1)
+    sentryCapture.mockRestore()
   })
 
   it('accumulates tokens when first attempt has valid JSON but fails validation then retry succeeds', async () => {

--- a/worker/src/lib/requesty.test.ts
+++ b/worker/src/lib/requesty.test.ts
@@ -164,15 +164,18 @@ describe('callRequestyWithSchemaRetry', () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(2)
   })
 
-  it('returns null immediately on HTTP error without retrying', async () => {
-    mockFetchResponses({ status: 500, body: 'Internal Server Error' })
+  it('returns null on HTTP error after retrying both attempts', async () => {
+    mockFetchResponses(
+      { status: 500, body: 'Internal Server Error' },
+      { status: 500, body: 'Internal Server Error' },
+    )
 
     const result = await callRequestyWithSchemaRetry(
       'key', 'model', 'prompt', 'strict',
       (p) => p,
     )
     expect(result).toBeNull()
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
   })
 
   it('accumulates tokens when first attempt has valid JSON but fails validation then retry succeeds', async () => {

--- a/worker/src/lib/requesty.ts
+++ b/worker/src/lib/requesty.ts
@@ -87,7 +87,7 @@ export async function callRequestyWithSchemaRetry<T>(
         })
         return null
       }
-      // First attempt failed with an HTTP error — let the retry loop continue.
+      // First attempt failed — let the retry loop continue.
       continue
     }
 

--- a/worker/src/lib/requesty.ts
+++ b/worker/src/lib/requesty.ts
@@ -76,15 +76,19 @@ export async function callRequestyWithSchemaRetry<T>(
     try {
       result = await callRequesty(apiKey, model, isRetry ? stricterPrompt : prompt, maxTokens, temperature)
     } catch (err) {
-      // HTTP errors (non-200) are not retryable — upstream is down or rate-limiting.
       const match = err instanceof Error ? err.message.match(/Requesty (\d+)/) : null
       const status = match ? parseInt(match[1], 10) : 0
       console.error('[requesty] callRequesty failed', { isRetry, status, err })
-      Sentry.captureException(toError(err), {
-        tags: { 'requesty.failure': 'http' },
-        contexts: { requesty: { isRetry, status } },
-      })
-      return null
+      if (isRetry) {
+        // Both attempts failed — report to Sentry and give up.
+        Sentry.captureException(toError(err), {
+          tags: { 'requesty.failure': 'http' },
+          contexts: { requesty: { isRetry, status } },
+        })
+        return null
+      }
+      // First attempt failed with an HTTP error — let the retry loop continue.
+      continue
     }
 
     totalOutputTokens += result.outputTokens

--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -648,7 +648,7 @@ describe('un-reminder-worker', () => {
   })
 
   it('returns 502 on /v1/habit-fields when upstream throws on both attempts', async () => {
-    // callRequesty throws on non-200 — no schema retry on HTTP errors, one 500 suffices
+    enqueueResponse(500, 'Internal Server Error')
     enqueueResponse(500, 'Internal Server Error')
 
     const req = makeRequest('/v1/habit-fields', {
@@ -660,5 +660,37 @@ describe('un-reminder-worker', () => {
     const res = await app.fetch(req, testEnv(), ctx)
     await waitOnExecutionContext(ctx)
     expect(res.status).toBe(502)
+  })
+
+  it('returns 200 on /v1/habit-fields when first HTTP call fails but retry succeeds', async () => {
+    enqueueResponse(500, 'Internal Server Error')
+    enqueueResponse(
+      200,
+      JSON.stringify({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                descriptionLadder: ['a', 'b', 'c', 'd', 'e', 'f'],
+              }),
+            },
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 20 },
+      }),
+      { 'Content-Type': 'application/json' },
+    )
+
+    const req = makeRequest('/v1/habit-fields', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-UR-Secret': SECRET },
+      body: { title: 'Meditate' },
+    })
+    const ctx = createExecutionContext()
+    const res = await app.fetch(req, testEnv(), ctx)
+    await waitOnExecutionContext(ctx)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { descriptionLadder: string[] }
+    expect(body.descriptionLadder).toHaveLength(6)
   })
 })

--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -664,22 +664,7 @@ describe('un-reminder-worker', () => {
 
   it('returns 200 on /v1/habit-fields when first HTTP call fails but retry succeeds', async () => {
     enqueueResponse(500, 'Internal Server Error')
-    enqueueResponse(
-      200,
-      JSON.stringify({
-        choices: [
-          {
-            message: {
-              content: JSON.stringify({
-                descriptionLadder: ['a', 'b', 'c', 'd', 'e', 'f'],
-              }),
-            },
-          },
-        ],
-        usage: { prompt_tokens: 10, completion_tokens: 20 },
-      }),
-      { 'Content-Type': 'application/json' },
-    )
+    mockRequestySuccess({ descriptionLadder: ['a', 'b', 'c', 'd', 'e', 'f'] })
 
     const req = makeRequest('/v1/habit-fields', {
       method: 'POST',

--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -288,7 +288,7 @@ describe('un-reminder-worker', () => {
   // ---- personalContext tests ----
 
   it('injects personalContext into prompt as Style line', async () => {
-    const variants = ['Stretch!', 'Move!', 'Go!']
+    const variants = [{ text: 'Stretch!' }, { text: 'Move!' }, { text: 'Go!' }]
     mockRequestySuccess(variants)
 
     const req = makeRequest('/v1/generate/batch', {
@@ -313,7 +313,7 @@ describe('un-reminder-worker', () => {
   })
 
   it('omits Style line when personalContext absent', async () => {
-    const variants = ['Stretch!', 'Move!', 'Go!']
+    const variants = [{ text: 'Stretch!' }, { text: 'Move!' }, { text: 'Go!' }]
     mockRequestySuccess(variants)
 
     const req = makeRequest('/v1/generate/batch', {


### PR DESCRIPTION
## Summary

Fixes transient upstream errors (500, 502, 503) by enabling HTTP error retry in `callRequestyWithSchemaRetry`. Previously, non-200 HTTP responses would immediately return `null`, causing the Worker to respond with 502. Now the first attempt failure falls through to retry, matching the existing behavior for schema-validation failures.

Only on final failure (second attempt) is the error reported to Sentry, reducing noise from transient issues that often resolve on retry.

## Changes

**worker/src/lib/requesty.ts**
- Modified HTTP error handling to continue to retry loop on first attempt instead of returning immediately
- Only reports to Sentry on second attempt failure (isRetry=true)
- Matches existing pattern used for schema-validation failures

**worker/src/lib/requesty.test.ts**
- Updated "returns null immediately on HTTP error without retrying" test to enqueue 2 mock responses

**worker/test/index.test.ts**
- Updated habitFields HTTP error test to enqueue 2 error responses (was 1)
- Added new test "returns 200 on /v1/habit-fields when first HTTP call fails but retry succeeds"
- Fixed personalContext mock data to use objects with `text` fields as required by schema validation

## Validation

✅ Type check: No errors
✅ Tests: 62 passed, 0 failed
✅ Lint: N/A (not configured)

## Issue

Fixes #265