### PR TITLE
Fix: stop reporting transient SocketTimeoutException to Sentry

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
@@ -17,6 +17,7 @@ import net.interstellarai.unreminder.data.repository.VariationRepository
 import io.sentry.Sentry
 import java.io.IOException
 import java.net.ConnectException
+import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.time.Instant
 import org.json.JSONException
@@ -112,6 +113,12 @@ class RefillWorker @AssistedInject constructor(
             // mobile handoff). Worker is on Cloudflare — a real server-side connect
             // refusal is vanishingly improbable, so treat as offline-class noise.
             Log.w(TAG, "Connect failed for habit $habitId, will retry", e)
+            Result.retry()
+        } catch (e: SocketTimeoutException) {
+            // Transient socket timeout (slow LTE handoff, Requesty/Cloudflare high load,
+            // Doze network throttling). Same class of offline noise as UnknownHostException
+            // and ConnectException — not actionable for the developer.
+            Log.w(TAG, "Socket timeout for habit $habitId, will retry", e)
             Result.retry()
         } catch (e: IOException) {
             Log.w(TAG, "IO error for habit $habitId, will retry", e)

--- a/app/src/test/java/net/interstellarai/unreminder/service/worker/RefillWorkerTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/worker/RefillWorkerTest.kt
@@ -28,6 +28,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.io.IOException
 import java.net.ConnectException
+import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 
 class RefillWorkerTest {
@@ -182,6 +183,26 @@ class RefillWorkerTest {
             coEvery {
                 mockProxyClient.generateBatch(any(), any(), any(), any(), any(), any(), any(), any())
             } throws ConnectException("Failed to connect to un-reminder-worker.alexsiri7.workers.dev/104.21.91.247:443")
+
+            val worker = createWorker()
+            assertEquals(Result.retry(), worker.doWork())
+            verify(exactly = 0) { Sentry.captureException(any(), any<ScopeCallback>()) }
+        } finally {
+            unmockkStatic(Sentry::class)
+        }
+    }
+
+    @Test
+    fun `doWork returns retry on SocketTimeoutException without reporting to Sentry`() = runTest {
+        mockkStatic(Sentry::class)
+        try {
+            every { Sentry.captureException(any(), any<ScopeCallback>()) } returns SentryId.EMPTY_ID
+
+            val habit = HabitEntity(id = 1L, name = "Meditate")
+            coEvery { mockHabitRepository.getByIdOnce(1L) } returns habit
+            coEvery {
+                mockProxyClient.generateBatch(any(), any(), any(), any(), any(), any(), any(), any())
+            } throws SocketTimeoutException("connect timed out")
 
             val worker = createWorker()
             assertEquals(Result.retry(), worker.doWork())


### PR DESCRIPTION
## Summary

Fix #216: `SocketTimeoutException` is being reported to Sentry on every socket timeout, creating noise that obscures real errors. This transient network exception should be silently retried (like `UnknownHostException` and `ConnectException` already are), not reported.

## Changes

### Main fix in `RefillWorker.kt`
- Added dedicated `SocketTimeoutException` catch clause **before** the generic `IOException` handler
- Matches the existing pattern for `UnknownHostException` and `ConnectException`
- Logs a warning and retries without reporting to Sentry

### Test coverage in `RefillWorkerTest.kt`
- Added test case: "doWork returns retry on SocketTimeoutException without reporting to Sentry"
- Mirrors existing patterns for the two sibling transient network exceptions
- Verifies `Sentry.captureException()` is **not** called for this exception type

## Root Cause

`SocketTimeoutException extends SocketException extends IOException`. It was falling through to the generic `IOException` catch block, which calls `Sentry.captureException()` before retrying. This was missing a dedicated handler even though the codebase already handles the same class of transient offline noise for similar exceptions (see #251 for `ConnectException`, #239/#244 for `UnknownHostException`).

## Validation

- Code review: ✅ Pattern matches existing handlers exactly
- Tests added: ✅ New test case covers the exception scenario
- Static analysis: ✅ Correct catch clause ordering (must be before `IOException`)
- Android SDK compilation: ⚠️ Skipped in CI (not available in worktree environment)

The fix is a trivial, pattern-identical catch clause insertion that mirrors two existing handlers in the same try-catch block.

## Issue

Fixes #216