### PR TITLE
Notification tap opens ReminderDetailScreen with deep-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ updated by geofence `ENTER`/`EXIT` callbacks. Empty set means no known location.
    `minutesSince` is minutes since the habit was last fired (cap: 1440 min = 24 h). A habit
    never fired receives the maximum weight (~13×). If the eligible set is empty, skip silently.
 4. Pick an unused variation from the cloud-generated pool (see Variation entity). If the pool is empty, use the level description fallback (see Fallback below).
-5. Post the notification with the generated text. Action buttons: **Did it**, **Dismiss**. When the variation includes an `actionUrl`, a third **Watch** button is added that opens the URL in a browser.
+5. Post the notification with the generated text. Action buttons: **Did it**, **Dismiss**. When the variation includes an `actionUrl`, a third **Watch** button is added that opens the URL in a browser. Tapping the notification body opens the **Reminder Detail screen** for that trigger.
 6. Record the trigger row with the generated prompt and the outcome when the user responds.
    - **Did it (COMPLETED):** the habit is excluded from the rest of today's triggers (step 2 above). When `auto_adjust_level` is true, consecutive completions promote `dedication_level` (up to max 5).
    - **Dismiss (DISMISSED):** a per-habit cooldown (default 3 h, configurable via `cooldownMinutes` in the Habit editor — presets 1h · 2h · 3h · 6h · 12h · None, where None=`0` disables the cooldown) applies before this habit is eligible again. When `auto_adjust_level` is true: 3 consecutive `DISMISSED` triggers demote `dedication_level` by 1; at level 0, 3 consecutive dismissals auto-pause the habit (`active = false`). The user can re-activate via the habit editor.
@@ -275,8 +275,9 @@ from the pool, not from a fresh generation.
 8. **Onboarding screen** — shown once on first launch. Walks the user through three collapsible steps: (1) granting Notifications and Location permissions, (2) creating a first habit with name/descriptions and weekday schedule, (3) creating a first time window. Includes a "Skip" action in the top bar. Completion (or skip) is persisted via DataStore (`onboarding_done` key) and never shown again. Bottom navigation bar is hidden while onboarding is active.
 9. **Feedback screen** — annotated screenshot tool. Captures the current screen, lets the user draw annotations (red/yellow/green strokes), type a description, and submit as a GitHub issue. Falls back to an offline queue (WorkManager) when connectivity is unavailable.
 10. **Reminder detail screen** — read/act view for a single past or recent trigger, accessible by tapping
-    any row in the Recent Triggers screen. Shows the AI-generated prompt text ("reminder" section) and,
-    if the trigger has an associated habit, the habit name and current dedication progress bar ("habit" section).
+    any row in the Recent Triggers screen or by tapping a live notification body. Shows the AI-generated
+    prompt text ("reminder" section) and, if the trigger has an associated habit, the habit name and
+    current dedication progress bar ("habit" section).
     Two action chips: **Did it** (records `COMPLETED`, dismisses the notification, navigates back) and
     **Dismiss** (records `DISMISSED`, dismisses the notification, navigates back). No bottom navigation bar
     (excluded from `showBottomBar` logic in `NavGraph`). Back navigation via "← back" text link or system back.

--- a/app/src/main/java/net/interstellarai/unreminder/MainActivity.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/MainActivity.kt
@@ -36,11 +36,13 @@ class MainActivity : ComponentActivity() {
 
     private lateinit var updateLauncher: ActivityResultLauncher<IntentSenderRequest>
     private var pendingTimerTriggerId by mutableStateOf<Long?>(null)
+    private var pendingDetailTriggerId by mutableStateOf<Long?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         handleTimerIntent(intent)
+        handleDetailIntent(intent)
 
         updateLauncher = registerForActivityResult(
             ActivityResultContracts.StartIntentSenderForResult()
@@ -74,6 +76,8 @@ class MainActivity : ComponentActivity() {
                     snackbarHostState = snackbarHostState,
                     pendingTimerTriggerId = pendingTimerTriggerId,
                     onTimerNavigated = { pendingTimerTriggerId = null },
+                    pendingDetailTriggerId = pendingDetailTriggerId,
+                    onDetailNavigated = { pendingDetailTriggerId = null },
                 )
             }
         }
