### PR TITLE
Fix: require network connectivity before dispatching RefillWorker

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillScheduler.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillScheduler.kt
@@ -2,7 +2,9 @@ package net.interstellarai.unreminder.service.worker
 
 import android.content.Context
 import androidx.work.BackoffPolicy
+import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkRequest
@@ -17,8 +19,12 @@ class RefillScheduler @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
     fun enqueueForHabit(habitId: Long) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
         val request = OneTimeWorkRequestBuilder<RefillWorker>()
             .setInputData(workDataOf(RefillWorker.KEY_HABIT_ID to habitId))
+            .setConstraints(constraints)
             .setBackoffCriteria(
                 BackoffPolicy.EXPONENTIAL,
                 WorkRequest.MIN_BACKOFF_MILLIS,

--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
@@ -103,8 +103,8 @@ class RefillWorker @AssistedInject constructor(
                 Result.failure()
             }
         } catch (e: UnknownHostException) {
-            // Transient DNS failure (offline, Doze wake-up race, captive portal).
-            // Not actionable for the developer — WorkManager retries with backoff.
+            // Safety net: NetworkType.CONNECTED constraint prevents most cases,
+            // but network can drop mid-request (handoff, captive portal redirect).
             Log.w(TAG, "DNS lookup failed for habit $habitId, will retry", e)
             Result.retry()
         } catch (e: ConnectException) {


### PR DESCRIPTION
## Summary

Fixes #238 — `RefillWorker` was being dispatched without a `NetworkType.CONNECTED` constraint, causing `UnknownHostException` when the device is offline (Doze mode, post-boot network race, captive portal, etc.).

## Root Cause

`RefillScheduler.enqueueForHabit()` had no network constraint on the `OneTimeWorkRequestBuilder`, so WorkManager would dispatch the job even without network connectivity. When `RefillWorker.doWork()` calls `requestyProxyClient.generateBatch()`, OkHttp attempts to resolve the worker URL and throws `UnknownHostException` on DNS failure.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `app/src/main/java/net/interstellarai/unreminder/service/worker/RefillScheduler.kt` | Add `Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED)` to `OneTimeWorkRequestBuilder` | +6 |
| `app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt` | Update `UnknownHostException` catch comment to reflect this is now a safety net | +2/-2 |

## Implementation Details

The fix adds a constraint to prevent WorkManager from dispatching the job until the device has an active network connection. The existing `UnknownHostException` catch block in `RefillWorker` remains as a safety net for rare race conditions (network drop mid-request, captive portal redirect).

## Validation

- Type check: ✅ Static review confirms changes match AndroidX WorkManager API patterns
- Code review: ✅ Changes are minimal and correct, matching the investigation specification exactly
- No regressions: ✅ Existing backoff criteria and error handling preserved

Fixes #238