### PR TITLE
Fix: require network connectivity before dispatching RefillWorker

### DIFF
--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillScheduler.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillScheduler.kt
@@ -2,7 +2,9 @@ package net.interstellarai.unreminder.service.worker
 
 import android.content.Context
 import androidx.work.BackoffPolicy
+import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkRequest
@@ -17,8 +19,12 @@ class RefillScheduler @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
     fun enqueueForHabit(habitId: Long) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
         val request = OneTimeWorkRequestBuilder<RefillWorker>()
             .setInputData(workDataOf(RefillWorker.KEY_HABIT_ID to habitId))
+            .setConstraints(constraints)
             .setBackoffCriteria(
                 BackoffPolicy.EXPONENTIAL,
                 WorkRequest.MIN_BACKOFF_MILLIS,

--- a/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt
@@ -103,8 +103,8 @@ class RefillWorker @AssistedInject constructor(
                 Result.failure()
             }
         } catch (e: UnknownHostException) {
-            // Transient DNS failure (offline, Doze wake-up race, captive portal).
-            // Not actionable for the developer — WorkManager retries with backoff.
+            // Safety net: NetworkType.CONNECTED constraint prevents most cases,
+            // but network can drop mid-request (handoff, captive portal redirect).
             Log.w(TAG, "DNS lookup failed for habit $habitId, will retry", e)
             Result.retry()
         } catch (e: ConnectException) {


### PR DESCRIPTION
## Summary

Fixes #238 — `RefillWorker` was dispatching network jobs without a network constraint, causing `UnknownHostException` crashes when attempting to resolve hostnames offline.

## Root Cause

`RefillScheduler.enqueueForHabit()` dispatches a `OneTimeWorkRequest` via WorkManager without specifying `NetworkType.CONNECTED`, allowing the job to run even without network availability.

## Changes

### RefillScheduler.kt
- Added `Constraints` and `NetworkType` imports
- Created a `Constraints.Builder()` with `setRequiredNetworkType(NetworkType.CONNECTED)`
- Applied constraints to the `OneTimeWorkRequest` via `.setConstraints()`

### RefillWorker.kt
- Updated the `UnknownHostException` catch block comment to reflect the new architecture
- Comment now indicates that the constraint is the primary defense; the catch block handles edge cases (network drop mid-request, captive portal redirects)

## Validation

- **Code review**: ✅ Changes use standard WorkManager Constraints API correctly
- **Type/Lint/Tests**: Skipped (Android SDK not available in environment)
- Implementation matches investigation exactly

## Files Changed

- `app/src/main/java/net/interstellarai/unreminder/service/worker/RefillScheduler.kt` (+6 lines)
- `app/src/main/java/net/interstellarai/unreminder/service/worker/RefillWorker.kt` (+2/-2 lines)

Fixes #238