### PR TITLE
Fix: guard against empty LLM response text before JSON.parse

### DIFF
--- a/worker/src/lib/requesty.test.ts
+++ b/worker/src/lib/requesty.test.ts
@@ -299,4 +299,61 @@ describe('callRequestyWithSchemaRetry', () => {
     expect(result!.inputTokens).toBe(30) // 15 + 15
     expect(result!.outputTokens).toBe(20) // 10 + 10
   })
+
+  it('retries with stricterPrompt when first attempt returns empty text', async () => {
+    const prompts: string[] = []
+    globalThis.fetch = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string)
+      prompts.push(body.messages[0].content)
+      if (prompts.length === 1) {
+        // First attempt: empty content
+        return new Response(
+          JSON.stringify({ choices: [{ message: { content: '' } }], usage: { prompt_tokens: 5, completion_tokens: 0 } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      // Retry: valid JSON
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: '{"ok":true}' } }],
+          usage: { prompt_tokens: 5, completion_tokens: 3 },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    }) as typeof fetch
+
+    const result = await callRequestyWithSchemaRetry(
+      'key', 'model', 'normal', 'strict',
+      (p) => (p as { ok: boolean }).ok ? p : null,
+    )
+    expect(result).not.toBeNull()
+    expect(result!.data).toEqual({ ok: true })
+    // Must use stricterPrompt on retry (empty text is a JSON/schema failure, not HTTP)
+    expect(prompts).toEqual(['normal', 'strict'])
+  })
+
+  it('returns null and reports warning (not exception) when both attempts return empty text', async () => {
+    const sentryCapture = vi.spyOn(Sentry, 'captureException').mockReturnValue({} as ReturnType<typeof Sentry.captureException>)
+    const sentryMessage = vi.spyOn(Sentry, 'captureMessage').mockReturnValue({} as ReturnType<typeof Sentry.captureMessage>)
+
+    mockFetchResponses(
+      {
+        status: 200,
+        body: { choices: [{ message: { content: '' } }], usage: { prompt_tokens: 5, completion_tokens: 0 } },
+      },
+      {
+        status: 200,
+        body: { choices: [{ message: { content: '' } }], usage: { prompt_tokens: 5, completion_tokens: 0 } },
+      },
+    )
+
+    const result = await callRequestyWithSchemaRetry('key', 'model', 'prompt', 'strict', () => null)
+    expect(result).toBeNull()
+    // Should NOT throw SyntaxError or call captureException
+    expect(sentryCapture).not.toHaveBeenCalled()
+    // Should report as a warning message on final retry
+    expect(sentryMessage).toHaveBeenCalledWith('Requesty returned empty response text', expect.any(Object))
+    sentryCapture.mockRestore()
+    sentryMessage.mockRestore()
+  })
 })

--- a/worker/src/lib/requesty.ts
+++ b/worker/src/lib/requesty.ts
@@ -110,28 +110,39 @@ export async function callRequestyWithSchemaRetry<T>(
     totalInputTokens += result.inputTokens
 
     const sample = result.text.slice(0, 200)
-    try {
-      const parsed = JSON.parse(result.text)
-      const validated = validate(parsed)
-      if (validated !== null) {
-        return { data: validated, outputTokens: totalOutputTokens, inputTokens: totalInputTokens }
-      }
-      console.warn('[requesty] schema validation failed', { isRetry, text: sample })
-      // Only report to Sentry on final failure; first-attempt misses are expected
-      // and recovered via stricterPrompt retry.
+
+    if (!result.text) {
+      console.warn('[requesty] empty response text', { isRetry })
       if (isRetry) {
-        Sentry.captureMessage('Requesty schema validation failed', {
+        Sentry.captureMessage('Requesty returned empty response text', {
           level: 'warning',
-          contexts: { requesty: { text: sample } },
+          contexts: { requesty: { isRetry } },
         })
       }
-    } catch (err) {
-      console.warn('[requesty] JSON.parse failed', { isRetry, err, text: sample })
-      if (isRetry) {
-        Sentry.captureException(toError(err), {
-          tags: { 'requesty.failure': 'json-parse' },
-          contexts: { requesty: { text: sample } },
-        })
+    } else {
+      try {
+        const parsed = JSON.parse(result.text)
+        const validated = validate(parsed)
+        if (validated !== null) {
+          return { data: validated, outputTokens: totalOutputTokens, inputTokens: totalInputTokens }
+        }
+        console.warn('[requesty] schema validation failed', { isRetry, text: sample })
+        // Only report to Sentry on final failure; first-attempt misses are expected
+        // and recovered via stricterPrompt retry.
+        if (isRetry) {
+          Sentry.captureMessage('Requesty schema validation failed', {
+            level: 'warning',
+            contexts: { requesty: { text: sample } },
+          })
+        }
+      } catch (err) {
+        console.warn('[requesty] JSON.parse failed', { isRetry, err, text: sample })
+        if (isRetry) {
+          Sentry.captureException(toError(err), {
+            tags: { 'requesty.failure': 'json-parse' },
+            contexts: { requesty: { text: sample } },
+          })
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Prevents `SyntaxError: Unexpected end of JSON input` when the LLM API returns empty content. The fix adds a guard clause before `JSON.parse` to check for empty text and handle it gracefully.

## Changes

- **`worker/src/lib/requesty.ts`**: Added empty-text guard in `callRequestyWithSchemaRetry` (lines 112-136)
  - Checks if `result.text` is empty before calling `JSON.parse`
  - Logs empty responses as warnings instead of throwing exceptions
  - Reports to Sentry as a `captureMessage` on final retry (not an exception)
  
- **`worker/src/lib/requesty.test.ts`**: Added two new test cases
  - "retries with stricterPrompt when first attempt returns empty text" — verifies the retry flow works correctly
  - "returns null and reports warning (not exception) when both attempts return empty text" — confirms Sentry reporting behavior

## Root Cause

When `callRequesty` receives a null/empty LLM response from the API, it returns `text = ""` (via optional chaining + `?? ''`). The code then called `JSON.parse("")` immediately, which throws `SyntaxError: Unexpected end of JSON input`. Although the catch block recovered via retry, the raw SyntaxError was reported to Sentry, creating misleading error noise that obscured real failures.

## Validation

- ✅ Type check: No errors
- ✅ Tests: 67 passed, 0 failed (added 2 new tests specific to empty-text behavior)
- ✅ All changes follow existing code patterns for Sentry reporting

## Related

Fixes #210