@@ -82,12 +86,20 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: android.content.Intent) {
         super.onNewIntent(intent)
         handleTimerIntent(intent)
+        handleDetailIntent(intent)
     }
 
     private fun handleTimerIntent(intent: android.content.Intent?) {
         if (intent?.getBooleanExtra(NotificationHelper.EXTRA_OPEN_TIMER, false) == true) {
             val id = intent.getLongExtra(NotificationHelper.EXTRA_TRIGGER_ID, -1L)
             if (id != -1L) pendingTimerTriggerId = id
+        }
+    }
+
+    private fun handleDetailIntent(intent: android.content.Intent?) {
+        if (intent?.getBooleanExtra(NotificationHelper.EXTRA_OPEN_DETAIL, false) == true) {
+            val id = intent.getLongExtra(NotificationHelper.EXTRA_TRIGGER_ID, -1L)
+            if (id != -1L) pendingDetailTriggerId = id
         }
     }
 

--- a/app/src/main/java/net/interstellarai/unreminder/MainActivity.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/MainActivity.kt
@@ -90,21 +90,16 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun handleTimerIntent(intent: android.content.Intent?) {
-        if (intent?.getBooleanExtra(NotificationHelper.EXTRA_OPEN_TIMER, false) == true) {
-            val id = intent.getLongExtra(NotificationHelper.EXTRA_TRIGGER_ID, -1L)
-            if (id != -1L) pendingTimerTriggerId = id
-        }
+        if (intent?.getBooleanExtra(NotificationHelper.EXTRA_OPEN_TIMER, false) != true) return
+        val id = intent.getLongExtra(NotificationHelper.EXTRA_TRIGGER_ID, -1L)
+        if (id != -1L) pendingTimerTriggerId = id
     }
 
     private fun handleDetailIntent(intent: android.content.Intent?) {
-        if (intent?.getBooleanExtra(NotificationHelper.EXTRA_OPEN_DETAIL, false) == true) {
-            val id = intent.getLongExtra(NotificationHelper.EXTRA_TRIGGER_ID, -1L)
-            if (id != -1L) {
-                pendingDetailTriggerId = id
-            } else {
-                Log.w(TAG, "handleDetailIntent: EXTRA_OPEN_DETAIL set but EXTRA_TRIGGER_ID missing")
-            }
-        }
+        if (intent?.getBooleanExtra(NotificationHelper.EXTRA_OPEN_DETAIL, false) != true) return
+        val id = intent.getLongExtra(NotificationHelper.EXTRA_TRIGGER_ID, -1L)
+        if (id != -1L) pendingDetailTriggerId = id
+        else Log.w(TAG, "handleDetailIntent: EXTRA_OPEN_DETAIL set but EXTRA_TRIGGER_ID missing")
     }
 
     override fun onResume() {

--- a/app/src/main/java/net/interstellarai/unreminder/MainActivity.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/MainActivity.kt
@@ -99,7 +99,11 @@ class MainActivity : ComponentActivity() {
     private fun handleDetailIntent(intent: android.content.Intent?) {
         if (intent?.getBooleanExtra(NotificationHelper.EXTRA_OPEN_DETAIL, false) == true) {
             val id = intent.getLongExtra(NotificationHelper.EXTRA_TRIGGER_ID, -1L)
-            if (id != -1L) pendingDetailTriggerId = id
+            if (id != -1L) {
+                pendingDetailTriggerId = id
+            } else {
+                Log.w(TAG, "handleDetailIntent: EXTRA_OPEN_DETAIL set but EXTRA_TRIGGER_ID missing")
+            }
         }
     }
 

--- a/app/src/main/java/net/interstellarai/unreminder/service/notification/NotificationHelper.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/service/notification/NotificationHelper.kt
@@ -27,11 +27,13 @@ class NotificationHelper @Inject constructor(
         const val CHANNEL_ID_SYSTEM = "un_reminder_system"
         const val CHANNEL_NAME_SYSTEM = "Habit Status"
         const val EXTRA_OPEN_TIMER = "open_timer"
+        const val EXTRA_OPEN_DETAIL = "open_detail"
         // Paused-habit notifications use habitId as offset.
         // Base chosen well above realistic trigger ID values to avoid collisions.
         const val NOTIFICATION_ID_PAUSED_BASE = 900_000L
         // Content intent base — above the * 3 action-intent range and PAUSED_BASE.
         const val NOTIFICATION_CONTENT_BASE = 2_000_000L
+        const val NOTIFICATION_DETAIL_BASE = 3_000_000L
     }
 
     fun createNotificationChannel() {
@@ -86,19 +88,19 @@ class NotificationHelper @Inject constructor(
             builder.addAction(0, "Watch", watchIntent)
         }
 
-        // Content intent: opens TimerScreen when user taps notification body
-        val timerIntent = Intent(context, net.interstellarai.unreminder.MainActivity::class.java).apply {
+        // Content intent: opens ReminderDetailScreen when user taps notification body
+        val detailIntent = Intent(context, net.interstellarai.unreminder.MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
             putExtra(EXTRA_TRIGGER_ID, triggerId)
-            putExtra(EXTRA_OPEN_TIMER, true)
+            putExtra(EXTRA_OPEN_DETAIL, true)
         }
-        val timerPendingIntent = PendingIntent.getActivity(
+        val detailPendingIntent = PendingIntent.getActivity(
             context,
-            (NOTIFICATION_CONTENT_BASE + triggerId).toRequestCode(),
-            timerIntent,
+            (NOTIFICATION_DETAIL_BASE + triggerId).toRequestCode(),
+            detailIntent,
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
-        builder.setContentIntent(timerPendingIntent)
+        builder.setContentIntent(detailPendingIntent)
 
         notificationManager.notify(triggerId.toRequestCode(), builder.build())
     }

--- a/app/src/main/java/net/interstellarai/unreminder/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/navigation/NavGraph.kt
@@ -65,6 +65,8 @@ fun NavGraph(
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     pendingTimerTriggerId: Long? = null,
     onTimerNavigated: () -> Unit = {},
+    pendingDetailTriggerId: Long? = null,
+    onDetailNavigated: () -> Unit = {},
 ) {
     val isOnboarded by navViewModel.isOnboarded.collectAsStateWithLifecycle()
 
@@ -82,6 +84,12 @@ fun NavGraph(
         val id = pendingTimerTriggerId ?: return@LaunchedEffect
         navController.navigate("timer/$id")
         onTimerNavigated()
+    }
+
+    LaunchedEffect(pendingDetailTriggerId) {
+        val id = pendingDetailTriggerId ?: return@LaunchedEffect
+        navController.navigate("reminder_detail/$id")
+        onDetailNavigated()
     }
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()

--- a/app/src/main/java/net/interstellarai/unreminder/ui/timer/TimerScreen.kt
+++ b/app/src/main/java/net/interstellarai/unreminder/ui/timer/TimerScreen.kt
@@ -82,7 +82,6 @@ fun TimerScreen(
 
         Spacer(Modifier.height(Dimens.lg))
 
-        // Prompt section
         MonoSectionLabel("reminder")
         HorizontalDivider(
             thickness = Dimens.hairline,
@@ -97,7 +96,6 @@ fun TimerScreen(
 
         Spacer(Modifier.height(Dimens.xl))
 
-        // Timer section — only when duration found
         if (uiState.totalSeconds != null) {
             MonoSectionLabel("timer")
             HorizontalDivider(
@@ -117,12 +115,10 @@ fun TimerScreen(
 
             Spacer(Modifier.height(Dimens.lg))
 
-            // Timer controls
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(Dimens.md, Alignment.CenterHorizontally),
             ) {
-                // Start / Pause button
                 if (uiState.isRunning) {
                     ActionChip(label = "Pause", filled = true, onClick = { viewModel.pause() })
                 } else {
@@ -140,7 +136,6 @@ fun TimerScreen(
             Spacer(Modifier.height(Dimens.xl))
         }
 
-        // Outcome buttons
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(Dimens.md, Alignment.CenterHorizontally),

--- a/app/src/test/java/net/interstellarai/unreminder/DetailIntentParserTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/DetailIntentParserTest.kt
@@ -1,0 +1,43 @@
+package net.interstellarai.unreminder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Tests the guard logic in MainActivity.handleDetailIntent().
+ * Uses a pure companion function that mirrors the intent-parsing conditional chain,
+ * following the same pattern as NotificationActionMappingTest.
+ */
+class DetailIntentParserTest {
+
+    /**
+     * Mirrors the guard logic in MainActivity.handleDetailIntent().
+     * Returns the trigger ID to navigate to, or null if the intent should be ignored.
+     */
+    private fun parseDetailIntent(hasFlag: Boolean, triggerId: Long): Long? {
+        if (!hasFlag) return null
+        if (triggerId == -1L) return null
+        return triggerId
+    }
+
+    @Test
+    fun `returns triggerId when flag is true and id is valid`() {
+        assertEquals(42L, parseDetailIntent(hasFlag = true, triggerId = 42L))
+    }
+
+    @Test
+    fun `returns null when EXTRA_OPEN_DETAIL flag is absent`() {
+        assertNull(parseDetailIntent(hasFlag = false, triggerId = 42L))
+    }
+
+    @Test
+    fun `returns null when triggerId is the sentinel value -1`() {
+        assertNull(parseDetailIntent(hasFlag = true, triggerId = -1L))
+    }
+
+    @Test
+    fun `returns null when both flag is false and id is sentinel`() {
+        assertNull(parseDetailIntent(hasFlag = false, triggerId = -1L))
+    }
+}

--- a/app/src/test/java/net/interstellarai/unreminder/service/notification/NotificationActionMappingTest.kt
+++ b/app/src/test/java/net/interstellarai/unreminder/service/notification/NotificationActionMappingTest.kt
@@ -77,3 +77,39 @@ class RequestCodeTest {
         assertEquals(0, 0x0000_0001_0000_0001L.toRequestCode())
     }
 }
+
+class NotificationRequestCodeCollisionTest {
+
+    @Test
+    fun `NOTIFICATION_DETAIL_BASE is distinct from NOTIFICATION_CONTENT_BASE`() {
+        assertNotEquals(
+            NotificationHelper.NOTIFICATION_DETAIL_BASE,
+            NotificationHelper.NOTIFICATION_CONTENT_BASE
+        )
+    }
+
+    @Test
+    fun `detail request code does not collide with content request code for same triggerId`() {
+        val triggerId = 42L
+        val detailCode = (NotificationHelper.NOTIFICATION_DETAIL_BASE + triggerId).toRequestCode()
+        val contentCode = (NotificationHelper.NOTIFICATION_CONTENT_BASE + triggerId).toRequestCode()
+        assertNotEquals(detailCode, contentCode)
+    }
+
+    @Test
+    fun `detail request code does not collide with action codes for same triggerId`() {
+        val triggerId = 42L
+        val detailCode = (NotificationHelper.NOTIFICATION_DETAIL_BASE + triggerId).toRequestCode()
+        assertNotEquals(detailCode, (triggerId * 3 + 0).toRequestCode())
+        assertNotEquals(detailCode, (triggerId * 3 + 1).toRequestCode())
+        assertNotEquals(detailCode, (triggerId * 3 + 2).toRequestCode())
+    }
+
+    @Test
+    fun `detail request code does not collide with paused-habit notification code`() {
+        val id = 1L
+        val detailCode = (NotificationHelper.NOTIFICATION_DETAIL_BASE + id).toRequestCode()
+        val pausedCode = (NotificationHelper.NOTIFICATION_ID_PAUSED_BASE + id).toRequestCode()
+        assertNotEquals(detailCode, pausedCode)
+    }
+}


### PR DESCRIPTION
## Summary

Notification taps now navigate directly to `ReminderDetailScreen` showing the full habit prompt and timer, instead of opening just the timer screen. This resolves the disconnect between issue #279 (which added the timer widget to ReminderDetailScreen) and the notification flow.

## Changes

### `NotificationHelper.kt`
- Added `EXTRA_OPEN_DETAIL` constant and `NOTIFICATION_DETAIL_BASE = 3_000_000L` request code base
- Replaced timer `PendingIntent` in notification's `setContentIntent` with a detail `PendingIntent` that carries `triggerId` via `EXTRA_TRIGGER_ID`
- Detail intent uses unique request codes to avoid collisions with existing action receiver intents

### `MainActivity.kt`
- Added `pendingDetailTriggerId` state variable to track incoming deep-link intents
- Added `handleDetailIntent()` function following the existing `handleTimerIntent` pattern
- Both handlers called in `onCreate()` and `onNewIntent()` to handle cold-start and running-app scenarios
- NavGraph receives new `pendingDetailTriggerId` and `onDetailNavigated` parameters

### `NavGraph.kt`
- Added `pendingDetailTriggerId` and `onDetailNavigated` parameters
- Added `LaunchedEffect` that navigates to `"reminder_detail/{triggerId}"` when a detail intent arrives
- Mirrors the existing timer deep-link pattern

## User Experience

**Before**: Tapping notification → TimerScreen (incomplete context)
**After**: Tapping notification → ReminderDetailScreen with full prompt + timer widget + back to home

## Validation

- ✅ Type check (compileDebugKotlin): Pass
- ⚠️ Full test suite: Blocked by pre-existing JDK 25 incompatibility with Hilt (environment issue, not code issue)
- ✅ Code review: Implementation mirrors existing `pendingTimerTriggerId` pattern exactly

## Testing

Manual verification required (environment JDK issue blocks automated tests):
1. Build and install: `./gradlew installDebug`
2. Trigger notification and tap → verify ReminderDetailScreen opens with correct trigger info
3. Press back → verify returns to Home screen
4. Force-stop app, tap notification again → verify cold-start deep-link works

Fixes #276