### PR TITLE
Fix: require NetworkType.CONNECTED constraint in RefillScheduler (#238)

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillScheduler.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillScheduler.kt
@@ -2,7 +2,9 @@ package net.interstellarai.unreminder.service.worker
 
 import android.content.Context
 import androidx.work.BackoffPolicy
+import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkRequest
@@ -17,8 +19,12 @@ class RefillScheduler @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
     fun enqueueForHabit(habitId: Long) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
         val request = OneTimeWorkRequestBuilder<RefillWorker>()
             .setInputData(workDataOf(RefillWorker.KEY_HABIT_ID to habitId))
+            .setConstraints(constraints)
             .setBackoffCriteria(
                 BackoffPolicy.EXPONENTIAL,
                 WorkRequest.MIN_BACKOFF_MILLIS,

--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
@@ -103,8 +103,8 @@ class RefillWorker @AssistedInject constructor(
                 Result.failure()
             }
         } catch (e: UnknownHostException) {
-            // Transient DNS failure (offline, Doze wake-up race, captive portal).
-            // Not actionable for the developer — WorkManager retries with backoff.
+            // Safety net: NetworkType.CONNECTED constraint prevents most cases,
+            // but network can drop mid-request (handoff, captive portal redirect).
             Log.w(TAG, "DNS lookup failed for habit $habitId, will retry", e)
             Result.retry()
         } catch (e: ConnectException) {


### PR DESCRIPTION
## Summary

- `RefillScheduler` was dispatching `RefillWorker` with no network constraint, causing `UnknownHostException` when the device is offline (Doze mode, post-boot race, captive portal, mobile handoff)
- Added `NetworkType.CONNECTED` constraint so WorkManager only runs the job when a network is available
- Updated `UnknownHostException` catch comment in `RefillWorker` to note it is now a safety net (for mid-request network drops) rather than the primary defense

## Test plan

- [ ] `./gradlew :app:compileDebugKotlin` — compiles without errors
- [ ] `./gradlew :app:testDebugUnitTest` — no regressions
- [ ] `./gradlew :app:lint` — no new warnings
- [ ] Manual: disable network, trigger a refill — job should be queued and deferred until network is available, not attempted immediately

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)